### PR TITLE
fix(security): restrict auth file permissions to owner-only

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import http from 'http';
@@ -42,9 +42,9 @@ export function getEmailDomain(email: string): string {
 
 export function saveSession(session: AuthSession): void {
   if (!existsSync(AUTH_DIR)) {
-    mkdirSync(AUTH_DIR, { recursive: true });
+    mkdirSync(AUTH_DIR, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(AUTH_PATH, JSON.stringify(session, null, 2));
+  writeFileSync(AUTH_PATH, JSON.stringify(session, null, 2), { mode: 0o600 });
 }
 
 export function loadSession(): AuthSession | null {
@@ -57,8 +57,12 @@ export function loadSession(): AuthSession | null {
 }
 
 export function clearSession(): void {
-  if (existsSync(AUTH_PATH)) {
-    writeFileSync(AUTH_PATH, '');
+  try {
+    if (existsSync(AUTH_PATH)) {
+      unlinkSync(AUTH_PATH);
+    }
+  } catch {
+    // File already removed or inaccessible
   }
 }
 


### PR DESCRIPTION
## Summary
- Set `mode: 0o700` on `~/.squads-cli` directory creation (owner rwx only)
- Set `mode: 0o600` on `auth.json` writes (owner rw only, prevents other users from reading the access token)
- Replace `writeFileSync(path, '')` with `unlinkSync(path)` in `clearSession()` to fully remove the credential file on logout

## Changes
- `src/lib/auth.ts`: Added `unlinkSync` import, restrictive file/directory permissions, and proper file deletion

## Test plan
- [ ] `grep -n "mode: 0o600" src/lib/auth.ts` returns >= 1
- [ ] `grep -n "mode: 0o700" src/lib/auth.ts` returns >= 1
- [ ] `grep -n "unlinkSync" src/lib/auth.ts` returns >= 1
- [ ] After `squads login`, `stat -f '%Lp' ~/.squads-cli/auth.json` returns `600`
- [ ] After `squads logout`, `~/.squads-cli/auth.json` no longer exists

Closes #322

---
Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |