### PR TITLE
feat(ux): add dashboard discoverability hints after run and status

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1178,6 +1178,7 @@ async function runSquad(
     writeLine(`  ${icons.success} All ${agentFiles.length} agents launched`);
     writeLine(`  ${colors.dim}Monitor: tmux ls | grep squads-${squad.name}${RESET}`);
     writeLine(`  ${colors.dim}Attach:  tmux attach -t <session>${RESET}`);
+    writeLine(`  ${colors.dim}Metrics: squads dash${RESET}`);
     writeLine();
     return;
   }
@@ -1385,6 +1386,7 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
     if (isForeground || isWatch) {
       writeLine();
       writeLine(`  ${icons.success} Lead session completed`);
+      writeLine(`  ${colors.dim}View metrics:${RESET} squads dash`);
     } else {
       writeLine(`  ${icons.success} Lead session launched in background`);
       writeLine(`  ${colors.dim}${result}${RESET}`);
@@ -1394,7 +1396,8 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
       writeLine(`  ${colors.dim}  2. Spawn Task agents for parallel execution${RESET}`);
       writeLine(`  ${colors.dim}  3. Coordinate and report results${RESET}`);
       writeLine();
-      writeLine(`  ${colors.dim}Monitor: squads workers${RESET}`);
+      writeLine(`  ${colors.dim}Monitor:${RESET} squads workers`);
+      writeLine(`  ${colors.dim}Metrics:${RESET} squads dash`);
     }
   } catch (error) {
     writeLine(`  ${icons.error} ${colors.red}Failed to launch: ${error}${RESET}`);
@@ -1719,12 +1722,14 @@ CRITICAL: When you have completed your tasks OR reached the time limit:
 
         if (isForeground || isWatch) {
           spinner.succeed(`Agent ${agentName} completed (${cliName})`);
+          writeLine(`  ${colors.dim}View metrics:${RESET} squads dash`);
         } else {
           spinner.succeed(`Agent ${agentName} launched in background (${cliName})`);
           writeLine(`  ${colors.dim}${result}${RESET}`);
           writeLine();
           writeLine(`  ${colors.dim}Monitor:${RESET} squads workers`);
           writeLine(`  ${colors.dim}Memory:${RESET}  squads memory show ${squadName}`);
+          writeLine(`  ${colors.dim}Metrics:${RESET} squads dash`);
         }
         break; // Success — exit retry loop
       } catch (error) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -420,6 +420,7 @@ async function showSquadStatus(
 
   writeLine();
   writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squadName}${RESET}           ${colors.dim}Run the squad${RESET}`);
+  writeLine(`  ${colors.dim}$${RESET} squads dash                    ${colors.dim}ROI metrics & cost projections${RESET}`);
   writeLine(`  ${colors.dim}$${RESET} squads memory show ${colors.cyan}${squadName}${RESET}   ${colors.dim}View full memory${RESET}`);
   writeLine(`  ${colors.dim}$${RESET} squads status ${colors.cyan}${squadName}${RESET} -v     ${colors.dim}Verbose status${RESET}`);
   writeLine();


### PR DESCRIPTION
## Summary

- Adds `squads dash` hints at every successful execution touchpoint in `run.ts`
- Adds `squads dash` to squad detail commands in `status.ts`
- Addresses the 63x usage gap between `squads status` (1,337/week) and `squads dash` (21/week)

## Changes

- `src/commands/run.ts` — 4 hint additions: after foreground completion, background launch, lead session, and parallel launch
- `src/commands/status.ts` — 1 hint addition: squad detail commands section

## Testing

- [x] Build passes (`npm run build`)
- [x] All 751 tests pass (`npm test`)
- [x] Changes are minimal — only `writeLine` additions, no logic changes

Closes #297

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Trigger | manual |
| Model | claude-opus-4-6 |
| Target | main |