### PR TITLE
feat(context): add squad-scoped skills and MCP servers

### DIFF
--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -4,6 +4,8 @@ import {
   listSquads,
   SquadContext,
   resolveExecutionContext,
+  getSquadLocalSkills,
+  ResolvedSkill,
 } from '../lib/squad-parser.js';
 import { track, Events } from '../lib/telemetry.js';
 import {
@@ -41,6 +43,9 @@ export async function contextShowCommand(
     process.exit(1);
   }
 
+  // Resolve execution context to get full skill and MCP info
+  const execContext = resolveExecutionContext(squad);
+
   if (options.json) {
     console.log(JSON.stringify({
       name: squad.name,
@@ -49,6 +54,7 @@ export async function contextShowCommand(
       stack: squad.stack,
       effort: squad.effort,
       context: squad.context,
+      resolved: execContext.resolved,
     }, null, 2));
     return;
   }
@@ -79,15 +85,32 @@ export async function contextShowCommand(
   writeLine();
   writeLine(`  ${colors.purple}${box.horizontal.repeat(tableWidth)}${RESET}`);
 
-  // MCP Servers
-  if (ctx.mcp && ctx.mcp.length > 0) {
+  // MCP Config (show resolved source)
+  const mcpSource = execContext.resolved.mcpSource;
+  const mcpSourceLabel = mcpSource === 'squad-local' ? `${colors.green}squad-local${RESET}` :
+                         mcpSource === 'generated' ? `${colors.cyan}generated${RESET}` :
+                         mcpSource === 'user-override' ? `${colors.yellow}user-override${RESET}` :
+                         `${colors.dim}fallback${RESET}`;
+
+  if (execContext.resolved.mcpServers.length > 0) {
+    writeLine(`  ${bold}MCP${RESET}       ${colors.cyan}${execContext.resolved.mcpServers.join(', ')}${RESET} ${colors.dim}(${mcpSourceLabel})${RESET}`);
+  } else if (ctx?.mcp && ctx.mcp.length > 0) {
     writeLine(`  ${bold}MCP${RESET}       ${colors.cyan}${ctx.mcp.join(', ')}${RESET}`);
   } else {
     writeLine(`  ${bold}MCP${RESET}       ${colors.dim}none${RESET}`);
   }
 
-  // Skills
-  if (ctx.skills && ctx.skills.length > 0) {
+  // Skills (show resolved with sources)
+  const resolvedSkills = execContext.resolved.skills || [];
+  if (resolvedSkills.length > 0) {
+    const skillLabels = resolvedSkills.map(s => {
+      const sourceColor = s.source === 'squad-local' ? colors.green :
+                          s.source === 'project' ? colors.cyan :
+                          colors.dim;
+      return `${colors.cyan}${s.name}${RESET} ${sourceColor}(${s.source})${RESET}`;
+    });
+    writeLine(`  ${bold}Skills${RESET}    ${skillLabels.join(', ')}`);
+  } else if (ctx?.skills && ctx.skills.length > 0) {
     writeLine(`  ${bold}Skills${RESET}    ${colors.cyan}${ctx.skills.join(', ')}${RESET}`);
   }
 
@@ -254,11 +277,15 @@ export async function contextActivateCommand(
       writeLine(`    Servers: ${execContext.resolved.mcpServers.join(', ')}`);
     }
 
-    if (execContext.resolved.skillPaths.length > 0) {
+    if (execContext.resolved.skills && execContext.resolved.skills.length > 0) {
       writeLine();
       writeLine(`  ${bold}Skills${RESET}`);
-      for (const path of execContext.resolved.skillPaths) {
-        writeLine(`    ${colors.dim}${path}${RESET}`);
+      for (const skill of execContext.resolved.skills) {
+        const sourceColor = skill.source === 'squad-local' ? colors.green :
+                           skill.source === 'project' ? colors.cyan :
+                           colors.dim;
+        writeLine(`    ${colors.cyan}${skill.name}${RESET} ${sourceColor}(${skill.source})${RESET}`);
+        writeLine(`      ${colors.dim}${skill.path}${RESET}`);
       }
     }
 
@@ -282,11 +309,15 @@ export async function contextActivateCommand(
   writeLine();
 
   // Show what was resolved/generated
-  const sourceLabel = execContext.resolved.mcpSource === 'generated'
-    ? `${colors.green}generated${RESET}`
+  const mcpSourceLabel = execContext.resolved.mcpSource === 'squad-local'
+    ? `${colors.green}squad-local${RESET}`
+    : execContext.resolved.mcpSource === 'generated'
+    ? `${colors.cyan}generated${RESET}`
     : execContext.resolved.mcpSource === 'user-override'
-    ? `${colors.cyan}user override${RESET}`
+    ? `${colors.yellow}user override${RESET}`
     : `${colors.dim}fallback${RESET}`;
+
+  const sourceLabel = mcpSourceLabel;
 
   writeLine(`  ${icons.success} MCP config: ${sourceLabel}`);
   writeLine(`    ${colors.dim}${execContext.resolved.mcpConfigPath}${RESET}`);
@@ -295,8 +326,18 @@ export async function contextActivateCommand(
     writeLine(`    ${colors.dim}Servers: ${execContext.resolved.mcpServers.join(', ')}${RESET}`);
   }
 
-  if (execContext.resolved.skillPaths.length > 0) {
-    writeLine(`  ${icons.success} Skills: ${execContext.resolved.skillPaths.length} resolved`);
+  if (execContext.resolved.skills && execContext.resolved.skills.length > 0) {
+    // Group skills by source
+    const bySource = execContext.resolved.skills.reduce((acc, s) => {
+      acc[s.source] = (acc[s.source] || 0) + 1;
+      return acc;
+    }, {} as Record<string, number>);
+
+    const sourceSummary = Object.entries(bySource)
+      .map(([source, count]) => `${count} ${source}`)
+      .join(', ');
+
+    writeLine(`  ${icons.success} Skills: ${execContext.resolved.skills.length} resolved (${sourceSummary})`);
   }
 
   if (execContext.resolved.memoryPaths.length > 0) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,7 +4,8 @@ import {
   findSquadsDir,
   loadSquad,
   listSquads,
-  listAgents
+  listAgents,
+  resolveExecutionContext,
 } from '../lib/squad-parser.js';
 import { findMemoryDir, getSquadState } from '../lib/memory.js';
 import { getLiveSessionSummaryAsync, cleanupStaleSessions } from '../lib/sessions.js';
@@ -224,6 +225,52 @@ async function showSquadStatus(
     writeLine(`  ${bold}Pipelines${RESET}`);
     for (const pipeline of squad.pipelines) {
       writeLine(`  ${colors.dim}${pipeline.agents.join(' → ')}${RESET}`);
+    }
+  }
+
+  // Context profile
+  const execContext = resolveExecutionContext(squad);
+  const hasContext = execContext.resolved.skills.length > 0 ||
+                     execContext.resolved.mcpServers.length > 0 ||
+                     (squad.context?.model?.default);
+
+  if (hasContext) {
+    writeLine();
+    writeLine(`  ${bold}Context${RESET}`);
+
+    // MCP servers
+    if (execContext.resolved.mcpServers.length > 0) {
+      const sourceLabel = execContext.resolved.mcpSource === 'squad-local' ? `${colors.green}local${RESET}` :
+                          execContext.resolved.mcpSource === 'generated' ? `${colors.cyan}generated${RESET}` :
+                          execContext.resolved.mcpSource === 'user-override' ? `${colors.yellow}override${RESET}` :
+                          '';
+      writeLine(`  ${colors.dim}MCP:${RESET}    ${colors.cyan}${execContext.resolved.mcpServers.join(', ')}${RESET}${sourceLabel ? ` ${colors.dim}(${sourceLabel})${RESET}` : ''}`);
+    }
+
+    // Skills (grouped by source)
+    if (execContext.resolved.skills.length > 0) {
+      const bySource = execContext.resolved.skills.reduce((acc, s) => {
+        acc[s.source] = acc[s.source] || [];
+        acc[s.source].push(s.name);
+        return acc;
+      }, {} as Record<string, string[]>);
+
+      const skillParts: string[] = [];
+      if (bySource['squad-local']) {
+        skillParts.push(`${colors.green}${bySource['squad-local'].join(', ')}${RESET} ${colors.dim}(local)${RESET}`);
+      }
+      if (bySource['project']) {
+        skillParts.push(`${colors.cyan}${bySource['project'].join(', ')}${RESET}`);
+      }
+      if (bySource['global']) {
+        skillParts.push(`${colors.dim}${bySource['global'].join(', ')}${RESET}`);
+      }
+      writeLine(`  ${colors.dim}Skills:${RESET} ${skillParts.join(', ')}`);
+    }
+
+    // Model
+    if (squad.context?.model?.default) {
+      writeLine(`  ${colors.dim}Model:${RESET}  ${colors.white}${squad.context.model.default}${RESET}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export {
   // Goal management
   addGoalToSquad,
   updateGoalInSquad,
+  // Context resolution (squad-scoped skills/MCP)
+  resolveExecutionContext,
+  getSquadLocalSkills,
   // Types
   type Squad,
   type Agent,
@@ -23,6 +26,8 @@ export {
   type SquadContext,
   type SquadFrontmatter,
   type EffortLevel,
+  type ExecutionContext,
+  type ResolvedSkill,
 } from './lib/squad-parser.js';
 
 // Context Condenser - for programmatic API usage

--- a/src/lib/squad-parser.ts
+++ b/src/lib/squad-parser.ts
@@ -26,6 +26,18 @@ export interface SquadContext {
   cooldown?: number;
 }
 
+/**
+ * Resolved skill with path and source information.
+ */
+export interface ResolvedSkill {
+  /** Skill name (directory or reference name) */
+  name: string;
+  /** Absolute path to the skill directory */
+  path: string;
+  /** Where the skill was found */
+  source: 'squad-local' | 'project' | 'global';
+}
+
 // Multi-LLM provider configuration
 export interface SquadProviders {
   /** Default provider for all agents (default: anthropic) */
@@ -146,11 +158,13 @@ export interface ExecutionContext extends SquadContext {
     /** Path to MCP config file to use */
     mcpConfigPath: string;
     /** Source of MCP config resolution */
-    mcpSource: 'user-override' | 'generated' | 'fallback';
+    mcpSource: 'user-override' | 'generated' | 'fallback' | 'squad-local';
     /** List of MCP servers in the config */
     mcpServers: string[];
-    /** Resolved skill directory paths */
+    /** Resolved skill directory paths (deprecated, use skills instead) */
     skillPaths: string[];
+    /** Resolved skills with source information */
+    skills: ResolvedSkill[];
     /** Resolved memory file paths */
     memoryPaths: string[];
   };
@@ -611,14 +625,66 @@ export function updateGoalInSquad(
 }
 
 /**
- * Find the skills directory (.claude/skills)
+ * Find the project-level skills directory (.claude/skills)
  */
-function findSkillsDir(): string | null {
+function findProjectSkillsDir(): string | null {
   const projectRoot = findProjectRoot();
   if (!projectRoot) return null;
 
   const skillsDir = join(projectRoot, '.claude', 'skills');
   return existsSync(skillsDir) ? skillsDir : null;
+}
+
+/**
+ * Find the global skills directory (~/.claude/skills)
+ */
+function findGlobalSkillsDir(): string | null {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  if (!home) return null;
+
+  const skillsDir = join(home, '.claude', 'skills');
+  return existsSync(skillsDir) ? skillsDir : null;
+}
+
+/**
+ * Find squad-local skills directory (.agents/squads/<squad>/skills)
+ */
+function findSquadLocalSkillsDir(squadDir: string): string | null {
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return null;
+
+  const skillsDir = join(squadsDir, squadDir, 'skills');
+  return existsSync(skillsDir) ? skillsDir : null;
+}
+
+/**
+ * List all skills in a directory.
+ * Skills are subdirectories containing SKILL.md or .md files.
+ */
+function listSkillsInDir(skillsDir: string): string[] {
+  if (!existsSync(skillsDir)) return [];
+
+  try {
+    const entries = readdirSync(skillsDir, { withFileTypes: true });
+    const skills: string[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        // Check if directory contains SKILL.md
+        const skillMdPath = join(skillsDir, entry.name, 'SKILL.md');
+        if (existsSync(skillMdPath)) {
+          skills.push(entry.name);
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.md') && entry.name !== 'README.md') {
+        // Single-file skill
+        skills.push(entry.name.replace('.md', ''));
+      }
+    }
+
+    return skills;
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -633,14 +699,81 @@ function findMemoryDir(): string | null {
 }
 
 /**
- * Resolve a skill name to its directory path.
+ * Resolve a skill name to its path using three-tier resolution:
+ * 1. Squad-local: .agents/squads/<squad>/skills/<skill>
+ * 2. Project: .claude/skills/<skill>
+ * 3. Global: ~/.claude/skills/<skill>
+ *
+ * @param skillName - Name of the skill to resolve
+ * @param squadDir - Squad directory name for squad-local lookup
+ * @returns Resolved skill with path and source, or null if not found
  */
-function resolveSkillPath(skillName: string): string | null {
-  const skillsDir = findSkillsDir();
-  if (!skillsDir) return null;
+function resolveSkill(skillName: string, squadDir?: string): ResolvedSkill | null {
+  // 1. Squad-local skills (highest priority)
+  if (squadDir) {
+    const squadSkillsDir = findSquadLocalSkillsDir(squadDir);
+    if (squadSkillsDir) {
+      // Check for directory-style skill
+      const dirPath = join(squadSkillsDir, skillName);
+      if (existsSync(dirPath) && existsSync(join(dirPath, 'SKILL.md'))) {
+        return { name: skillName, path: dirPath, source: 'squad-local' };
+      }
+      // Check for single-file skill
+      const filePath = join(squadSkillsDir, `${skillName}.md`);
+      if (existsSync(filePath)) {
+        return { name: skillName, path: filePath, source: 'squad-local' };
+      }
+    }
+  }
 
-  const skillPath = join(skillsDir, skillName);
-  return existsSync(skillPath) ? skillPath : null;
+  // 2. Project-level skills
+  const projectSkillsDir = findProjectSkillsDir();
+  if (projectSkillsDir) {
+    const dirPath = join(projectSkillsDir, skillName);
+    if (existsSync(dirPath) && existsSync(join(dirPath, 'SKILL.md'))) {
+      return { name: skillName, path: dirPath, source: 'project' };
+    }
+    const filePath = join(projectSkillsDir, `${skillName}.md`);
+    if (existsSync(filePath)) {
+      return { name: skillName, path: filePath, source: 'project' };
+    }
+  }
+
+  // 3. Global skills
+  const globalSkillsDir = findGlobalSkillsDir();
+  if (globalSkillsDir) {
+    const dirPath = join(globalSkillsDir, skillName);
+    if (existsSync(dirPath) && existsSync(join(dirPath, 'SKILL.md'))) {
+      return { name: skillName, path: dirPath, source: 'global' };
+    }
+    const filePath = join(globalSkillsDir, `${skillName}.md`);
+    if (existsSync(filePath)) {
+      return { name: skillName, path: filePath, source: 'global' };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get all available squad-local skills for a squad.
+ * Scans .agents/squads/<squad>/skills/ directory.
+ */
+export function getSquadLocalSkills(squadDir: string): ResolvedSkill[] {
+  const squadSkillsDir = findSquadLocalSkillsDir(squadDir);
+  if (!squadSkillsDir) return [];
+
+  const skillNames = listSkillsInDir(squadSkillsDir);
+  const skills: ResolvedSkill[] = [];
+
+  for (const name of skillNames) {
+    const resolved = resolveSkill(name, squadDir);
+    if (resolved && resolved.source === 'squad-local') {
+      skills.push(resolved);
+    }
+  }
+
+  return skills;
 }
 
 /**
@@ -683,11 +816,22 @@ function resolveMemoryPaths(patterns: string[]): string[] {
 }
 
 /**
+ * Check for squad-local MCP config (.agents/squads/<squad>/mcp.json)
+ */
+function findSquadLocalMcpConfig(squadDir: string): string | null {
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return null;
+
+  const mcpConfigPath = join(squadsDir, squadDir, 'mcp.json');
+  return existsSync(mcpConfigPath) ? mcpConfigPath : null;
+}
+
+/**
  * Resolve execution context for a squad.
  *
  * Takes a Squad object and resolves all context references to actual paths:
- * - MCP config path (three-tier resolution)
- * - Skill directory paths
+ * - MCP config path (four-tier resolution: squad-local, user-override, generated, fallback)
+ * - Skill directory paths (three-tier: squad-local, project, global)
  * - Memory file paths
  *
  * @param squad - The squad to resolve context for
@@ -700,20 +844,61 @@ export function resolveExecutionContext(
 ): ExecutionContext {
   const ctx = squad.context || {};
 
-  // Resolve MCP config
-  const mcpResolution: McpResolution = resolveMcpConfig(
-    squad.name,
-    ctx.mcp,
-    forceRegenerate
-  );
+  // Check for squad-local MCP config first (highest priority)
+  const squadLocalMcpConfig = findSquadLocalMcpConfig(squad.dir);
 
-  // Resolve skill paths
-  const skillPaths: string[] = [];
+  let mcpConfigPath: string;
+  let mcpSource: 'squad-local' | 'user-override' | 'generated' | 'fallback';
+  let mcpServers: string[] = [];
+
+  if (squadLocalMcpConfig) {
+    // Use squad-local MCP config
+    mcpConfigPath = squadLocalMcpConfig;
+    mcpSource = 'squad-local';
+
+    // Try to read server names from the config
+    try {
+      const content = readFileSync(squadLocalMcpConfig, 'utf-8');
+      const config = JSON.parse(content);
+      mcpServers = Object.keys(config.mcpServers || {});
+    } catch {
+      // Ignore parse errors
+    }
+  } else {
+    // Fall back to existing resolution (user-override, generated, fallback)
+    const mcpResolution: McpResolution = resolveMcpConfig(
+      squad.name,
+      ctx.mcp,
+      forceRegenerate
+    );
+    mcpConfigPath = mcpResolution.path;
+    mcpSource = mcpResolution.source;
+    mcpServers = mcpResolution.servers || [];
+  }
+
+  // Resolve skills with three-tier resolution
+  const resolvedSkills: ResolvedSkill[] = [];
+  const skillPaths: string[] = []; // For backward compatibility
+
+  // First, add any squad-local skills that exist (auto-discovered)
+  const squadLocalSkills = getSquadLocalSkills(squad.dir);
+  for (const skill of squadLocalSkills) {
+    resolvedSkills.push(skill);
+    skillPaths.push(skill.path);
+  }
+
+  // Then, resolve explicitly listed skills from context
   if (ctx.skills) {
-    for (const skill of ctx.skills) {
-      const path = resolveSkillPath(skill);
-      if (path) {
-        skillPaths.push(path);
+    for (const skillName of ctx.skills) {
+      // Check if already resolved as squad-local
+      if (resolvedSkills.some(s => s.name === skillName)) {
+        continue;
+      }
+
+      const resolved = resolveSkill(skillName, squad.dir);
+      if (resolved) {
+        resolvedSkills.push(resolved);
+        skillPaths.push(resolved.path);
       }
     }
   }
@@ -730,10 +915,11 @@ export function resolveExecutionContext(
     squadName: squad.name,
     // Add resolved paths
     resolved: {
-      mcpConfigPath: mcpResolution.path,
-      mcpSource: mcpResolution.source,
-      mcpServers: mcpResolution.servers || [],
-      skillPaths,
+      mcpConfigPath,
+      mcpSource,
+      mcpServers,
+      skillPaths, // Backward compatible
+      skills: resolvedSkills, // New detailed skill info
       memoryPaths,
     },
   };


### PR DESCRIPTION
## Summary

Implements #109: Squad-scoped skills and MCP servers.

This PR enables squads to have their own skills and MCP configurations that are automatically loaded when running that squad, reducing context overhead by only loading what is needed.

### Changes
- Three-tier skill resolution: squad-local > project > global
- Squad-local MCP config support (.agents/squads/<squad>/mcp.json)
- ResolvedSkill interface with path and source information
- Updated commands to display skill sources and context profiles
- Export new types and functions from library

### Resolution Order

**Skills:**
1. Squad-local: .agents/squads/<squad>/skills/<skill>/
2. Project: .claude/skills/<skill>/
3. Global: ~/.claude/skills/<skill>/

**MCP Config:**
1. Squad-local: .agents/squads/<squad>/mcp.json
2. User override: ~/.claude/mcp-configs/<squad>.json
3. Generated: ~/.claude/mcp-configs/<squad>-generated.json
4. Fallback: ~/.claude.json

## Test plan

- [ ] squads context show <squad> displays skills with their sources
- [ ] squads context activate <squad> shows resolved skill paths
- [ ] squads status <squad> shows context profile
- [ ] Squad with .agents/squads/<squad>/skills/ directory auto-discovers skills
- [ ] Squad with .agents/squads/<squad>/mcp.json uses local config

Closes #109

Generated with Agents Squads