### PR TITLE
test(dashboard): add unit tests — 92% coverage on engine, renderers, loader, sources

### DIFF
--- a/test/dashboard-engine.test.ts
+++ b/test/dashboard-engine.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the loader module
+vi.mock('../src/lib/dashboard/loader.js', () => ({
+  findDashboard: vi.fn(),
+  listDashboards: vi.fn(),
+  loadDashboard: vi.fn(),
+}));
+
+// Mock the postgres source
+vi.mock('../src/lib/dashboard/sources/postgres.js', () => ({
+  postgresSource: {
+    name: 'postgres',
+    query: vi.fn(),
+    isAvailable: vi.fn(),
+    close: vi.fn(),
+  },
+  buildQuery: vi.fn(() => 'SELECT 1'),
+  buildWhereClause: vi.fn(() => null),
+  parseDateRange: vi.fn(() => ({ start: new Date(), end: new Date() })),
+}));
+
+// Mock terminal output to avoid polluting test output
+vi.mock('../src/lib/terminal.js', () => ({
+  colors: {
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    cyan: '\x1b[36m',
+    purple: '\x1b[35m',
+    dim: '\x1b[2m',
+    blue: '\x1b[34m',
+  },
+  bold: '\x1b[1m',
+  RESET: '\x1b[0m',
+  box: {
+    horizontal: '─',
+    vertical: '│',
+    topLeft: '┌',
+    topRight: '┐',
+    bottomLeft: '└',
+    bottomRight: '┘',
+    teeRight: '├',
+    teeLeft: '┤',
+  },
+  padEnd: (str: string, len: number) => str.padEnd(len),
+  truncate: (str: string, len: number) => str.slice(0, len) + '...',
+  writeLine: vi.fn(),
+  progressBar: vi.fn(() => '[===   ]'),
+  sparkline: vi.fn(() => '▁▂▃▄'),
+  barChart: vi.fn(() => '████'),
+  gradient: vi.fn((text: string) => text),
+}));
+
+import { executeDashboard, renderDashboard, showAvailableDashboards } from '../src/lib/dashboard/engine.js';
+import { findDashboard, listDashboards, loadDashboard } from '../src/lib/dashboard/loader.js';
+import { postgresSource } from '../src/lib/dashboard/sources/postgres.js';
+import { writeLine } from '../src/lib/terminal.js';
+
+// Strip ANSI codes
+function strip(str: string) {
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+const mockDashboardDef = {
+  name: 'test',
+  title: 'Test Dashboard',
+  source: 'postgres' as const,
+  table: 'executions',
+  metrics: [
+    { name: 'total', sql: 'COUNT(*)', format: 'number' as const, label: 'Total' },
+  ],
+  dimensions: [
+    { name: 'squad', sql: 'squad_name', type: 'string' as const },
+  ],
+  filters: [],
+  views: [
+    { id: 'overview', type: 'summary' as const, metrics: ['total'] },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(postgresSource.close).mockResolvedValue(undefined);
+  vi.mocked(postgresSource.query).mockResolvedValue({ rows: [{ total: 42 }], columns: ['total'] });
+  vi.mocked(postgresSource.isAvailable).mockResolvedValue(true);
+});
+
+describe('dashboard engine', () => {
+  describe('executeDashboard', () => {
+    it('returns failure when dashboard not found', async () => {
+      vi.mocked(findDashboard).mockReturnValue(null);
+      const result = await executeDashboard('nonexistent');
+      expect(result.success).toBe(false);
+      expect(strip(result.lines.join('\n'))).toContain('not found');
+    });
+
+    it('returns failure when data source is not supported', async () => {
+      vi.mocked(findDashboard).mockReturnValue({
+        ...mockDashboardDef,
+        source: 'langfuse' as 'postgres',
+      });
+      const result = await executeDashboard('test');
+      expect(result.success).toBe(false);
+      expect(strip(result.lines.join('\n'))).toContain('not available');
+    });
+
+    it('returns failure when postgres is unavailable', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      vi.mocked(postgresSource.isAvailable).mockResolvedValue(false);
+      const result = await executeDashboard('test');
+      expect(result.success).toBe(false);
+      expect(strip(result.lines.join('\n'))).toContain('Cannot connect');
+    });
+
+    it('returns success with rendered lines when dashboard executes', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      const result = await executeDashboard('test');
+      expect(result.success).toBe(true);
+      expect(result.lines.length).toBeGreaterThan(0);
+    });
+
+    it('includes title in output', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      const result = await executeDashboard('test');
+      expect(strip(result.lines.join('\n'))).toContain('Test Dashboard');
+    });
+
+    it('includes description when verbose is true', async () => {
+      vi.mocked(findDashboard).mockReturnValue({
+        ...mockDashboardDef,
+        description: 'Dashboard description here',
+      });
+      const result = await executeDashboard('test', { verbose: true });
+      expect(strip(result.lines.join('\n'))).toContain('Dashboard description here');
+    });
+
+    it('does not include description when verbose is false', async () => {
+      vi.mocked(findDashboard).mockReturnValue({
+        ...mockDashboardDef,
+        description: 'Dashboard description here',
+      });
+      const result = await executeDashboard('test', { verbose: false });
+      expect(strip(result.lines.join('\n'))).not.toContain('Dashboard description here');
+    });
+
+    it('renders only specified views when views option provided', async () => {
+      const defWithMultipleViews = {
+        ...mockDashboardDef,
+        views: [
+          { id: 'view1', type: 'summary' as const, metrics: ['total'] },
+          { id: 'view2', type: 'summary' as const, metrics: ['total'] },
+        ],
+      };
+      vi.mocked(findDashboard).mockReturnValue(defWithMultipleViews);
+      // Render only view1
+      const result = await executeDashboard('test', { views: ['view1'] });
+      expect(result.success).toBe(true);
+      // Query should have been called once (for view1)
+      expect(vi.mocked(postgresSource.query).mock.calls.length).toBe(1);
+    });
+
+    it('applies default date_range filter when not provided', async () => {
+      const { parseDateRange } = await import('../src/lib/dashboard/sources/postgres.js');
+      const defWithFilter = {
+        ...mockDashboardDef,
+        filters: [
+          { name: 'period', type: 'date_range' as const, default: 'last_7d', field: 'created_at' },
+        ],
+      };
+      vi.mocked(findDashboard).mockReturnValue(defWithFilter);
+      await executeDashboard('test');
+      expect(parseDateRange).toHaveBeenCalledWith('last_7d');
+    });
+
+    it('handles view rendering errors gracefully when not verbose', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      vi.mocked(postgresSource.query).mockRejectedValue(new Error('DB error'));
+      const result = await executeDashboard('test');
+      // Should still succeed (errors are silently swallowed when not verbose)
+      expect(result.success).toBe(true);
+    });
+
+    it('includes view error message when verbose and error occurs', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      vi.mocked(postgresSource.query).mockRejectedValue(new Error('DB error'));
+      const result = await executeDashboard('test', { verbose: true });
+      expect(strip(result.lines.join('\n'))).toContain('Error rendering');
+    });
+
+    it('uses custom view source SQL when provided', async () => {
+      const defWithCustomSQL = {
+        ...mockDashboardDef,
+        views: [
+          { id: 'custom', type: 'summary' as const, metrics: ['total'], source: 'SELECT COUNT(*) AS total FROM custom_table' },
+        ],
+      };
+      vi.mocked(findDashboard).mockReturnValue(defWithCustomSQL);
+      await executeDashboard('test');
+      expect(vi.mocked(postgresSource.query)).toHaveBeenCalledWith('SELECT COUNT(*) AS total FROM custom_table');
+    });
+
+    it('throws when no table defined and no view source', async () => {
+      const defNoTable = {
+        ...mockDashboardDef,
+        table: undefined,
+        views: [{ id: 'v1', type: 'summary' as const, metrics: ['total'] }],
+      };
+      vi.mocked(findDashboard).mockReturnValue(defNoTable);
+      // Error is caught per-view, result still succeeds
+      const result = await executeDashboard('test');
+      expect(result.success).toBe(true);
+    });
+
+    it('closes the data source after execution', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      await executeDashboard('test');
+      expect(postgresSource.close).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('renderDashboard', () => {
+    it('writes lines to terminal and returns success', async () => {
+      vi.mocked(findDashboard).mockReturnValue(mockDashboardDef);
+      const success = await renderDashboard('test');
+      expect(success).toBe(true);
+      expect(writeLine).toHaveBeenCalled();
+    });
+
+    it('returns false on failure', async () => {
+      vi.mocked(findDashboard).mockReturnValue(null);
+      const success = await renderDashboard('not-found');
+      expect(success).toBe(false);
+    });
+  });
+
+  describe('showAvailableDashboards', () => {
+    it('shows no dashboards message when none exist', () => {
+      vi.mocked(listDashboards).mockReturnValue([]);
+      showAvailableDashboards();
+      expect(writeLine).toHaveBeenCalled();
+      const calls = vi.mocked(writeLine).mock.calls.map(c => strip(String(c[0] || '')));
+      expect(calls.some(c => c.includes('No dashboards'))).toBe(true);
+    });
+
+    it('lists available dashboards', () => {
+      vi.mocked(listDashboards).mockReturnValue(['costs', 'runs']);
+      vi.mocked(loadDashboard).mockImplementation((name) => ({
+        ...mockDashboardDef,
+        name,
+        title: `${name} dashboard`,
+      }));
+      showAvailableDashboards();
+      const calls = vi.mocked(writeLine).mock.calls.map(c => strip(String(c[0] || '')));
+      expect(calls.some(c => c.includes('costs'))).toBe(true);
+      expect(calls.some(c => c.includes('runs'))).toBe(true);
+    });
+
+    it('shows usage instructions', () => {
+      vi.mocked(listDashboards).mockReturnValue(['costs']);
+      vi.mocked(loadDashboard).mockReturnValue(mockDashboardDef);
+      showAvailableDashboards();
+      const calls = vi.mocked(writeLine).mock.calls.map(c => strip(String(c[0] || '')));
+      expect(calls.some(c => c.includes('squads dash'))).toBe(true);
+    });
+  });
+});

