### PR TITLE
fix: Gemini provider fails due to worktree sandboxing and missing headless flags

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import { spawn, execSync } from 'child_process';
 import { join, dirname } from 'path';
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, cpSync } from 'fs';
 import {
   findSquadsDir,
   loadSquad,
@@ -2224,7 +2224,6 @@ async function executeWithProvider(
   }
 
   const projectRoot = options.cwd || getProjectRoot();
-  const args = cliConfig.buildArgs(prompt);
   const squadName = options.squadName || 'unknown';
   const agentName = options.agentName || 'unknown';
   const timestamp = Date.now();
@@ -2249,6 +2248,26 @@ async function executeWithProvider(
   } catch {
     // Worktree creation failed — fall back to project root
   }
+
+  // Copy .agents directory into worktree so sandboxed providers can access
+  // agent definitions, memory, and config files. Providers like Gemini restrict
+  // file reads to the workspace directory, so these must be local.
+  let effectivePrompt = prompt;
+  if (workDir !== projectRoot) {
+    const agentsDir = join(projectRoot, '.agents');
+    const targetAgentsDir = join(workDir, '.agents');
+    if (existsSync(agentsDir) && !existsSync(targetAgentsDir)) {
+      try {
+        cpSync(agentsDir, targetAgentsDir, { recursive: true });
+      } catch {
+        // Non-fatal: agent def may still be accessible if tracked in git
+      }
+    }
+    // Rewrite absolute paths in prompt so sandboxed providers can resolve them
+    effectivePrompt = prompt.replaceAll(projectRoot, workDir);
+  }
+
+  const args = cliConfig.buildArgs(effectivePrompt);
 
   if (options.verbose) {
     writeLine(`  ${colors.dim}Provider: ${cliConfig.displayName}${RESET}`);
@@ -2291,7 +2310,7 @@ async function executeWithProvider(
     mkdirSync(logDir, { recursive: true });
   }
 
-  const escapedPrompt = prompt.replace(/'/g, "'\\''");
+  const escapedPrompt = effectivePrompt.replace(/'/g, "'\\''");
   const providerArgs = cliConfig.buildArgs(escapedPrompt).map(a => `'${a}'`).join(' ');
   const shellScript = `cd '${workDir}' && ${cliConfig.command} ${providerArgs} > '${logFile}' 2>&1`;
   const wrapperScript = `echo $$ > '${pidFile}'; ${shellScript}`;

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -67,7 +67,7 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     displayName: 'Google',
     command: 'gemini',
     install: 'npm i -g @google/gemini-cli',
-    buildArgs: (prompt) => ['--prompt', prompt],
+    buildArgs: (prompt) => ['--yolo', '--prompt', prompt],
   },
 
   openai: {


### PR DESCRIPTION
## Summary

Fixes two issues blocking Google/Gemini provider execution:

1. **Headless auto-approval (`--yolo`)**: Gemini CLI requires interactive confirmation for tool calls. When spawned in background/headless mode by squads-cli, it denies all tool execution with "Tool execution denied by policy". Added `--yolo` flag to auto-approve tool calls.

2. **Worktree file access**: Gemini CLI sandboxes file reads to its workspace directory. The prompt references agent definition files at the original project root, which Gemini blocks as "Path not in workspace". Now we:
   - Copy the `.agents` directory into the worktree after creation
   - Rewrite absolute paths in the prompt from project root to worktree path

## Changes
- `src/lib/llm-clis.ts`: Add `--yolo` flag to Google/Gemini `buildArgs`
- `src/commands/run.ts`: In `executeWithProvider`, copy `.agents` to worktree and rewrite prompt paths before building CLI args

## Testing
- [x] TypeScript compiles (`npm run build` passes)
- [x] 749 tests pass, 0 new failures (2 pre-existing failures in eval.test.ts)
- [ ] Manual: `squads run <squad> --provider google --execute` with Gemini CLI installed

Closes #371

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |
| Target | develop |