### PR TITLE
fix(security): remove hardcoded telemetry API key

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -22,13 +22,14 @@ const EVENTS_PATH = join(TELEMETRY_DIR, 'events.json');
 
 // Telemetry endpoint - locked to Agents Squads infrastructure
 // Users can opt-out but cannot redirect telemetry
-const TELEMETRY_ENDPOINT = Buffer.from(
+const TELEMETRY_ENDPOINT = process.env.SQUADS_TELEMETRY_ENDPOINT || Buffer.from(
   'aHR0cHM6Ly9zcXVhZHMtdGVsZW1ldHJ5LTk3ODg3MTgxNzYxMC51cy1jZW50cmFsMS5ydW4uYXBwL3Bpbmc=',
   'base64'
 ).toString();
 
-// API key for endpoint validation (obfuscated)
-const TELEMETRY_KEY = Buffer.from('c3FfdGVsX3YxXzdmOGE5YjJjM2Q0ZTVmNmE=', 'base64').toString();
+// API key for endpoint validation — must be set via environment variable
+// NEVER hardcode API keys in source (see: engineering#51)
+const TELEMETRY_KEY = process.env.SQUADS_TELEMETRY_KEY || '';
 
 // Event queue for batch flushing
 let eventQueue: TelemetryEvent[] = [];
@@ -210,7 +211,7 @@ export async function track(event: string, properties?: Record<string, string | 
  * Flush queued events to the telemetry endpoint
  */
 export async function flushEvents(): Promise<void> {
-  if (!TELEMETRY_ENDPOINT || eventQueue.length === 0) {
+  if (!TELEMETRY_ENDPOINT || !TELEMETRY_KEY || eventQueue.length === 0) {
     flushScheduled = false;
     return;
   }


### PR DESCRIPTION
## Summary

Removes the hardcoded (base64-obfuscated) telemetry API key from source code. The key was committed to a public repo's git history and must be rotated server-side.

## Changes

- `src/lib/telemetry.ts`
  - **Removed hardcoded API key** — replaced with `SQUADS_TELEMETRY_KEY` env var
  - **Added env var for endpoint** — `SQUADS_TELEMETRY_ENDPOINT` (with existing URL as fallback)
  - **Skip telemetry send** when key is not set (graceful no-op)

## Remaining Action Required

The exposed key must be **rotated server-side** (key value removed from this description 2026-07-09; tracked internally). The new key is set via:
- `SQUADS_TELEMETRY_KEY` env var on internal deployments
- Not committed to source

## Testing

- Build passes
- Telemetry no-ops cleanly when the env var is unset