### PR TITLE
security: remove hardcoded database credentials from db.ts

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -8,16 +8,21 @@ const require = createRequire(import.meta.url);
 const pg = require('pg');
 const { Pool } = pg;
 
-// Connection config from environment or defaults
-const DATABASE_URL = process.env.SQUADS_DATABASE_URL ||
-  'postgresql://squads:squads_local_dev@localhost:5433/squads';
+// Connection config from environment
+// No hardcoded fallback - database is optional, use env var to configure
+const DATABASE_URL = process.env.SQUADS_DATABASE_URL;
 
 let pool: InstanceType<typeof Pool> | null = null;
 
 /**
  * Get or create the connection pool
+ * Returns null if DATABASE_URL is not configured
  */
-function getPool(): InstanceType<typeof Pool> {
+function getPool(): InstanceType<typeof Pool> | null {
+  if (!DATABASE_URL) {
+    return null;
+  }
+
   if (!pool) {
     pool = new Pool({
       connectionString: DATABASE_URL,
@@ -40,6 +45,9 @@ function getPool(): InstanceType<typeof Pool> {
 export async function isDatabaseAvailable(): Promise<boolean> {
   try {
     const pool = getPool();
+    if (!pool) {
+      return false;
+    }
     const client = await pool.connect();
     await client.query('SELECT 1');
     client.release();
@@ -101,6 +109,9 @@ export interface SquadSnapshotData {
 export async function saveDashboardSnapshot(snapshot: DashboardSnapshot): Promise<number | null> {
   try {
     const pool = getPool();
+    if (!pool) {
+      return null;
+    }
     const client = await pool.connect();
 
     const result = await client.query(`
@@ -149,7 +160,11 @@ export async function saveDashboardSnapshot(snapshot: DashboardSnapshot): Promis
  */
 export async function getDashboardHistory(limit: number = 30): Promise<DashboardSnapshot[]> {
   try {
-    const client = await getPool().connect();
+    const pool = getPool();
+    if (!pool) {
+      return [];
+    }
+    const client = await pool.connect();
 
     const result = await client.query(`
       SELECT


### PR DESCRIPTION
## Summary
- Removed hardcoded PostgreSQL credentials fallback from `src/lib/db.ts`
- Database now requires explicit `SQUADS_DATABASE_URL` environment variable
- All database functions gracefully handle missing configuration (return null/empty)

## Changes
- `getPool()` returns `null` when `DATABASE_URL` is not set (instead of using hardcoded fallback)
- `isDatabaseAvailable()` returns `false` when pool is null
- `saveDashboardSnapshot()` returns `null` when pool is null
- `getDashboardHistory()` returns `[]` when pool is null

## Impact
- Database features work as before when `SQUADS_DATABASE_URL` is configured
- Database features gracefully degrade (no-op) when not configured
- No more credentials exposed in source code

## Test plan
- [x] `npm run build` passes
- [ ] CLI works normally with `SQUADS_DATABASE_URL` set
- [ ] CLI works normally without `SQUADS_DATABASE_URL` (dashboard history disabled)

Closes #155

🤖 Generated with [Agents Squads](https://agents-squads.com)