--- a/test/dashboard-loader.test.ts
+++ b/test/dashboard-loader.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// We test loader functions by controlling the filesystem via temp dirs and process.cwd()
+// The loader walks up from cwd to find .agents/dashboards/
+
+let tempDir: string;
+let dashboardsDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'squads-dashboard-test-')));
+  dashboardsDir = join(tempDir, '.agents', 'dashboards');
+  mkdirSync(dashboardsDir, { recursive: true });
+  originalCwd = process.cwd();
+  process.chdir(tempDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+// Helper to write a YAML dashboard file
+function writeDashboard(name: string, content: string) {
+  writeFileSync(join(dashboardsDir, `${name}.yaml`), content);
+}
+
+const VALID_DASHBOARD_YAML = `
+name: test-dash
+title: Test Dashboard
+source: postgres
+table: executions
+metrics:
+  - name: total_runs
+    sql: COUNT(*)
+    format: number
+    label: Total Runs
+dimensions:
+  - name: squad
+    sql: squad_name
+    type: string
+views:
+  - id: overview
+    type: summary
+    metrics: [total_runs]
+`;
+
+describe('dashboard loader', () => {
+  describe('findDashboardsDir', () => {
+    it('finds .agents/dashboards from cwd', async () => {
+      const { findDashboardsDir } = await import('../src/lib/dashboard/loader.js');
+      const found = findDashboardsDir();
+      expect(found).toBe(dashboardsDir);
+    });
+
+    it('returns null when no .agents/dashboards exists', async () => {
+      const { findDashboardsDir } = await import('../src/lib/dashboard/loader.js');
+      // Remove the dashboards dir
+      rmSync(dashboardsDir, { recursive: true });
+      // Re-chdir to a clean temp dir with no .agents/dashboards
+      const emptyDir = mkdtempSync(join(tmpdir(), 'squads-empty-'));
+      process.chdir(emptyDir);
+      const found = findDashboardsDir();
+      expect(found).toBeNull();
+      process.chdir(tempDir);
+      rmSync(emptyDir, { recursive: true });
+    });
+  });
+
+  describe('listDashboards', () => {
+    it('returns empty array when no dashboards exist', async () => {
+      const { listDashboards } = await import('../src/lib/dashboard/loader.js');
+      const names = listDashboards();
+      expect(names).toEqual([]);
+    });
+
+    it('lists yaml files in dashboards dir', async () => {
+      writeDashboard('costs', VALID_DASHBOARD_YAML);
+      writeDashboard('runs', VALID_DASHBOARD_YAML);
+      const { listDashboards } = await import('../src/lib/dashboard/loader.js');
+      const names = listDashboards();
+      expect(names).toContain('costs');
+      expect(names).toContain('runs');
+      expect(names).toHaveLength(2);
+    });
+
+    it('excludes files starting with underscore', async () => {
+      writeDashboard('visible', VALID_DASHBOARD_YAML);
+      writeFileSync(join(dashboardsDir, '_hidden.yaml'), VALID_DASHBOARD_YAML);
+      const { listDashboards } = await import('../src/lib/dashboard/loader.js');
+      const names = listDashboards();
+      expect(names).toContain('visible');
+      expect(names).not.toContain('_hidden');
+    });
+
+    it('excludes non-yaml files', async () => {
+      writeDashboard('valid', VALID_DASHBOARD_YAML);
+      writeFileSync(join(dashboardsDir, 'notes.txt'), 'some text');
+      const { listDashboards } = await import('../src/lib/dashboard/loader.js');
+      const names = listDashboards();
+      expect(names).toContain('valid');
+      expect(names).not.toContain('notes.txt');
+      expect(names).not.toContain('notes');
+    });
+  });
+
+  describe('loadDashboard', () => {
+    it('loads a valid dashboard definition', async () => {
+      writeDashboard('test-dash', VALID_DASHBOARD_YAML);
+      const { loadDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = loadDashboard('test-dash');
+      expect(def).not.toBeNull();
+      expect(def!.name).toBe('test-dash');
+      expect(def!.title).toBe('Test Dashboard');
+      expect(def!.source).toBe('postgres');
+      expect(def!.metrics).toHaveLength(1);
+      expect(def!.views).toHaveLength(1);
+    });
+
+    it('returns null for non-existent dashboard', async () => {
+      const { loadDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = loadDashboard('nonexistent');
+      expect(def).toBeNull();
+    });
+
+    it('returns null for dashboard with missing required fields', async () => {
+      writeDashboard('bad-dash', 'name: incomplete\ntitle: Missing fields');
+      const { loadDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = loadDashboard('bad-dash');
+      expect(def).toBeNull();
+    });
+
+    it('caches dashboards after first load', async () => {
+      writeDashboard('cached', VALID_DASHBOARD_YAML);
+      const { loadDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def1 = loadDashboard('cached');
+      const def2 = loadDashboard('cached');
+      expect(def1).toBe(def2); // Same reference = cached
+    });
+  });
+
+  describe('clearDashboardCache', () => {
+    it('clears cached dashboards so they reload from disk', async () => {
+      writeDashboard('refresh', VALID_DASHBOARD_YAML);
+      const { loadDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def1 = loadDashboard('refresh');
+      clearDashboardCache();
+      const def2 = loadDashboard('refresh');
+      expect(def1).not.toBe(def2); // Different references after cache clear
+      expect(def1?.name).toBe(def2?.name); // But same data
+    });
+  });
+
+  describe('loadAllDashboards', () => {
+    it('returns empty array when no dashboards', async () => {
+      const { loadAllDashboards, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const all = loadAllDashboards();
+      expect(all).toEqual([]);
+    });
+
+    it('loads all valid dashboards', async () => {
+      writeDashboard('dash-a', VALID_DASHBOARD_YAML);
+      writeDashboard('dash-b', VALID_DASHBOARD_YAML.replace('test-dash', 'dash-b').replace('Test Dashboard', 'Dashboard B'));
+      const { loadAllDashboards, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const all = loadAllDashboards();
+      expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('findDashboard', () => {
+    it('finds dashboard by exact name', async () => {
+      writeDashboard('costs', VALID_DASHBOARD_YAML);
+      const { findDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = findDashboard('costs');
+      expect(def).not.toBeNull();
+    });
+
+    it('finds dashboard by partial match', async () => {
+      writeDashboard('agent-costs', VALID_DASHBOARD_YAML);
+      const { findDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = findDashboard('costs');
+      expect(def).not.toBeNull();
+    });
+
+    it('returns null when no match found', async () => {
+      const { findDashboard, clearDashboardCache } = await import('../src/lib/dashboard/loader.js');
+      clearDashboardCache();
+      const def = findDashboard('nonexistent');
+      expect(def).toBeNull();
+    });
+  });
+});

--- a/test/dashboard-renderers.test.ts
+++ b/test/dashboard-renderers.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from 'vitest';
+import { formatValue, getThresholdColor, calculateColumnWidths } from '../src/lib/dashboard/renderers/base.js';
+import { renderView } from '../src/lib/dashboard/renderers/index.js';
+import type { ViewDefinition, MetricDefinition, DimensionDefinition, QueryResult } from '../src/lib/dashboard/types.js';
+
+// Strip ANSI escape codes for cleaner assertions
+function strip(str: string): string {
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+const emptyData: QueryResult = { rows: [], columns: [] };
+
+const metricDefs: MetricDefinition[] = [
+  { name: 'total_runs', sql: 'COUNT(*)', format: 'number', label: 'Total Runs' },
+  { name: 'cost', sql: 'SUM(cost)', format: 'currency', label: 'Total Cost' },
+  { name: 'success_rate', sql: 'AVG(success)', format: 'percent', label: 'Success' },
+  { name: 'duration', sql: 'AVG(dur)', format: 'duration', label: 'Avg Duration' },
+  { name: 'tokens', sql: 'SUM(tokens)', format: 'tokens', label: 'Tokens' },
+];
+
+const dimensionDefs: DimensionDefinition[] = [
+  { name: 'squad', sql: 'squad_name', type: 'string', label: 'Squad' },
+];
+
+describe('dashboard renderers', () => {
+  describe('formatValue', () => {
+    describe('number format', () => {
+      it('formats small numbers', () => {
+        expect(strip(formatValue(42, 'number'))).toBe('42');
+      });
+
+      it('formats thousands with k suffix', () => {
+        expect(strip(formatValue(1500, 'number'))).toBe('1.5k');
+      });
+
+      it('formats millions with M suffix', () => {
+        expect(strip(formatValue(2_500_000, 'number'))).toBe('2.5M');
+      });
+
+      it('handles NaN gracefully', () => {
+        expect(strip(formatValue('not-a-number', 'number'))).toBe('not-a-number');
+      });
+    });
+
+    describe('currency format', () => {
+      it('formats with dollar sign and 2 decimals', () => {
+        expect(strip(formatValue(12.5, 'currency'))).toBe('$12.50');
+      });
+
+      it('formats zero', () => {
+        expect(strip(formatValue(0, 'currency'))).toBe('$0.00');
+      });
+    });
+
+    describe('percent format', () => {
+      it('formats with one decimal and percent sign', () => {
+        expect(strip(formatValue(87.654, 'percent'))).toBe('87.7%');
+      });
+
+      it('formats zero percent', () => {
+        expect(strip(formatValue(0, 'percent'))).toBe('0.0%');
+      });
+    });
+
+    describe('duration format', () => {
+      it('formats seconds under 60', () => {
+        expect(strip(formatValue(45.2, 'duration'))).toBe('45.2s');
+      });
+
+      it('formats minutes and seconds', () => {
+        expect(strip(formatValue(125, 'duration'))).toBe('2m 5s');
+      });
+
+      it('formats hours and minutes', () => {
+        expect(strip(formatValue(3700, 'duration'))).toBe('1h 1m');
+      });
+    });
+
+    describe('tokens format', () => {
+      it('formats small token count', () => {
+        expect(strip(formatValue(500, 'tokens'))).toBe('500');
+      });
+
+      it('formats thousands with k suffix', () => {
+        expect(strip(formatValue(15000, 'tokens'))).toBe('15k');
+      });
+
+      it('formats millions with M suffix', () => {
+        expect(strip(formatValue(1_200_000, 'tokens'))).toBe('1.2M');
+      });
+    });
+
+    describe('relative_time format', () => {
+      it('formats recent time as seconds ago', () => {
+        const recent = new Date(Date.now() - 30000); // 30 seconds ago
+        const result = strip(formatValue(recent, 'relative_time'));
+        expect(result).toMatch(/\d+s ago/);
+      });
+
+      it('formats older time as minutes ago', () => {
+        const older = new Date(Date.now() - 5 * 60 * 1000); // 5 min ago
+        const result = strip(formatValue(older, 'relative_time'));
+        expect(result).toMatch(/\d+m ago/);
+      });
+
+      it('handles invalid date', () => {
+        const result = strip(formatValue('not-a-date', 'relative_time'));
+        expect(result).toBe('not-a-date');
+      });
+    });
+
+    describe('relative_date format', () => {
+      it('formats today', () => {
+        const today = new Date();
+        const result = strip(formatValue(today, 'relative_date'));
+        expect(result).toBe('today');
+      });
+
+      it('formats yesterday', () => {
+        const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const result = strip(formatValue(yesterday, 'relative_date'));
+        expect(result).toBe('yesterday');
+      });
+    });
+
+    describe('status_badge format', () => {
+      it('formats success status', () => {
+        const result = formatValue('success', 'status_badge');
+        expect(strip(result)).toBe('success');
+      });
+
+      it('formats failed status', () => {
+        const result = formatValue('failed', 'status_badge');
+        expect(strip(result)).toBe('failed');
+      });
+
+      it('formats running status', () => {
+        const result = formatValue('running', 'status_badge');
+        expect(strip(result)).toBe('running');
+      });
+    });
+
+    describe('null/undefined handling', () => {
+      it('handles null values', () => {
+        const result = strip(formatValue(null, 'number'));
+        expect(result).toBe('—');
+      });
+
+      it('handles undefined values', () => {
+        const result = strip(formatValue(undefined, 'number'));
+        expect(result).toBe('—');
+      });
+    });
+
+    describe('default format with truncation', () => {
+      it('truncates long strings', () => {
+        const longStr = 'a'.repeat(50);
+        const result = strip(formatValue(longStr, 'string', 10));
+        expect(result.length).toBeLessThanOrEqual(13); // truncate adds '...'
+      });
+
+      it('does not truncate short strings', () => {
+        const shortStr = 'hello';
+        const result = strip(formatValue(shortStr, 'string', 20));
+        expect(result).toBe('hello');
+      });
+    });
+  });
+
+  describe('getThresholdColor', () => {
+    it('returns green for values above good threshold (up direction)', () => {
+      const color = getThresholdColor(90, { good: 80, warning: 50, direction: 'up' });
+      expect(color).toContain('\x1b['); // is an ANSI code
+      expect(strip(color + 'x')).toBe('x');
+    });
+
+    it('returns yellow for values between warning and good', () => {
+      const good = getThresholdColor(90, { good: 80, direction: 'up' });
+      const warning = getThresholdColor(60, { good: 80, direction: 'up' });
+      expect(good).not.toBe(warning);
+    });
+
+    it('uses default thresholds when not provided', () => {
+      // Should not throw
+      expect(() => getThresholdColor(75, {})).not.toThrow();
+    });
+
+    it('handles down direction (lower is better)', () => {
+      const good = getThresholdColor(10, { good: 20, warning: 50, direction: 'down' });
+      const bad = getThresholdColor(90, { good: 20, warning: 50, direction: 'down' });
+      expect(good).not.toBe(bad);
+    });
+  });
+
+  describe('calculateColumnWidths', () => {
+    it('returns widths matching number of columns', () => {
+      const rows = [{ name: 'Alice', age: '30' }];
+      const cols = [{ field: 'name' }, { field: 'age' }];
+      const widths = calculateColumnWidths(rows, cols);
+      expect(widths).toHaveLength(2);
+    });
+
+    it('returns minimum width of 5', () => {
+      const rows = [{ x: '1' }];
+      const cols = [{ field: 'x', label: 'X' }];
+      const widths = calculateColumnWidths(rows, cols, 1); // Force scale down
+      expect(widths[0]).toBeGreaterThanOrEqual(5);
+    });
+
+    it('scales down widths when total exceeds maxWidth', () => {
+      const rows = [{ a: 'a'.repeat(40), b: 'b'.repeat(40) }];
+      const cols = [{ field: 'a' }, { field: 'b' }];
+      const widths = calculateColumnWidths(rows, cols, 40);
+      const total = widths.reduce((sum, w) => sum + w, 0);
+      expect(total).toBeLessThanOrEqual(40);
+    });
+
+    it('caps individual column width at 30', () => {
+      const rows = [{ long_col: 'x'.repeat(100) }];
+      const cols = [{ field: 'long_col' }];
+      const widths = calculateColumnWidths(rows, cols, 200);
+      expect(widths[0]).toBeLessThanOrEqual(30);
+    });
+  });
+
+  describe('renderView', () => {
+    describe('summary view', () => {
+      it('renders summary with metric values', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'summary', metrics: ['total_runs'] };
+        const data: QueryResult = { rows: [{ total_runs: 42 }], columns: ['total_runs'] };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        const combined = strip(lines.join('\n'));
+        expect(combined).toContain('42');
+      });
+    });
+
+    describe('table view', () => {
+      it('renders no data message when empty', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'table', metrics: ['total_runs'] };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        const combined = strip(lines.join('\n'));
+        expect(combined).toContain('No data');
+      });
+
+      it('renders table with data', () => {
+        const view: ViewDefinition = {
+          id: 'v1', type: 'table',
+          group_by: ['squad'],
+          metrics: ['total_runs'],
+        };
+        const data: QueryResult = {
+          rows: [{ squad: 'eng', total_runs: 10 }],
+          columns: ['squad', 'total_runs'],
+        };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        const combined = strip(lines.join('\n'));
+        expect(combined).toContain('eng');
+        expect(combined).toContain('10');
+      });
+    });
+
+    describe('bar view', () => {
+      it('renders no data message when empty', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'bar', group_by: ['squad'], metrics: ['total_runs'] };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('No data');
+      });
+
+      it('renders bars for each row', () => {
+        const view: ViewDefinition = {
+          id: 'v1', type: 'bar',
+          group_by: ['squad'],
+          metrics: ['total_runs'],
+        };
+        const data: QueryResult = {
+          rows: [
+            { squad: 'engineering', total_runs: 10 },
+            { squad: 'marketing', total_runs: 5 },
+          ],
+          columns: ['squad', 'total_runs'],
+        };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        expect(lines.length).toBeGreaterThan(1);
+        const combined = strip(lines.join('\n'));
+        expect(combined).toContain('engineering');
+        expect(combined).toContain('marketing');
+      });
+
+      it('shows error when group_by or metrics are missing', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'bar' };
+        const data: QueryResult = { rows: [{ x: 1 }], columns: ['x'] };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('requires');
+      });
+    });
+
+    describe('pie view', () => {
+      it('renders no data message when empty', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'pie', group_by: ['squad'], metrics: ['total_runs'] };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('No data');
+      });
+
+      it('renders pie distribution', () => {
+        const view: ViewDefinition = {
+          id: 'v1', type: 'pie',
+          group_by: ['squad'],
+          metrics: ['total_runs'],
+        };
+        const data: QueryResult = {
+          rows: [
+            { squad: 'engineering', total_runs: 60 },
+            { squad: 'marketing', total_runs: 40 },
+          ],
+          columns: ['squad', 'total_runs'],
+        };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        expect(lines.length).toBeGreaterThan(2);
+      });
+    });
+
+    describe('list view', () => {
+      it('renders no data message when empty', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'list' };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('No data');
+      });
+
+      it('renders list items', () => {
+        const view: ViewDefinition = {
+          id: 'v1', type: 'list',
+          columns: [{ field: 'name' }, { field: 'status' }],
+        };
+        const data: QueryResult = {
+          rows: [{ name: 'Agent Alpha', status: 'active' }],
+          columns: ['name', 'status'],
+        };
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('Agent Alpha');
+      });
+
+      it('renders recent list when columns include time fields', () => {
+        const view: ViewDefinition = {
+          id: 'v1', type: 'list',
+          columns: [{ field: 'name' }, { field: 'created_at', format: 'relative_time' }],
+        };
+        const data: QueryResult = {
+          rows: [{ name: 'Run A', created_at: new Date().toISOString() }],
+          columns: ['name', 'created_at'],
+        };
+        // Should not throw
+        const lines = renderView(view, data, metricDefs, dimensionDefs);
+        expect(lines.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('trend view', () => {
+      it('handles trend view type', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'trend', metrics: ['total_runs'] };
+        // Should not throw even with empty data
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(Array.isArray(lines)).toBe(true);
+      });
+    });
+
+    describe('unimplemented view types', () => {
+      it('returns not implemented message for histogram', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'histogram' };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('not yet implemented');
+      });
+
+      it('returns not implemented message for heatmap', () => {
+        const view: ViewDefinition = { id: 'v1', type: 'heatmap' };
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('not yet implemented');
+      });
+
+      it('returns unknown type message for unrecognized type', () => {
+        const view = { id: 'v1', type: 'unknown_type' } as unknown as ViewDefinition;
+        const lines = renderView(view, emptyData, metricDefs, dimensionDefs);
+        expect(strip(lines.join('\n'))).toContain('Unknown view type');
+      });
+    });
+  });
+});

--- a/test/dashboard-sources.test.ts
+++ b/test/dashboard-sources.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildQuery,
+  buildWhereClause,
+  parseDateRange,
+  postgresSource,
+} from '../src/lib/dashboard/sources/postgres.js';
+
+describe('dashboard postgres source', () => {
+  describe('buildQuery', () => {
+    it('builds a simple SELECT with metric', () => {
+      const sql = buildQuery('executions', [{ name: 'total', sql: 'COUNT(*)' }]);
+      expect(sql).toBe('SELECT COUNT(*) AS total FROM executions');
+    });
+
+    it('includes GROUP BY when group_by is provided', () => {
+      const sql = buildQuery(
+        'executions',
+        [{ name: 'total', sql: 'COUNT(*)' }],
+        ['squad_name']
+      );
+      expect(sql).toContain('GROUP BY squad_name');
+      expect(sql).toContain('squad_name');
+    });
+
+    it('includes WHERE when where clause is provided', () => {
+      const sql = buildQuery(
+        'executions',
+        [{ name: 'total', sql: 'COUNT(*)' }],
+        undefined,
+        "status = 'success'"
+      );
+      expect(sql).toContain("WHERE status = 'success'");
+    });
+
+    it('includes ORDER BY when orderBy is provided', () => {
+      const sql = buildQuery(
+        'executions',
+        [{ name: 'total', sql: 'COUNT(*)' }],
+        undefined,
+        undefined,
+        'created_at DESC'
+      );
+      expect(sql).toContain('ORDER BY created_at DESC');
+    });
+
+    it('includes LIMIT when limit is provided', () => {
+      const sql = buildQuery(
+        'executions',
+        [{ name: 'total', sql: 'COUNT(*)' }],
+        undefined,
+        undefined,
+        undefined,
+        10
+      );
+      expect(sql).toContain('LIMIT 10');
+    });
+
+    it('builds full query with all clauses', () => {
+      const sql = buildQuery(
+        'executions',
+        [{ name: 'total', sql: 'COUNT(*)' }, { name: 'avg_cost', sql: 'AVG(cost)' }],
+        ['squad_name', 'status'],
+        "created_at > '2024-01-01'",
+        'total DESC',
+        5
+      );
+      expect(sql).toContain('SELECT');
+      expect(sql).toContain('squad_name');
+      expect(sql).toContain('COUNT(*) AS total');
+      expect(sql).toContain('AVG(cost) AS avg_cost');
+      expect(sql).toContain('FROM executions');
+      expect(sql).toContain("WHERE created_at > '2024-01-01'");
+      expect(sql).toContain('GROUP BY squad_name, status');
+      expect(sql).toContain('ORDER BY total DESC');
+      expect(sql).toContain('LIMIT 5');
+    });
+
+    it('handles multiple metrics', () => {
+      const sql = buildQuery('table1', [
+        { name: 'm1', sql: 'COUNT(*)' },
+        { name: 'm2', sql: 'SUM(cost)' },
+      ]);
+      expect(sql).toContain('COUNT(*) AS m1');
+      expect(sql).toContain('SUM(cost) AS m2');
+    });
+  });
+
+  describe('buildWhereClause', () => {
+    it('returns null for empty filters', () => {
+      const result = buildWhereClause({}, []);
+      expect(result).toBeNull();
+    });
+
+    it('builds date_range filter', () => {
+      const start = new Date('2024-01-01');
+      const end = new Date('2024-01-31');
+      const result = buildWhereClause(
+        { created_at: { start, end } },
+        [{ name: 'created_at', field: 'created_at', type: 'date_range' }]
+      );
+      expect(result).toContain("created_at >= '");
+      expect(result).toContain("created_at <= '");
+    });
+
+    it('builds select filter with array', () => {
+      const result = buildWhereClause(
+        { status: ['success', 'failed'] },
+        [{ name: 'status', field: 'status', type: 'select' }]
+      );
+      expect(result).toContain("status IN ('success', 'failed')");
+    });
+
+    it('skips empty select arrays', () => {
+      const result = buildWhereClause(
+        { status: [] },
+        [{ name: 'status', field: 'status', type: 'select' }]
+      );
+      expect(result).toBeNull();
+    });
+
+    it('builds boolean filter', () => {
+      const result = buildWhereClause(
+        { is_active: true },
+        [{ name: 'is_active', field: 'is_active', type: 'boolean' }]
+      );
+      expect(result).toBe('is_active = true');
+    });
+
+    it('builds text ILIKE filter', () => {
+      const result = buildWhereClause(
+        { name: 'engineering' },
+        [{ name: 'name', field: 'squad_name', type: 'text' }]
+      );
+      expect(result).toContain('ILIKE');
+      expect(result).toContain('%engineering%');
+    });
+
+    it('uses field name as column name when field not specified', () => {
+      const result = buildWhereClause(
+        { is_active: false },
+        [{ name: 'is_active', type: 'boolean' }]
+      );
+      expect(result).toBe('is_active = false');
+    });
+
+    it('skips unknown filter names', () => {
+      const result = buildWhereClause(
+        { unknown_filter: 'value' },
+        [{ name: 'known_filter', field: 'known_filter', type: 'text' }]
+      );
+      expect(result).toBeNull();
+    });
+
+    it('skips null and undefined values', () => {
+      const result = buildWhereClause(
+        { status: null, squad: undefined },
+        [
+          { name: 'status', field: 'status', type: 'text' },
+          { name: 'squad', field: 'squad', type: 'text' },
+        ]
+      );
+      expect(result).toBeNull();
+    });
+
+    it('joins multiple conditions with AND', () => {
+      const result = buildWhereClause(
+        { is_active: true, is_success: false },
+        [
+          { name: 'is_active', field: 'is_active', type: 'boolean' },
+          { name: 'is_success', field: 'is_success', type: 'boolean' },
+        ]
+      );
+      expect(result).toContain(' AND ');
+    });
+
+    it('escapes single quotes in text values', () => {
+      const result = buildWhereClause(
+        { name: "it's here" },
+        [{ name: 'name', field: 'name', type: 'text' }]
+      );
+      expect(result).toContain("it''s");
+    });
+  });
+
+  describe('parseDateRange', () => {
+    it('parses today', () => {
+      const { start, end } = parseDateRange('today');
+      const now = new Date();
+      expect(start.getDate()).toBe(now.getDate());
+      expect(start.getHours()).toBe(0);
+      expect(end.getHours()).toBe(23);
+    });
+
+    it('parses yesterday', () => {
+      const { start, end } = parseDateRange('yesterday');
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      expect(start.getDate()).toBe(yesterday.getDate());
+      expect(end.getDate()).toBe(yesterday.getDate());
+    });
+
+    it('parses last_7d', () => {
+      const { start, end } = parseDateRange('last_7d');
+      const diffDays = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+      expect(diffDays).toBeGreaterThanOrEqual(6);
+      expect(diffDays).toBeLessThanOrEqual(8);
+    });
+
+    it('parses last_30d', () => {
+      const { start, end } = parseDateRange('last_30d');
+      const diffDays = Math.round((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24));
+      expect(diffDays).toBeGreaterThanOrEqual(29);
+      expect(diffDays).toBeLessThanOrEqual(31);
+    });
+
+    it('parses this_month', () => {
+      const { start } = parseDateRange('this_month');
+      expect(start.getDate()).toBe(1);
+    });
+
+    it('parses last_month', () => {
+      const { start, end } = parseDateRange('last_month');
+      expect(start.getDate()).toBe(1);
+      // end should be last day of previous month
+      expect(end.getDate()).toBeGreaterThan(27);
+    });
+
+    it('parses this_quarter', () => {
+      const { start } = parseDateRange('this_quarter');
+      const now = new Date();
+      const q = Math.floor(now.getMonth() / 3);
+      expect(start.getMonth()).toBe(q * 3);
+      expect(start.getDate()).toBe(1);
+    });
+
+    it('defaults to last_7d for unknown presets', () => {
+      const { start: def } = parseDateRange('unknown_preset');
+      const { start: last7 } = parseDateRange('last_7d');
+      // Both should be approximately the same (within 1 minute)
+      expect(Math.abs(def.getTime() - last7.getTime())).toBeLessThan(60 * 1000);
+    });
+
+    it('returns Date objects', () => {
+      const { start, end } = parseDateRange('today');
+      expect(start).toBeInstanceOf(Date);
+      expect(end).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('postgresSource stub', () => {
+    it('is always unavailable (stub)', async () => {
+      const available = await postgresSource.isAvailable();
+      expect(available).toBe(false);
+    });
+
+    it('returns empty result on query', async () => {
+      const result = await postgresSource.query('SELECT 1');
+      expect(result.rows).toEqual([]);
+      expect(result.columns).toEqual([]);
+    });
+
+    it('close does not throw', async () => {
+      await expect(postgresSource.close()).resolves.toBeUndefined();
+    });
+
+    it('has name property', () => {
+      expect(postgresSource.name).toBe('postgres');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #314. Adds 115 unit tests for the dashboard module that was at 0% coverage.

**Coverage achieved: 92.24% statements, 80.26% branches, 95% functions**

## Test files added

- `test/dashboard-loader.test.ts` — 16 tests: `findDashboardsDir`, `listDashboards`, `loadDashboard`, `clearDashboardCache`, `loadAllDashboards`, `findDashboard`
- `test/dashboard-renderers.test.ts` — 49 tests: `formatValue` (all 10 formats), `getThresholdColor`, `calculateColumnWidths`, `renderView` (all view types including edge cases)
- `test/dashboard-sources.test.ts` — 31 tests: `buildQuery`, `buildWhereClause`, `parseDateRange` (all presets), `postgresSource` stub
- `test/dashboard-engine.test.ts` — 19 tests: `executeDashboard`, `renderDashboard`, `showAvailableDashboards` (with mocked loader and postgres source)

## Test plan

- [x] `npx vitest run test/dashboard-*.test.ts` — 115/115 pass
- [x] `npm run build` — passes
- [x] Coverage: `src/lib/dashboard` at 92% statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)