### PR TITLE
fix: improve type safety in issues.ts

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -11,12 +11,22 @@ import {
   writeLine,
 } from '../lib/terminal.js';
 
+interface Label {
+  name: string;
+  color?: string;
+  description?: string;
+}
+
 interface Issue {
   number: number;
   title: string;
   state: string;
-  labels: string[];
+  labels: Label[];
   createdAt: string;
+}
+
+function getLabelName(label: Label | string): string {
+  return typeof label === 'string' ? label : label.name;
 }
 
 interface RepoIssues {
@@ -64,7 +74,7 @@ export async function issuesCommand(options: IssuesOptions = {}): Promise<void> 
       const issues: Issue[] = JSON.parse(result);
       repoData.push({ repo, issues });
       totalOpen += issues.length;
-    } catch (e: any) {
+    } catch {
       repoData.push({ repo, issues: [], error: 'not found or no access' });
     }
   }
@@ -124,7 +134,7 @@ export async function issuesCommand(options: IssuesOptions = {}): Promise<void> 
 
     for (const issue of allIssues) {
       const labelStr = issue.labels.length > 0
-        ? `${colors.dim}[${issue.labels.map((l: any) => l.name || l).join(', ')}]${RESET}`
+        ? `${colors.dim}[${issue.labels.map(getLabelName).join(', ')}]${RESET}`
         : '';
 
       writeLine(`  ${icons.empty} ${colors.dim}#${issue.number}${RESET} ${truncate(issue.title, 50)} ${labelStr}`);


### PR DESCRIPTION
## Summary
- Add `Label` interface with proper type definition for GitHub issue labels
- Replace `catch (e: any)` with simple `catch` block (no unused variable)
- Add `getLabelName` helper function for type-safe label extraction
- Update `labels` type from `string[]` to `Label[]` matching GitHub API

## Changes
- `src/commands/issues.ts`

## Testing
- [x] TypeScript compiles without errors
- [x] No `any` types in the catch block
- [x] Label handling is type-safe

Closes #2
Closes #6

🤖 Generated with [Agents Squads](https://agents-squads.com)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>