### PR TITLE
ux: clarify dashboard budget display for different plans

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -585,11 +585,23 @@ async function _renderTokenEconomics(_squadNames: string[]): Promise<void> {
   writeLine(`  ${bold}Token Economics${RESET} ${colors.dim}(last 100 calls)${RESET}`);
   writeLine();
 
-  // Budget bar
-  const barWidth = 32;
-  const costBar = formatCostBar(costs.usedPercent, barWidth);
-  writeLine(`  ${colors.dim}Budget $${costs.dailyBudget}${RESET} [${costBar}] ${costs.usedPercent.toFixed(1)}%`);
-  writeLine(`  ${colors.green}$${costs.totalCost.toFixed(2)}${RESET} used  ${colors.dim}│${RESET}  ${colors.cyan}$${costs.idleBudget.toFixed(2)}${RESET} idle`);
+  // Budget bar - display depends on plan type
+  const maxPlan = isMaxPlan();
+  if (maxPlan) {
+    // On Max plan, costs are informational (no real budget constraint)
+    writeLine(`  ${colors.dim}Daily spend${RESET} ${colors.green}$${costs.totalCost.toFixed(2)}${RESET} ${colors.dim}(target: $${costs.dailyBudget})${RESET}`);
+  } else {
+    // On usage plan, show budget bar with clear labeling
+    const barWidth = 32;
+    const costBar = formatCostBar(Math.min(costs.usedPercent, 100), barWidth);
+    const pctColor = costs.usedPercent > 100 ? colors.red : costs.usedPercent > 80 ? colors.yellow : colors.green;
+    writeLine(`  ${colors.dim}Daily target $${costs.dailyBudget}${RESET} [${costBar}] ${pctColor}$${costs.totalCost.toFixed(2)}${RESET}`);
+    if (costs.usedPercent > 100) {
+      writeLine(`  ${colors.yellow}⚠${RESET} ${colors.dim}${costs.usedPercent.toFixed(0)}% of target - consider increasing SQUADS_DAILY_BUDGET${RESET}`);
+    } else {
+      writeLine(`  ${colors.cyan}$${costs.idleBudget.toFixed(2)}${RESET} ${colors.dim}remaining of daily target${RESET}`);
+    }
+  }
   writeLine();
 
   // Anthropic tier and limits


### PR DESCRIPTION
## Summary
- On Max plan: Show daily spend without confusing percentage (costs are informational)
- On usage plan: Show budget bar capped at 100%, with clear "target" labeling
- Add contextual guidance when over target instead of alarming red bar

## Problem
The budget display showed a percentage (e.g., "284%") that looked like an over-budget alert, causing user confusion. On Max plan, costs are just informational tracking, not a hard limit.

## Before
```
Budget $50 [████████████████████████████████] 284.0%
$141.81 used  │  $-91.81 idle
```
This reads as "over budget by 184%" which is alarming.

## After (Max Plan)
```
Daily spend $141.81 (target: $50)
```
Clear, informational, no red flags.

## After (Usage Plan)
```
Daily target $50 [████████████████████████████████] $141.81
⚠ 284% of target - consider increasing SQUADS_DAILY_BUDGET
```
Clear labeling with actionable guidance.

## Changes
- `src/commands/dashboard.ts`: Updated budget bar rendering logic

## Testing
- [x] Build passes
- [ ] Manual test: run `squads dash` on Max plan
- [ ] Manual test: run `squads dash` on usage plan

Closes #121

🤖 Generated with [Agents Squads](https://agents-squads.com)