### PR TITLE
fix: handle EPIPE gracefully when output is piped

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,22 @@ if (!process.stdout.isTTY) {
   chalk.level = 0;
 }
 
+// Handle EPIPE gracefully when output is piped through head/tail/grep
+// These commands close the pipe early, which is normal Unix behavior
+process.stdout.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') {
+    process.exit(0);
+  }
+  throw err;
+});
+
+process.stderr.on('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') {
+    process.exit(0);
+  }
+  throw err;
+});
+
 // Load .env from multiple locations (first found wins)
 const envPaths = [
   join(process.cwd(), '.env'),


### PR DESCRIPTION
## Summary

Fixes #138 - Commands now handle EPIPE errors gracefully when output is piped through `head`, `tail`, `grep`, or other stream-terminating utilities.

### Problem

When running commands like `squads status | head -1`, the CLI would crash with an unhandled EPIPE error after the pipe closed. This is standard Unix behavior but requires explicit handling.

### Solution

Added error handlers to `process.stdout` and `process.stderr` in `src/cli.ts`:

```typescript
process.stdout.on('error', (err: NodeJS.ErrnoException) => {
  if (err.code === 'EPIPE') {
    process.exit(0); // Clean exit when pipe closes
  }
  throw err;
});
```

### Files Changed

- `src/cli.ts`: Added EPIPE handlers for stdout/stderr

## Test plan

- [x] `squads status | head -1` exits cleanly
- [x] `squads dash | head -5` exits cleanly
- [x] `squads list | grep cli` works
- [x] Normal (non-piped) output unchanged
- [x] All 180 tests pass

---

🤖 Generated with [Agents Squads](https://agents-squads.com)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>