### PR TITLE
chore: remove stale TODOs and stub functions from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,6 @@ export interface Squad {
   mission?: string;
 }
 
-// Core functions (to be implemented)
-export async function loadSquad(path: string): Promise<Squad | null> {
-  // TODO: Load squad from markdown file
-  return null;
-}
-
-export async function runAgent(agent: Agent, prompt: string): Promise<string> {
-  // TODO: Execute agent
-  return '';
-}
+// Note: Programmatic API (loadSquad, runAgent) not yet implemented.
+// Use the CLI for squad execution: `squads run <squad>`
+// See: https://github.com/agents-squads/squads-cli for documentation.


### PR DESCRIPTION
## Summary
- Remove never-implemented `loadSquad` and `runAgent` stub functions
- Keep type exports (`Agent`, `Squad`) as they may be useful
- Add clear documentation note directing to CLI usage

## Rationale
The stub functions returning `null` and empty strings were confusing for contributors who might think they were planned work. Since the CLI is the primary interface, these unimplemented stubs added no value.

## Changes
- `src/index.ts`

## Testing
- [x] TypeScript compiles without errors
- [x] Existing CLI functionality unaffected (stubs were unused)

Closes #18

🤖 Generated with [Agents Squads](https://agents-squads.com)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>