### PR TITLE
test: add unit tests for dashboard bar and trend renderers

### DIFF
--- a/test/dashboard-bar.test.ts
+++ b/test/dashboard-bar.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Tests for dashboard bar renderer
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderBar, renderPie } from '../src/lib/dashboard/renderers/bar.js';
+import type { ViewDefinition, MetricDefinition, DimensionDefinition, QueryResult } from '../src/lib/dashboard/types.js';
+
+// Helper to strip ANSI codes for easier assertions
+const stripAnsi = (str: string): string => str.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('dashboard bar renderer', () => {
+  describe('renderBar', () => {
+    const metricDefs: MetricDefinition[] = [
+      { name: 'count', label: 'Count', format: 'number' },
+      { name: 'cost', label: 'Cost', format: 'currency' },
+    ];
+    const dimensionDefs: DimensionDefinition[] = [
+      { name: 'category', label: 'Category', type: 'string' },
+    ];
+
+    it('returns "No data" for empty data', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = { rows: [], columns: [] };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      expect(result.length).toBe(1);
+      expect(stripAnsi(result[0])).toContain('No data');
+    });
+
+    it('renders title when provided', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        title: 'Test Bar Chart',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', count: 10 }],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result[0])).toContain('Test Bar Chart');
+    });
+
+    it('requires group_by and metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', count: 10 }],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result.join(''))).toContain('requires group_by and metrics');
+    });
+
+    it('requires metrics when only group_by provided', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', count: 10 }],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result.join(''))).toContain('requires group_by and metrics');
+    });
+
+    it('renders bars for each row', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 100 },
+          { category: 'B', count: 50 },
+          { category: 'C', count: 25 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Should have entries for each row
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('A'))).toBe(true);
+      expect(stripped.some(line => line.includes('B'))).toBe(true);
+      expect(stripped.some(line => line.includes('C'))).toBe(true);
+    });
+
+    it('handles string values by parsing to number', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: '100' },
+          { category: 'B', count: '50' },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Should render without error
+      expect(result.length).toBeGreaterThan(0);
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('A'))).toBe(true);
+    });
+
+    it('handles null/undefined dimension values', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: null, count: 100 },
+          { category: undefined, count: 50 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Unknown'))).toBe(true);
+    });
+
+    it('handles non-numeric values gracefully', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 'not a number' },
+          { category: 'B', count: NaN },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Should render without error, values default to 0
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('truncates long labels', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'This is a very long category name that should be truncated', count: 100 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Labels are capped at 20 chars
+      const stripped = result.map(stripAnsi).join('');
+      expect(stripped.includes('This is a very long category name that should be truncated')).toBe(false);
+    });
+
+    it('uses metric format for value display', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['cost'],
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', cost: 1000 }],
+        columns: ['category', 'cost'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Should use currency format
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles missing metric definition', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'bar',
+        group_by: ['category'],
+        metrics: ['unknown_metric'],
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', unknown_metric: 100 }],
+        columns: ['category', 'unknown_metric'],
+      };
+
+      const result = renderBar(view, data, metricDefs, dimensionDefs);
+
+      // Should render without error, using default format
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('renderPie', () => {
+    const metricDefs: MetricDefinition[] = [
+      { name: 'count', label: 'Count', format: 'number' },
+    ];
+    const dimensionDefs: DimensionDefinition[] = [
+      { name: 'category', label: 'Category', type: 'string' },
+    ];
+
+    it('returns "No data" for empty data', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = { rows: [], columns: [] };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      expect(result.length).toBe(1);
+      expect(stripAnsi(result[0])).toContain('No data');
+    });
+
+    it('renders title when provided', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        title: 'Test Pie Chart',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', count: 10 }],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result[0])).toContain('Test Pie Chart');
+    });
+
+    it('requires group_by and metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+      };
+      const data: QueryResult = {
+        rows: [{ category: 'A', count: 10 }],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result.join(''))).toContain('requires group_by and metrics');
+    });
+
+    it('handles all zeros (total = 0)', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 0 },
+          { category: 'B', count: 0 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      expect(stripAnsi(result.join(''))).toContain('No data');
+    });
+
+    it('renders distribution bar and legend', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 50 },
+          { category: 'B', count: 30 },
+          { category: 'C', count: 20 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      // Should have bar and legend entries
+      expect(result.length).toBeGreaterThan(3);
+      const stripped = result.map(stripAnsi);
+      // Should show percentages
+      expect(stripped.some(line => line.includes('%'))).toBe(true);
+    });
+
+    it('calculates correct percentages', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 100 },
+          { category: 'B', count: 100 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      // Each should be 50%
+      expect(stripped.includes('50.0%')).toBe(true);
+    });
+
+    it('handles string values by parsing to number', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: '60' },
+          { category: 'B', count: '40' },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      expect(stripped.includes('60.0%')).toBe(true);
+      expect(stripped.includes('40.0%')).toBe(true);
+    });
+
+    it('handles null/undefined dimension values', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: null, count: 50 },
+          { category: 'B', count: 50 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Unknown'))).toBe(true);
+    });
+
+    it('cycles through color palette for many items', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 20 },
+          { category: 'B', count: 20 },
+          { category: 'C', count: 20 },
+          { category: 'D', count: 20 },
+          { category: 'E', count: 10 },
+          { category: 'F', count: 10 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      // Should have legend entries for all 6 items
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('A'))).toBe(true);
+      expect(stripped.some(line => line.includes('F'))).toBe(true);
+    });
+
+    it('truncates long labels in legend', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'This is a very long category name', count: 100 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      // Labels in pie chart are sliced to 15 chars
+      const stripped = result.map(stripAnsi).join('');
+      expect(stripped.includes('This is a very long category name')).toBe(false);
+    });
+
+    it('shows values in parentheses in legend', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'pie',
+        group_by: ['category'],
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { category: 'A', count: 1000 },
+          { category: 'B', count: 500 },
+        ],
+        columns: ['category', 'count'],
+      };
+
+      const result = renderPie(view, data, metricDefs, dimensionDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      // Should show formatted values in parentheses
+      expect(stripped.includes('(1,000)')).toBe(true);
+      expect(stripped.includes('(500)')).toBe(true);
+    });
+  });
+});

