### PR TITLE
fix: add DEBUG logging to silent error handlers

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -101,8 +101,10 @@ function getRecentCommits(since?: string): CommitInfo[] {
         });
       }
     }
-  } catch {
-    // Not in a git repo or other error
+  } catch (err) {
+    if (process.env.DEBUG) {
+      console.error('Git log failed (not a git repo or other error):', err);
+    }
   }
 
   return commits;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -184,7 +184,10 @@ export async function getDashboardHistory(limit: number = 30): Promise<Dashboard
       authorsData: row.authors_data || [],
       reposData: row.repos_data || [],
     }));
-  } catch {
+  } catch (err) {
+    if (process.env.DEBUG) {
+      console.error('Failed to get snapshots from database:', err);
+    }
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Add DEBUG-enabled error logging to catch blocks that previously swallowed errors silently
- Improves debuggability while maintaining graceful degradation in production

## Changes
- `src/commands/sync.ts`: Log git log failures when DEBUG is set
- `src/lib/db.ts`: Log getDashboardHistory failures when DEBUG is set

## Testing
- [x] `npm run build` passes
- [ ] Manual testing with `DEBUG=1 squads sync`
- [ ] Manual testing with `DEBUG=1 squads dash`

Closes #56

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Trigger | manual |
| Model | claude-opus-4-5 |