### PR TITLE
chore: remove unused imports from commands

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -12,7 +12,6 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "fs";
 import { join } from "path";
-import { spawn, ChildProcess } from "child_process";
 import { findSquadsDir, listSquads, loadSquad, Routine } from "../lib/squad-parser.js";
 
 const PID_FILE = "/tmp/squads-autonomous.pid";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -9,24 +9,17 @@ import chalk from 'chalk';
 import ora from 'ora';
 import fs from 'fs/promises';
 import path from 'path';
-import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
 import { createInterface } from 'readline';
 import { checkGitStatus, getRepoName } from '../lib/git.js';
 import { track, Events } from '../lib/telemetry.js';
 import {
   loadTemplate,
-  toKebabCase,
   type TemplateVariables,
 } from '../lib/templates.js';
 import {
-  checkClaudeCli,
-  checkGhCli,
-  checkDockerPrereqs,
   commandExists,
-  isDockerRunning,
   PROVIDERS,
-  type CheckResult,
 } from '../lib/setup-checks.js';
 import { setupCommand } from './setup.js';
 

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -1,13 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
-import { findMemoryDir, appendToMemory } from '../lib/memory.js';
+import { findMemoryDir } from '../lib/memory.js';
 import { findSquadsDir, listSquads } from '../lib/squad-parser.js';
 import {
   colors,
-  bold,
   RESET,
   gradient,
-  box,
   icons,
   writeLine,
 } from '../lib/terminal.js';

--- a/src/commands/orchestrate.ts
+++ b/src/commands/orchestrate.ts
@@ -18,8 +18,6 @@ import { join } from 'path';
 import {
   initEventsDir,
   buildLeadPrompt,
-  buildWorkerCommand,
-  getPendingEvents,
   watchForEvents,
 } from '../lib/orchestration/lead-orchestrator.js';
 import { resolveMcpConfigPath } from '../lib/mcp-config.js';

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -9,7 +9,6 @@
 
 import {
   colors,
-  bold,
   RESET,
   gradient,
   icons,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,7 +9,6 @@ import {
   loadAgentDefinition,
   parseAgentProvider,
   EffortLevel,
-  resolveExecutionContext,
   Squad,
 } from '../lib/squad-parser.js';
 import { resolveMcpConfigPath } from '../lib/mcp-config.js';
@@ -30,10 +29,8 @@ import {
   writeLine,
 } from '../lib/terminal.js';
 import {
-  LLM_CLIS,
   getCLIConfig,
   isProviderCLIAvailable,
-  type CLIConfig,
 } from '../lib/llm-clis.js';
 
 interface RunOptions {

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -26,10 +26,6 @@ import {
   writeLine,
 } from '../lib/terminal.js';
 import {
-  checkDockerPrereqs,
-  checkClaudeCli,
-  checkGhCli,
-  checkGhPermissions,
   runPrereqChecks,
   runAuthChecks,
   displayCheckResults,

--- a/src/lib/condenser/pruning.ts
+++ b/src/lib/condenser/pruning.ts
@@ -159,21 +159,21 @@ export class TokenPruner {
       // Messages at or after protection index are kept as-is
       if (i >= protectionIndex) {
         // Remove internal annotations
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+         
         const { _tokens, _prunable, ...clean } = msg;
         return clean;
       }
 
       // Non-tool messages are kept
       if (!this.isToolResult(msg)) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+         
         const { _tokens, _prunable, ...clean } = msg;
         return clean;
       }
 
       // Protected tools are kept
       if (this.isProtectedTool(msg)) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+         
         const { _tokens, _prunable, ...clean } = msg;
         return clean;
       }


### PR DESCRIPTION
## Summary
Partial fix for #27 - removes unused imports from command files.

## Changes
- `autonomous.ts`: Remove unused spawn/ChildProcess imports
- `init.ts`: Remove unused existsSync, toKebabCase, check functions
- `learn.ts`: Remove unused appendToMemory, bold, box imports
- `orchestrate.ts`: Remove unused buildWorkerCommand, getPendingEvents
- `providers.ts`: Remove unused bold import
- `run.ts`: Remove unused resolveExecutionContext, LLM_CLIS, CLIConfig
- `setup.ts`: Remove unused check function imports

**Progress**: Reduces lint warnings from 115 to 87 (~25% reduction).

Remaining warnings are mostly:
- Unused local variables/functions that need careful review
- Catch block error variables
- Type-only imports that could be optimized

## Testing
- [x] `npm run build` passes
- [x] `npm run lint` runs without errors (only warnings)

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Trigger | manual |
| Model | claude-opus-4-5 |