### PR TITLE
fix(ux): consistent exit code 0 when parent commands show help text

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,7 +313,8 @@ registerOrchestrateCommand(program);
 // Env command - squad execution environment (MCP, skills, budget, model)
 const env = program
   .command('env')
-  .description('View squad execution environment (MCP, skills, model, budget)');
+  .description('View squad execution environment (MCP, skills, model, budget)')
+  .action(() => { env.outputHelp(); });
 
 env
   .command('show <squad>')
@@ -514,7 +515,8 @@ Examples:
   $ squads kpi record engineering leads_generated 15
   $ squads kpi trend engineering leads_generated
   $ squads kpi insights                   Show insights across all squads
-`);
+`)
+  .action(() => { kpi.outputHelp(); });
 
 kpi
   .command('list')
@@ -569,7 +571,8 @@ progress
 // Feedback command group
 const feedback = program
   .command('feedback')
-  .description('Record and view execution feedback');
+  .description('Record and view execution feedback')
+  .action(() => { feedback.outputHelp(); });
 
 feedback
   .command('add <squad> <rating> <feedback>')
@@ -791,7 +794,8 @@ sessions
 // Session command group - lifecycle management
 const session = program
   .command('session')
-  .description('Manage current session lifecycle');
+  .description('Manage current session lifecycle')
+  .action(() => { session.outputHelp(); });
 
 session
   .command('start')

--- a/src/commands/approval.ts
+++ b/src/commands/approval.ts
@@ -288,7 +288,8 @@ async function cancelApproval(approvalId: string): Promise<void> {
 export function registerApprovalCommand(program: Command): void {
   const approval = program
     .command("approval")
-    .description("Manage approval requests for agent actions");
+    .description("Manage approval requests for agent actions")
+    .action(() => { approval.outputHelp(); });
 
   approval
     .command("send <type>")

--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -627,7 +627,8 @@ export function registerAutonomousCommand(program: Command): void {
   const autonomous = program
     .command("autonomous")
     .alias("auto")
-    .description("Local scheduling daemon for autonomous agent execution");
+    .description("Local scheduling daemon for autonomous agent execution")
+    .action(() => { autonomous.outputHelp(); });
 
   autonomous
     .command("start")

--- a/src/commands/trigger.ts
+++ b/src/commands/trigger.ts
@@ -228,7 +228,8 @@ async function showStatus(): Promise<void> {
 export function registerTriggerCommand(program: Command): void {
   const trigger = program
     .command("trigger")
-    .description("Manage smart triggers");
+    .description("Manage smart triggers")
+    .action(() => { trigger.outputHelp(); });
 
   trigger
     .command("list [squad]")


### PR DESCRIPTION
## Summary

- Added default `.action(() => cmd.outputHelp())` to 7 parent commands that were exiting 1 when showing help text
- All parent commands now consistently exit 0 when invoked without a subcommand

## Changes

- `src/cli.ts`: Fixed `env`, `kpi`, `feedback`, `session`
- `src/commands/trigger.ts`: Fixed `trigger`
- `src/commands/approval.ts`: Fixed `approval`
- `src/commands/autonomous.ts`: Fixed `autonomous`

## Testing

- [x] TypeScript compiles cleanly
- [x] Pattern matches existing working commands (memory, goal, deploy, exec)
- [ ] Manual: `squads trigger` exits 0
- [ ] Manual: `squads approval` exits 0
- [ ] Manual: `squads session` exits 0

Closes #319

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |
| Target | main |