### PR TITLE
perf: lazy-load ioredis to fix 385% help command regression

### DIFF
--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -3,10 +3,10 @@
  * Uses Redis when available, falls back to file-based locks
  */
 
-import Redis from 'ioredis';
 import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { createHash } from 'crypto';
+import type Redis from 'ioredis';
 
 // Lock configuration
 const LOCK_TTL_MS = 30000; // 30 seconds max lock hold time
@@ -19,13 +19,17 @@ let redisAvailable: boolean | null = null;
 
 /**
  * Get or create Redis client
+ * Lazy-loads ioredis only when Redis is actually needed
  */
 async function getRedis(): Promise<Redis | null> {
   if (redisAvailable === false) return null;
 
   if (!redisClient) {
     try {
-      redisClient = new Redis({
+      // Lazy-load ioredis to avoid startup penalty
+      const { default: RedisConstructor } = await import('ioredis');
+
+      redisClient = new RedisConstructor({
         host: process.env.REDIS_HOST || 'localhost',
         port: parseInt(process.env.REDIS_PORT || '6379'),
         connectTimeout: 1000,


### PR DESCRIPTION
## Summary

Fixes P1 performance regression where `--help` command became 385% slower (114ms → 553ms) due to synchronous `ioredis` import added in commit a23a57a.

## Problem

- `ioredis` is a 1MB dependency that was being loaded synchronously at CLI startup
- This added ~400ms overhead to **every CLI command**, including `--help`
- Most users never need Redis locking, so they pay this penalty unnecessarily

## Solution

Changed to **dynamic import** inside `getRedis()` function:
- `ioredis` is now only loaded when Redis locking is actually needed
- Type-only import (`import type Redis`) keeps TypeScript types at compile time
- Zero impact on users who don't use Redis

## Changes

- `src/lib/lock.ts`: Convert synchronous import to lazy dynamic import

## Performance Impact

**Before**: 553ms average (5 runs: 548, 557, 519, 603, 539)  
**Expected after**: ~115ms (baseline from Jan 7)  
**Improvement**: 5x faster startup, 438ms saved per invocation

## Testing

- [ ] `squads --help` runs in <200ms
- [ ] File-based locking still works (no Redis)
- [ ] Redis locking still works (with Redis available)
- [ ] No TypeScript errors

Closes #179

🤖 Generated with [Agents Squads](https://agents-squads.com)