### PR TITLE
test: fix flaky memory tests on macOS

### DIFF
--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -7,7 +7,7 @@ import {
   updateMemorySync,
   appendToMemorySync,
 } from '../src/lib/memory';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync, realpathSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -17,7 +17,8 @@ describe('memory utilities', () => {
   let originalCwd: string;
 
   beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'squads-memory-test-'));
+    // Use realpathSync to handle macOS /var -> /private/var symlink
+    tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'squads-memory-test-')));
     memoryDir = join(tempDir, '.agents', 'memory');
     mkdirSync(memoryDir, { recursive: true });
     originalCwd = process.cwd();


### PR DESCRIPTION
## Summary

- Use `realpathSync` to normalize temp directory paths in memory tests
- Fixes the `/var` -> `/private/var` symlink issue on macOS
- All 523 tests pass after this fix

## Changes

- `test/memory.test.ts`: Added `realpathSync` to handle macOS symlink

## Test plan

- [x] `npm test` passes (523 tests)
- [x] `test/memory.test.ts` specifically passes (24 tests)
- [x] Build passes

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Trigger | manual |
| Model | claude-opus-4-5-20251101 |
| Target | sprint/2026-w04 |