### PR TITLE
fix(run): make agents use branch/PR workflow instead of direct main push

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1145,10 +1145,21 @@ After completion:
    IMPORTANT: Use ISO timestamps (e.g., 2026-01-23T14:30:00Z) not just dates.
    This allows tracking multiple executions per day.
 2. Log any learnings to learnings.md
-3. Commit and push your work:
-   git add .agents/memory/${squadName}/ && git commit -m "feat(${squadName}): ${agentName} execution $(date -u +%Y-%m-%dT%H:%M:%SZ)
+3. Create a branch, commit, push, and open a PR:
+   BRANCH="${squadName}/${agentName}-$(date -u +%Y%m%d-%H%M%S)"
+   git checkout -b "$BRANCH"
+   git add .agents/memory/${squadName}/
+   git commit -m "feat(${squadName}): ${agentName} execution $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-Co-Authored-By: Claude <noreply@anthropic.com>" && git push origin main
+Co-Authored-By: Claude <noreply@anthropic.com>"
+   git push -u origin "$BRANCH"
+   gh pr create --title "feat(${squadName}): ${agentName} execution" --body "Automated execution by ${agentName} agent.
+
+## Changes
+- Updated agent memory/state
+- Logged learnings (if any)
+
+🤖 Generated with [Agents Squads](https://agents-squads.com)" --base main
 4. Summarize what was accomplished
 
 CRITICAL: When you have completed your tasks OR reached the time limit:


### PR DESCRIPTION
## Summary
- Agents now create branches instead of committing directly to main
- Each agent execution creates: `{squad}/{agent}-{timestamp}` branch
- Agents use `gh pr create` to open PRs for their changes

## Changes
- Updated agent prompt in `run.ts` to use branch/PR workflow

## Test plan
- [x] Build succeeds
- [ ] Run an agent and verify it creates a branch and PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)