### PR TITLE
fix(test): make otel-collector infra test optional

### DIFF
--- a/test/infra.test.ts
+++ b/test/infra.test.ts
@@ -1,7 +1,8 @@
 /**
  * Infrastructure Integration Tests
  *
- * Tests the local stack: postgres, redis, bridge, otel
+ * Tests the local stack: postgres, redis, bridge
+ * Optional: otel-collector (not in standard docker-compose)
  * Run with: npm test -- --grep "infra"
  *
  * Prerequisites:
@@ -16,12 +17,11 @@ import * as net from 'net';
 
 const TIMEOUT = 10000;
 
-// Required infrastructure services
+// Required infrastructure services (included in docker-compose)
 const SERVICES = {
   postgres: { port: 5433, type: 'tcp' },
   redis: { port: 6379, type: 'tcp' },
   bridge: { port: 8088, type: 'http', url: 'http://localhost:8088/health' },
-  otel: { port: 4318, type: 'tcp' },
 };
 
 /**
@@ -184,8 +184,12 @@ describeInfra('infra', () => {
   });
 
   describe('telemetry pipeline', () => {
-    it('otel-collector accepts spans on 4318', async () => {
+    it('otel-collector accepts spans on 4318 (optional)', async () => {
       const open = await isPortOpen(4318);
+      if (!open) {
+        console.info('otel-collector not running, skipping');
+        return;
+      }
       expect(open).toBe(true);
     }, TIMEOUT);
 


### PR DESCRIPTION
## Summary

- Removed `otel` from required SERVICES constant (not in standard docker-compose)
- Made otel-collector test skip gracefully when port 4318 is unavailable
- Updated file header comment to reflect otel is optional

## Changes

- `test/infra.test.ts`: otel-collector test now returns early with info log instead of failing

## Testing

- [x] otel test passes when collector is running
- [x] otel test skips gracefully when collector is not running
- [x] All other infra tests unaffected

Closes #337

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |
| Target | main |