### PR TITLE
fix: add error parameters to empty catch blocks in autonomous.ts

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -187,7 +187,7 @@ async function syncRoutines(): Promise<void> {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ squad: name, routines }),
         });
-      } catch {
+      } catch (_error) {
         // Bridge might not support routines endpoint yet
       }
     }
@@ -211,11 +211,11 @@ function isRunning(): { running: boolean; pid?: number } {
     // Check if process is alive (signal 0 doesn't kill, just checks)
     process.kill(pid, 0);
     return { running: true, pid };
-  } catch {
+  } catch (_error) {
     // Process not running, clean up stale PID file
     try {
       unlinkSync(PID_FILE);
-    } catch {
+    } catch (_cleanupError) {
       // Ignore - file may already be deleted
     }
     return { running: false };


### PR DESCRIPTION
## Summary

Fixes ESLint `no-empty` warnings by capturing error parameters in catch blocks, even when errors are intentionally ignored.

## Problem

ESLint was flagging 3 empty catch blocks in `autonomous.ts` at lines 190, 214, and 218. While these had explanatory comments, they still violated the `no-empty` rule.

## Solution

Changed from `catch { }` to `catch (_error) { }` to explicitly show that errors are intentionally ignored. The underscore prefix is a TypeScript convention for unused variables.

## Changes

- Line 190: Bridge API sync (optional operation)
- Line 214: Process health check (expected failure)
- Line 218: PID file cleanup (expected ENOENT)

All three cases are legitimate error-ignoring scenarios where:
1. The operation is optional (Bridge endpoint might not exist)
2. The error is expected (process not running)
3. The cleanup can fail safely (file already deleted)

## Testing

- [ ] ESLint no longer flags these lines
- [ ] Functionality unchanged (errors still ignored as intended)
- [ ] Comments preserved to explain why errors are ignored

Closes #170

🤖 Generated with [Agents Squads](https://agents-squads.com)