### PR TITLE
feat: add squads create command for local squad creation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,6 +92,10 @@ function removedCommand(name: string, alternative: string): () => void {
 // Maps command paths to user-friendly hints when required arguments are missing.
 // Each entry: { message: plain-language explanation, example: usage example }
 const friendlyArgErrors: Record<string, { message: string; example: string }> = {
+  'create': {
+    message: 'Specify a name for the new squad.',
+    example: 'squads create marketing             # create with interactive prompts\n  squads create marketing -d "Drive growth" -y  # non-interactive',
+  },
   'run': {
     message: 'Specify which squad or agent to run.',
     example: 'squads run engineering            # run the whole squad\n  squads run engineering/code-review  # run a specific agent',
@@ -229,6 +233,26 @@ program
   .action(async (...args) => {
     const { initCommand } = await import('./commands/init.js');
     return initCommand(...args);
+  });
+
+// Create command - add a new squad to your workforce
+program
+  .command('create <name>')
+  .description('Create a new squad with directory structure and starter files')
+  .option('-d, --description <text>', 'Squad mission (one sentence)')
+  .option('-g, --goal <text>', 'First goal for the squad')
+  .option('-m, --model <model>', 'Default model (default: sonnet)')
+  .option('-f, --force', 'Overwrite existing squad')
+  .option('-y, --yes', 'Accept all defaults (non-interactive)')
+  .addHelpText('after', `
+Examples:
+  $ squads create marketing                          Create with interactive prompts
+  $ squads create marketing -d "Drive growth" -y     Create non-interactively
+  $ squads create marketing --force                  Overwrite existing squad
+`)
+  .action(async (...args) => {
+    const { createCommand } = await import('./commands/create.js');
+    return createCommand(...args);
   });
 
 // Run command - execute squads or individual agents

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -1,0 +1,148 @@
+/**
+ * squads create <name> — Create a new squad with directory structure and starter files.
+ *
+ * Creates:
+ *   .agents/squads/<name>/SQUAD.md
+ *   .agents/squads/<name>/lead.md
+ *   .agents/memory/<name>/lead/  (empty, ready for state)
+ *
+ * Squad discovery is filesystem-based (squad-parser.ts), so creating the
+ * directory + SQUAD.md is all that's needed for `squads list` to find it.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import chalk from 'chalk';
+import { findSquadsDir, findProjectRoot, listSquads } from '../lib/squad-parser.js';
+import { loadTemplate, toKebabCase, toTitleCase, type TemplateVariables } from '../lib/templates.js';
+import { track } from '../lib/telemetry.js';
+
+interface CreateOptions {
+  description?: string;
+  goal?: string;
+  model?: string;
+  force?: boolean;
+  yes?: boolean;
+}
+
+export async function createCommand(name: string, options: CreateOptions): Promise<void> {
+  const squadId = toKebabCase(name);
+  const squadName = toTitleCase(squadId);
+
+  if (!squadId) {
+    console.error(chalk.red('\n  Invalid squad name. Use letters, numbers, and hyphens.\n'));
+    process.exit(1);
+  }
+
+  // Find project root (where .agents/ lives)
+  const projectRoot = findProjectRoot();
+  if (!projectRoot) {
+    console.error(chalk.red('\n  Not in a squads project. Run `squads init` first.\n'));
+    process.exit(1);
+  }
+
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) {
+    console.error(chalk.red('\n  No .agents/squads directory found. Run `squads init` first.\n'));
+    process.exit(1);
+  }
+
+  // Check if squad already exists
+  const squadDir = join(squadsDir, squadId);
+  if (existsSync(join(squadDir, 'SQUAD.md')) && !options.force) {
+    console.error(chalk.red(`\n  Squad "${squadId}" already exists. Use --force to overwrite.\n`));
+    process.exit(1);
+  }
+
+  // Collect description and goal — prompt interactively if not provided via flags
+  let description = options.description;
+  let goal = options.goal;
+
+  if (!options.yes && (!description || !goal)) {
+    const inquirer = await import('inquirer');
+
+    if (!description) {
+      const answer = await inquirer.default.prompt([{
+        type: 'input',
+        name: 'description',
+        message: 'Squad mission (one sentence):',
+        default: `The ${squadName} squad handles ${squadId}-related tasks.`,
+      }]);
+      description = answer.description;
+    }
+
+    if (!goal) {
+      const answer = await inquirer.default.prompt([{
+        type: 'input',
+        name: 'goal',
+        message: 'First goal:',
+        default: `Define ${squadId} squad objectives and deliver first results`,
+      }]);
+      goal = answer.goal;
+    }
+  }
+
+  // Defaults for non-interactive mode
+  description = description || `The ${squadName} squad handles ${squadId}-related tasks.`;
+  goal = goal || `Define ${squadId} squad objectives and deliver first results`;
+  const model = options.model || 'sonnet';
+
+  // Template variables
+  const vars: TemplateVariables = {
+    SQUAD_NAME: squadName,
+    SQUAD_ID: squadId,
+    SQUAD_DESCRIPTION: description,
+    GOAL: goal,
+  };
+
+  // 1. Create squad directory
+  mkdirSync(squadDir, { recursive: true });
+
+  // 2. Create SQUAD.md from template
+  let squadContent: string;
+  try {
+    squadContent = loadTemplate('first-squad/SQUAD.md.template', vars);
+  } catch {
+    // Fallback if template not found
+    squadContent = `# ${squadName}\n\n${description}\n\n## Goals\n\n- [ ] ${goal}\n\n## Agents\n\n| Agent | Purpose |\n|-------|--------|\n| lead | Orchestrates the squad and coordinates work |\n\n## Pipeline\n\n\`lead\` (orchestrates all work)\n\n## Usage\n\n\`\`\`bash\nsquads run ${squadId} --execute\n\`\`\`\n`;
+  }
+  writeFileSync(join(squadDir, 'SQUAD.md'), squadContent);
+
+  // 3. Create lead agent from template
+  let leadContent: string;
+  try {
+    leadContent = loadTemplate('first-squad/lead.md.template', vars);
+  } catch {
+    // Fallback if template not found
+    leadContent = `# Lead Agent\n\n## Purpose\nOrchestrate the ${squadName} squad to achieve its goals.\n\n## Model\n${model}\n\n## Tools\n- Read\n- Write\n- Edit\n- Bash\n- WebSearch\n- WebFetch\n- Task\n\n## Instructions\n\nYou are the lead agent for the ${squadName} squad.\n\n**Goal**: ${goal}\n\n### Approach\n\n1. **Understand the goal** - Break down what needs to be accomplished\n2. **Plan the work** - Create a clear execution plan\n3. **Execute** - Work through the plan step by step\n4. **Verify** - Confirm the goal is achieved\n5. **Document** - Update memory with learnings\n\n## Output\nProgress updates and work artifacts as appropriate.\n\n## Labels\n- lead\n- orchestration\n`;
+  }
+  writeFileSync(join(squadDir, 'lead.md'), leadContent);
+
+  // 4. Create memory directories
+  const memoryDir = join(projectRoot, '.agents', 'memory', squadId, 'lead');
+  mkdirSync(memoryDir, { recursive: true });
+
+  // Track creation event
+  await track('cli.create', {
+    squad: squadId,
+    hasDescription: !!options.description,
+    hasGoal: !!options.goal,
+    force: !!options.force,
+  }).catch(() => {});
+
+  // 5. Show success
+  const existing = listSquads(squadsDir);
+  console.log();
+  console.log(chalk.green('  ✓ Squad created:'), chalk.cyan(squadId));
+  console.log();
+  console.log(chalk.dim('  Files:'));
+  console.log(`    .agents/squads/${squadId}/SQUAD.md`);
+  console.log(`    .agents/squads/${squadId}/lead.md`);
+  console.log(`    .agents/memory/${squadId}/lead/`);
+  console.log();
+  console.log(chalk.dim('  Next steps:'));
+  console.log(`    ${chalk.cyan('$')} squads run ${squadId}              ${chalk.dim('# run the squad')}`);
+  console.log(`    ${chalk.cyan('$')} squads status ${squadId}           ${chalk.dim('# check status')}`);
+  console.log(`    ${chalk.cyan('$')} squads list                       ${chalk.dim(`# ${existing.length} squads total`)}`);
+  console.log();
+}

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('create command', () => {
+  let testDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), 'squads-create-test-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+    // Create .agents/squads to simulate initialized project
+    mkdirSync(join(testDir, '.agents', 'squads'), { recursive: true });
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('directory structure creation', () => {
+    it('creates squad directory with SQUAD.md', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('my-squad', { yes: true });
+
+      const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
+      expect(existsSync(squadDir)).toBe(true);
+      expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
+    });
+
+    it('creates lead agent file', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('my-squad', { yes: true });
+
+      const leadFile = join(testDir, '.agents', 'squads', 'my-squad', 'lead.md');
+      expect(existsSync(leadFile)).toBe(true);
+    });
+
+    it('creates memory directory for lead agent', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('my-squad', { yes: true });
+
+      const memoryDir = join(testDir, '.agents', 'memory', 'my-squad', 'lead');
+      expect(existsSync(memoryDir)).toBe(true);
+    });
+  });
+
+  describe('SQUAD.md content', () => {
+    it('uses squad name in title', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('marketing', { yes: true, description: 'Drive growth' });
+
+      const content = readFileSync(
+        join(testDir, '.agents', 'squads', 'marketing', 'SQUAD.md'),
+        'utf-8'
+      );
+      expect(content).toContain('Marketing');
+    });
+
+    it('includes custom description', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('marketing', { yes: true, description: 'Drive organic growth through content' });
+
+      const content = readFileSync(
+        join(testDir, '.agents', 'squads', 'marketing', 'SQUAD.md'),
+        'utf-8'
+      );
+      expect(content).toContain('Drive organic growth through content');
+    });
+
+    it('includes custom goal', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('marketing', { yes: true, goal: 'Publish 10 blog posts' });
+
+      const content = readFileSync(
+        join(testDir, '.agents', 'squads', 'marketing', 'SQUAD.md'),
+        'utf-8'
+      );
+      expect(content).toContain('Publish 10 blog posts');
+    });
+  });
+
+  describe('name handling', () => {
+    it('converts names to kebab-case', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('My Cool Squad', { yes: true });
+
+      expect(existsSync(join(testDir, '.agents', 'squads', 'my-cool-squad', 'SQUAD.md'))).toBe(true);
+    });
+
+    it('rejects empty names', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+      try {
+        await createCommand('!!!', { yes: true });
+      } catch {
+        // Expected
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+  });
+
+  describe('overwrite protection', () => {
+    it('refuses to overwrite existing squad without --force', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      // Create squad first
+      await createCommand('existing', { yes: true });
+
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('exit'); });
+
+      try {
+        await createCommand('existing', { yes: true });
+      } catch {
+        // Expected
+      }
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('overwrites existing squad with --force', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('existing', { yes: true, description: 'Original' });
+      await createCommand('existing', { yes: true, force: true, description: 'Updated' });
+
+      const content = readFileSync(
+        join(testDir, '.agents', 'squads', 'existing', 'SQUAD.md'),
+        'utf-8'
+      );
+      expect(content).toContain('Updated');
+    });
+  });
+
+  describe('squad discoverability', () => {
+    it('new squad appears in listSquads', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      const { listSquads } = await import('../../src/lib/squad-parser.js');
+
+      await createCommand('new-squad', { yes: true });
+
+      const squadsDir = join(testDir, '.agents', 'squads');
+      const squads = listSquads(squadsDir);
+      expect(squads).toContain('new-squad');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `squads create <name>` command that creates a new squad with directory structure and starter files:
- `.agents/squads/<name>/SQUAD.md` — squad definition from template
- `.agents/squads/<name>/lead.md` — starter lead agent
- `.agents/memory/<name>/lead/` — memory directory for state

Supports interactive prompts (inquirer) and non-interactive mode (`-y` / `--yes`).

## Changes
- `src/commands/create.ts` — new command handler
- `src/cli.ts` — register `create` command + friendly error hint
- `test/commands/create.test.ts` — 11 unit tests

## Usage
```bash
squads create marketing                          # interactive prompts
squads create marketing -d "Drive growth" -y     # non-interactive
squads create marketing --force                  # overwrite existing
```

## Design Decisions
- **No organization.yaml**: Squads are discovered dynamically via filesystem (`findSquadsDir` + `listSquads`), so creating the directory + SQUAD.md is sufficient
- **Template-first with fallback**: Uses `loadTemplate()` from templates.ts with inline fallback if templates aren't found
- **Lazy-loaded**: Uses dynamic `import()` in cli.ts action handler (consistent with other commands, saves ~300ms cold start)

## Testing
- [x] 11 unit tests pass (directory creation, content, naming, overwrite protection, discoverability)
- [x] Build passes (`npm run build`)
- [x] Full test suite: 760 passed, 2 pre-existing failures in eval.test.ts (unrelated)

Closes #280

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Trigger | manual |
| Model | claude-opus-4-6 |
| Target | develop |