--- a/test/dashboard-trend.test.ts
+++ b/test/dashboard-trend.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Tests for dashboard trend renderer
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderTrend, renderStackedTrend } from '../src/lib/dashboard/renderers/trend.js';
+import type { ViewDefinition, MetricDefinition, QueryResult } from '../src/lib/dashboard/types.js';
+
+// Helper to strip ANSI codes for easier assertions
+const stripAnsi = (str: string): string => str.replace(/\x1b\[[0-9;]*m/g, '');
+
+describe('dashboard trend renderer', () => {
+  describe('renderTrend', () => {
+    const metricDefs: MetricDefinition[] = [
+      { name: 'count', label: 'Count', format: 'number' },
+      { name: 'cost', label: 'Cost', format: 'currency' },
+      { name: 'percent', label: 'Percent', format: 'percent' },
+    ];
+
+    it('returns "No data" for empty data', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = { rows: [], columns: [] };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      expect(result.length).toBe(1);
+      expect(stripAnsi(result[0])).toContain('No data');
+    });
+
+    it('renders title when provided', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        title: 'Test Trend Chart',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ count: 10 }, { count: 20 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      expect(stripAnsi(result[0])).toContain('Test Trend Chart');
+    });
+
+    it('renders sparkline for metric', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 10 },
+          { count: 20 },
+          { count: 30 },
+          { count: 25 },
+          { count: 35 },
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should have a line with sparkline characters
+      expect(result.length).toBeGreaterThan(0);
+      const stripped = result.map(stripAnsi);
+      // Should show metric label
+      expect(stripped.some(line => line.includes('Count'))).toBe(true);
+      // Should show "total"
+      expect(stripped.some(line => line.includes('total'))).toBe(true);
+    });
+
+    it('calculates and shows change percentage', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 100 }, // latest (gets reversed to be last)
+          { count: 50 },  // previous
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      // After reversal: [50, 100], change = (100-50)/50 = 100%
+      expect(stripped.includes('%')).toBe(true);
+    });
+
+    it('handles string values by parsing to number', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: '100' },
+          { count: '200' },
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should render without error
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles non-numeric values gracefully', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 'not a number' },
+          { count: NaN },
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should render without error (values default to 0)
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('skips metrics without definition', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['unknown_metric'],
+      };
+      const data: QueryResult = {
+        rows: [{ unknown_metric: 100 }],
+        columns: ['unknown_metric'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should not render anything for unknown metric (no def found)
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('unknown_metric'))).toBe(false);
+    });
+
+    it('renders multiple metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count', 'cost'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 10, cost: 100 },
+          { count: 20, cost: 200 },
+        ],
+        columns: ['count', 'cost'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Count'))).toBe(true);
+      expect(stripped.some(line => line.includes('Cost'))).toBe(true);
+    });
+
+    it('uses metric label from definition', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ count: 10 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      // Should use "Count" label not "count"
+      expect(stripped.some(line => line.includes('Count'))).toBe(true);
+    });
+
+    it('falls back to metric name when no label', () => {
+      const metricDefsNoLabel: MetricDefinition[] = [
+        { name: 'count', format: 'number' },
+      ];
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ count: 10 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefsNoLabel);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('count'))).toBe(true);
+    });
+
+    it('handles zero previous value for change calculation', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 100 }, // latest
+          { count: 0 },   // previous
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should not crash, change = 0 when previous = 0
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles single data point', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [{ count: 100 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should render without error
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles empty metrics array', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: [],
+      };
+      const data: QueryResult = {
+        rows: [{ count: 100 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should not crash
+      expect(result).toBeDefined();
+    });
+
+    it('handles undefined metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+      };
+      const data: QueryResult = {
+        rows: [{ count: 100 }],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      // Should not crash
+      expect(result).toBeDefined();
+    });
+
+    it('shows positive change with plus sign', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'trend',
+        metrics: ['count'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { count: 200 }, // latest (reversed to be last)
+          { count: 100 }, // previous
+        ],
+        columns: ['count'],
+      };
+
+      const result = renderTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      // Should show positive change
+      expect(stripped.includes('+') || stripped.includes('%')).toBe(true);
+    });
+  });
+
+  describe('renderStackedTrend', () => {
+    const metricDefs: MetricDefinition[] = [
+      { name: 'revenue', label: 'Revenue', format: 'currency' },
+      { name: 'cost', label: 'Cost', format: 'currency' },
+      { name: 'profit', label: 'Profit', format: 'currency' },
+    ];
+
+    it('returns "No data" for empty data', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue', 'cost'],
+      };
+      const data: QueryResult = { rows: [], columns: [] };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      expect(result.length).toBe(1);
+      expect(stripAnsi(result[0])).toContain('No data');
+    });
+
+    it('renders title when provided', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        title: 'Test Stacked Trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100 }],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      expect(stripAnsi(result[0])).toContain('Test Stacked Trend');
+    });
+
+    it('renders sparkline for primary metric', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue', 'cost'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: 100, cost: 50 },
+          { revenue: 150, cost: 60 },
+          { revenue: 200, cost: 70 },
+        ],
+        columns: ['revenue', 'cost'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      // Should have sparkline and legend
+      expect(result.length).toBeGreaterThan(1);
+    });
+
+    it('shows legend with totals for all metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue', 'cost'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: 100, cost: 50 },
+          { revenue: 150, cost: 60 },
+        ],
+        columns: ['revenue', 'cost'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Revenue'))).toBe(true);
+      expect(stripped.some(line => line.includes('Cost'))).toBe(true);
+    });
+
+    it('calculates correct totals', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: 100 },
+          { revenue: 200 },
+          { revenue: 300 },
+        ],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi).join(' ');
+      // Total should be 600
+      expect(stripped.includes('600') || stripped.includes('$600')).toBe(true);
+    });
+
+    it('handles string values by parsing to number', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: '100' },
+          { revenue: '200' },
+        ],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      // Should render without error
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles non-numeric values gracefully', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: 'invalid' },
+          { revenue: NaN },
+        ],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      // Should render without error
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('skips metrics without definition in legend', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue', 'unknown_metric'],
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100, unknown_metric: 50 }],
+        columns: ['revenue', 'unknown_metric'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Revenue'))).toBe(true);
+      expect(stripped.some(line => line.includes('unknown_metric'))).toBe(false);
+    });
+
+    it('handles three metrics with color coding', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue', 'cost', 'profit'],
+      };
+      const data: QueryResult = {
+        rows: [
+          { revenue: 100, cost: 50, profit: 50 },
+        ],
+        columns: ['revenue', 'cost', 'profit'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('Revenue'))).toBe(true);
+      expect(stripped.some(line => line.includes('Cost'))).toBe(true);
+      expect(stripped.some(line => line.includes('Profit'))).toBe(true);
+    });
+
+    it('uses metric label from definition', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100 }],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      const stripped = result.map(stripAnsi);
+      // Should use "Revenue" label
+      expect(stripped.some(line => line.includes('Revenue'))).toBe(true);
+    });
+
+    it('falls back to metric name when no label', () => {
+      const metricDefsNoLabel: MetricDefinition[] = [
+        { name: 'revenue', format: 'currency' },
+      ];
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: ['revenue'],
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100 }],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefsNoLabel);
+
+      const stripped = result.map(stripAnsi);
+      expect(stripped.some(line => line.includes('revenue'))).toBe(true);
+    });
+
+    it('handles empty metrics array', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+        metrics: [],
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100 }],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      // Should not crash
+      expect(result).toBeDefined();
+    });
+
+    it('handles undefined metrics', () => {
+      const view: ViewDefinition = {
+        name: 'test',
+        type: 'stacked_trend',
+      };
+      const data: QueryResult = {
+        rows: [{ revenue: 100 }],
+        columns: ['revenue'],
+      };
+
+      const result = renderStackedTrend(view, data, metricDefs);
+
+      // Should not crash
+      expect(result).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added 22 tests for bar renderer (renderBar, renderPie functions)
- Added 28 tests for trend renderer (renderTrend, renderStackedTrend functions)
- Total: 50 new tests

## Changes
- test/dashboard-bar.test.ts (471 lines)
- test/dashboard-trend.test.ts (561 lines)

## Testing
- [x] All 50 tests pass
- [x] Build passes
- [x] No regressions in existing tests

Part of #226

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Trigger | manual |
| Execution | N/A |
| Model | claude-opus-4-5 |
| Target | sprint/2026-w04 |