### PR TITLE
fix(lint): remove all unused imports/vars, replace require() with ESM import

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,17 +115,6 @@ await autoUpdateOnStartup();
 // Register telemetry exit handler early
 registerExitHandler();
 
-// Helper: output JSON envelope for --json flag
-function jsonOutput(command: string, data: unknown, meta?: Record<string, unknown>): void {
-  console.log(JSON.stringify({
-    ok: true,
-    command,
-    data,
-    error: null,
-    meta: { duration_ms: 0, connected: !!process.env.SQUADS_BRIDGE_URL, ...meta },
-  }));
-}
-
 // Helper: show removed command message
 function removedCommand(name: string, alternative: string): () => void {
   return () => {

--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -23,7 +23,7 @@ import {
   mkdirSync,
   appendFileSync,
 } from "fs";
-import { join, basename } from "path";
+import { join } from "path";
 import { homedir } from "os";
 import { spawn, execSync } from "child_process";
 import { findSquadsDir, listSquads, Routine } from "../lib/squad-parser.js";
@@ -298,7 +298,7 @@ async function daemonLoop(): Promise<void> {
 
       // 2. Check running agents
       const running = getRunningAgents();
-      const runningCount = running.length;
+      const _runningCount = running.length;
 
       // 3. Timeout enforcement
       for (const agent of running) {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -4,8 +4,6 @@ import {
   listSquads,
   SquadContext,
   resolveExecutionContext,
-  getSquadLocalSkills,
-  ResolvedSkill,
 } from '../lib/squad-parser.js';
 import { track, Events } from '../lib/telemetry.js';
 import {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -10,8 +10,8 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { join, relative } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
 import {
   findSquadsDir,
   listSquads,
@@ -396,7 +396,6 @@ function buildManifest(squadsDir: string, filterSquad?: string): DeployManifest 
   // Try to get git SHA
   let gitSha: string | undefined;
   try {
-    const { execSync } = require('child_process');
     gitSha = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
   } catch {
     // Not in a git repo

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -21,7 +21,6 @@ import {
   findSquadsDir,
   loadSquad,
   listAgents,
-  Agent,
 } from '../lib/squad-parser.js';
 import { findMemoryDir } from '../lib/memory.js';
 import { track } from '../lib/telemetry.js';

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -11,17 +11,12 @@ import { findMemoryDir, getSquadState } from '../lib/memory.js';
 import {
   getLiveSessionSummaryAsync,
   cleanupStaleSessions,
-  detectAIProcessesFast,
-  enrichProcessesWithSquad,
-  AIProcess,
-  getRecentSessions,
 } from '../lib/sessions.js';
 import {
   listExecutions,
   getExecutionStats,
   formatDuration,
   formatRelativeTime,
-  Execution,
 } from '../lib/executions.js';
 import { checkForUpdate } from '../lib/update.js';
 import { track, Events } from '../lib/telemetry.js';


### PR DESCRIPTION
## Summary

- Remove 15 ESLint `@typescript-eslint/no-unused-vars` warnings across 6 files (cli.ts, autonomous.ts, context.ts, deploy.ts, eval.ts, status.ts)
- Replace `require('child_process')` in deploy.ts with a top-level ESM `import { execSync } from 'child_process'` for consistency with the rest of the codebase
- ESLint now reports 0 warnings, TypeScript compiles cleanly

Closes #307, #310, #312

## Test plan

- [x] `npx eslint src/` returns 0 warnings
- [x] `npx tsc --noEmit` compiles without errors
- [ ] `npx vitest run` passes (CI will verify)

🤖 Generated with [Agents Squads](https://agents-squads.com)