### PR TITLE
fix: handle scheduler offline error in trigger list

### DIFF
--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -64,8 +64,28 @@ async function fetchScheduler<T>(
 }
 
 async function listTriggers(squad?: string): Promise<void> {
-  const params = squad ? `?squad=${squad}` : "";
-  const triggers = await fetchScheduler<Trigger[]>(`/triggers${params}`);
+  let triggers: Trigger[];
+
+  try {
+    const params = squad ? `?squad=${squad}` : "";
+    triggers = await fetchScheduler<Trigger[]>(`/triggers${params}`);
+  } catch (error: unknown) {
+    // Check for connection refused (scheduler offline)
+    const isConnectionError = error instanceof Error &&
+      (error.cause?.toString().includes('ECONNREFUSED') ||
+       error.message.includes('fetch failed'));
+
+    if (isConnectionError) {
+      console.error(chalk.red("\n  Scheduler not running\n"));
+      console.log(chalk.gray("  The trigger system requires the local stack to be running.\n"));
+      console.log(`  ${chalk.cyan("$ squads stack start")}    Start the local stack`);
+      console.log(`  ${chalk.cyan("$ squads stack status")}   Check stack status\n`);
+      return;
+    }
+
+    // Re-throw unexpected errors
+    throw error;
+  }
 
   if (triggers.length === 0) {
     console.log(chalk.gray("No triggers found"));


### PR DESCRIPTION
## Summary
- Wraps the trigger list fetch call in try/catch to handle connection errors gracefully
- Detects ECONNREFUSED errors when scheduler is offline
- Displays helpful error message with recovery steps instead of raw stack trace

## Changes
- `src/commands/trigger.ts`: Added error handling for `listTriggers` function

## Before
```
TypeError: fetch failed
    at node:internal/deps/undici/undici:13510:13
    ...
  [cause]: AggregateError [ECONNREFUSED]: 
    ...
```

## After
```
  Scheduler not running

  The trigger system requires the local stack to be running.

  $ squads stack start    Start the local stack
  $ squads stack status   Check stack status
```

## Testing
- [x] Build passes
- [ ] Manual test: run `squads trigger list` with scheduler offline

Closes #31

🤖 Generated with [Agents Squads](https://agents-squads.com)