### PR TITLE
fix: autonomous start daemon now persists as background process

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -22,6 +22,7 @@ import {
   readdirSync,
   mkdirSync,
   appendFileSync,
+  openSync,
 } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -441,8 +442,10 @@ async function startScheduler(): Promise<void> {
     return;
   }
 
-  // Check if we're being invoked as the daemon itself (--daemon flag)
-  if (process.argv.includes("--daemon")) {
+  // Check if we're being invoked as the daemon itself (via env var).
+  // Using an env var instead of a --daemon CLI flag avoids Commander.js
+  // rejecting the unknown option and silently killing the child process.
+  if (process.env.SQUADS_DAEMON === "1") {
     // We ARE the daemon — run the loop
     writeFileSync(PID_FILE, process.pid.toString());
     await daemonLoop();
@@ -453,26 +456,33 @@ async function startScheduler(): Promise<void> {
   }
 
   // Spawn a detached daemon process
+  // Redirect child stdout/stderr to daemon log for diagnosability
+  if (!existsSync(DAEMON_LOG)) {
+    writeFileSync(DAEMON_LOG, "");
+  }
+  const logFd = openSync(DAEMON_LOG, "a");
+
   const child = spawn(
     process.execPath, // node
-    [process.argv[1], "autonomous", "start", "--daemon"],
+    [process.argv[1], "autonomous", "start"],
     {
       cwd: process.cwd(),
       detached: true,
-      stdio: "ignore",
-      env: { ...process.env },
+      stdio: ["ignore", logFd, logFd],
+      env: { ...process.env, SQUADS_DAEMON: "1" },
     }
   );
   child.unref();
 
-  // Wait briefly for PID file to appear
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  // Wait for PID file to appear (2s for slower systems)
+  await new Promise((resolve) => setTimeout(resolve, 2000));
 
   const check = isRunning();
   if (check.running) {
     console.log(chalk.green(`\n  Daemon started (PID ${check.pid})`));
   } else {
-    console.log(chalk.green("\n  Daemon starting..."));
+    console.log(chalk.red("\n  Daemon failed to start. Check log:"));
+    console.log(chalk.gray(`  $ tail -20 ${DAEMON_LOG}`));
   }
 
   console.log(chalk.gray(`  Log: ${DAEMON_LOG}`));


### PR DESCRIPTION
## Summary

Fixes the `squads autonomous start` command which was silently failing to persist a daemon process.

**Root cause**: The spawned child process received `--daemon` as a CLI flag, but Commander.js doesn't know about this option and rejects it with "error: unknown option '--daemon'". Since `stdio: "ignore"` was set, this error was swallowed — no PID file, no log, no daemon.

**Fix**: Replace the `--daemon` CLI flag with a `SQUADS_DAEMON=1` environment variable to signal daemon mode, avoiding Commander.js argument parsing entirely.

## Changes

- `src/commands/autonomous.ts`: Use `SQUADS_DAEMON` env var instead of `--daemon` CLI flag
- Redirect child stdout/stderr to daemon log file for error visibility
- Increase PID wait from 1s to 2s for slower systems
- Show clear error message when daemon fails to start (instead of misleading "Daemon starting...")

## Testing

- [x] Build passes (`npm run build`)
- [x] Existing tests pass (749/766, 2 pre-existing failures unrelated to this change)
- [ ] Manual: `squads autonomous start` should write PID file and persist
- [ ] Manual: `squads autonomous status` should show "Daemon running"
- [ ] Manual: `squads autonomous stop` should terminate the daemon

Closes #343

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |