### PR TITLE
fix: daemon process exits immediately due to undeclared --daemon flag

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -23,6 +23,7 @@ import {
   readdirSync,
   mkdirSync,
   appendFileSync,
+  openSync,
 } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -442,8 +443,8 @@ async function startScheduler(): Promise<void> {
     return;
   }
 
-  // Check if we're being invoked as the daemon itself (--daemon flag)
-  if (process.argv.includes("--daemon")) {
+  // Check if we're being invoked as the daemon itself (via env var)
+  if (process.env.SQUADS_DAEMON === "1") {
     // We ARE the daemon — run the loop
     writeFileSync(PID_FILE, process.pid.toString());
     await daemonLoop();
@@ -454,26 +455,36 @@ async function startScheduler(): Promise<void> {
   }
 
   // Spawn a detached daemon process
+  // Use SQUADS_DAEMON env var instead of --daemon CLI flag to avoid
+  // Commander.js rejecting the unknown option and silently exiting
+
+  // Redirect child stdout/stderr to daemon log for diagnosability
+  if (!existsSync(DAEMON_LOG)) {
+    writeFileSync(DAEMON_LOG, "");
+  }
+  const logFd = openSync(DAEMON_LOG, "a");
+
   const child = spawn(
     process.execPath, // node
-    [process.argv[1], "autonomous", "start", "--daemon"],
+    [process.argv[1], "autonomous", "start"],
     {
       cwd: process.cwd(),
       detached: true,
-      stdio: "ignore",
-      env: { ...process.env },
+      stdio: ["ignore", logFd, logFd],
+      env: { ...process.env, SQUADS_DAEMON: "1" },
     }
   );
   child.unref();
 
-  // Wait briefly for PID file to appear
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  // Wait for PID file to appear (2s for slower systems)
+  await new Promise((resolve) => setTimeout(resolve, 2000));
 
   const check = isRunning();
   if (check.running) {
     writeLine(chalk.green(`\n  Daemon started (PID ${check.pid})`));
   } else {
-    writeLine(chalk.green("\n  Daemon starting..."));
+    writeLine(chalk.red("\n  Daemon failed to start. Check log:"));
+    writeLine(chalk.gray(`  $ tail -20 ${DAEMON_LOG}`));
   }
 
   writeLine(chalk.gray(`  Log: ${DAEMON_LOG}`));


### PR DESCRIPTION
## Summary

`squads autonomous start` spawns a child process with `--daemon` as a CLI flag, but the `start` subcommand never declares this option. Commander.js rejects unknown options by default, so the child process exits immediately before writing a PID file or starting the daemon loop.

## Changes

- `src/commands/autonomous.ts`:
  - Replace `--daemon` CLI flag with `SQUADS_DAEMON=1` environment variable to bypass Commander.js option parsing
  - Redirect child process stdout/stderr to daemon log file for diagnosability
  - Show clear error message when daemon fails to start instead of optimistic "Daemon starting..."
  - Increase startup wait from 1s to 2s for more reliable PID file detection

## Testing

- [x] All 18 autonomous tests pass
- [x] TypeScript typecheck passes
- [x] No new test failures (2 pre-existing on develop: deploy.test.ts, eval.test.ts)

Closes #343

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Trigger | manual |
| Model | claude-opus-4-6 |
| Target | develop |