### PR TITLE
test(e2e): E2E test suite for init, status, and run workflows

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,51 @@
+# E2E Tests
+
+End-to-end tests that verify the CLI works correctly from a user's perspective.
+
+## What's Tested
+
+### cli-commands.e2e.test.ts
+Tests core CLI functionality:
+- Version output
+- Help system
+- Command listing
+- Provider enumeration
+- Error handling for unknown commands
+
+## Running E2E Tests
+
+```bash
+# Run all E2E tests
+npm test -- test/e2e/
+
+# Run specific E2E test file
+npm test -- test/e2e/cli-commands.e2e.test.ts
+```
+
+## Adding New E2E Tests
+
+When adding new E2E tests:
+1. Use the `CLI_PATH` constant to reference the built CLI
+2. Test from a user's perspective (what they see/experience)
+3. Use temp directories for file system operations
+4. Clean up resources in `afterEach` hooks
+5. Test both success and failure paths
+
+Example:
+```typescript
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CLI_PATH = path.resolve(__dirname, '../../dist/cli.js');
+
+it('tests something', () => {
+  const output = execSync(`node ${CLI_PATH} command`, {
+    encoding: 'utf-8',
+  });
+
+  expect(output).toContain('expected output');
+});
+```

--- a/test/e2e/cli-commands.e2e.test.ts
+++ b/test/e2e/cli-commands.e2e.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CLI_PATH = path.resolve(__dirname, '../../dist/cli.js');
+
+describe('E2E: Core CLI Commands', () => {
+  it('shows version without errors', () => {
+    const output = execSync(`node ${CLI_PATH} --version`, {
+      encoding: 'utf-8',
+    });
+
+    expect(output).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it('shows help without errors', () => {
+    const output = execSync(`node ${CLI_PATH} --help`, {
+      encoding: 'utf-8',
+    });
+
+    expect(output).toContain('Commands:');
+    expect(output).toContain('Options:');
+  });
+
+  it('lists available commands in help', () => {
+    const output = execSync(`node ${CLI_PATH} --help`, {
+      encoding: 'utf-8',
+    });
+
+    // Verify key commands are listed
+    expect(output).toContain('init');
+    expect(output).toContain('run');
+    expect(output).toContain('status');
+    expect(output).toContain('dashboard');
+  });
+
+  it('shows command-specific help', () => {
+    const output = execSync(`node ${CLI_PATH} init --help`, {
+      encoding: 'utf-8',
+    });
+
+    expect(output).toContain('Initialize a new squad project');
+    expect(output).toContain('Options:');
+  });
+
+  it('handles unknown commands gracefully', () => {
+    expect(() => {
+      execSync(`node ${CLI_PATH} nonexistent-command`, {
+        stdio: 'pipe',
+      });
+    }).toThrow();
+  });
+
+  it('providers command lists available providers', () => {
+    const output = execSync(`node ${CLI_PATH} providers`, {
+      encoding: 'utf-8',
+    });
+
+    // Should mention Claude or other providers
+    expect(output.length).toBeGreaterThan(0);
+  });
+});

--- a/test/e2e/workflows.e2e.test.ts
+++ b/test/e2e/workflows.e2e.test.ts
@@ -1,0 +1,297 @@
+/**
+ * E2E tests for critical user workflows: init → status → run
+ *
+ * These tests run the actual CLI binary in isolated temp directories
+ * to verify that the full user journey produces expected output.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { mkdirSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const CLI_PATH = resolve(__dirname, '../../dist/cli.js');
+
+/** Strip ANSI escape codes for plain-text assertions */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[[0-9;]*[mGKHF]/g, '').replace(/\x1B\[[0-9;]*m/g, '');
+}
+
+function runCli(
+  args: string,
+  cwd: string,
+  opts: { timeout?: number } = {}
+): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${args}`, {
+      encoding: 'utf-8',
+      cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: opts.timeout ?? 15000,
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' },
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const e = error as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: stripAnsi(e.stdout || ''),
+      stderr: stripAnsi(e.stderr || ''),
+      exitCode: e.status || 1,
+    };
+  }
+}
+
+/**
+ * Run init and return which squad directories were created.
+ * Works regardless of whether init creates 'demo' or 'company/research/...' squads.
+ */
+function getCreatedSquads(testDir: string): string[] {
+  const squadsDir = join(testDir, '.agents', 'squads');
+  if (!existsSync(squadsDir)) return [];
+  const { readdirSync } = require('fs');
+  return readdirSync(squadsDir) as string[];
+}
+
+describe('E2E: squads init workflow', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `squads-e2e-init-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    // init requires a git repo
+    execSync('git init -q', { cwd: testDir });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits with code 0 on successful init', () => {
+    const result = runCli('init --yes --provider none --force', testDir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('reports success in output', () => {
+    const result = runCli('init --yes --provider none --force', testDir);
+    const out = stripAnsi(result.stdout);
+    // Accept either "Squads initialized" or "AI workforce is ready" success messages
+    expect(out).toMatch(/initialized|workforce is ready/i);
+  });
+
+  it('creates .agents/squads directory', () => {
+    runCli('init --yes --provider none --force', testDir);
+    expect(existsSync(join(testDir, '.agents', 'squads'))).toBe(true);
+  });
+
+  it('creates at least one squad directory', () => {
+    runCli('init --yes --provider none --force', testDir);
+    const squads = getCreatedSquads(testDir);
+    expect(squads.length).toBeGreaterThan(0);
+  });
+
+  it('creates SQUAD.md in each squad directory', () => {
+    runCli('init --yes --provider none --force', testDir);
+    const squads = getCreatedSquads(testDir);
+    for (const squad of squads) {
+      const squadFile = join(testDir, '.agents', 'squads', squad, 'SQUAD.md');
+      expect(existsSync(squadFile)).toBe(true);
+      const content = readFileSync(squadFile, 'utf-8');
+      expect(content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('creates agent definition files in each squad', () => {
+    runCli('init --yes --provider none --force', testDir);
+    const squads = getCreatedSquads(testDir);
+    const { readdirSync } = require('fs');
+    for (const squad of squads) {
+      const squadDir = join(testDir, '.agents', 'squads', squad);
+      const files = readdirSync(squadDir) as string[];
+      const agentFiles = files.filter((f: string) => f.endsWith('.md') && f !== 'SQUAD.md');
+      expect(agentFiles.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('creates memory directory', () => {
+    runCli('init --yes --provider none --force', testDir);
+    expect(existsSync(join(testDir, '.agents', 'memory'))).toBe(true);
+  });
+
+  it('creates provider config', () => {
+    runCli('init --yes --provider none --force', testDir);
+    expect(existsSync(join(testDir, '.agents', 'config', 'provider.yaml'))).toBe(true);
+  });
+
+  it('shows next steps in output', () => {
+    const result = runCli('init --yes --provider none --force', testDir);
+    const out = stripAnsi(result.stdout);
+    // Should mention at least one next step command
+    expect(out).toMatch(/squads (status|run|dash)/);
+  });
+});
+
+describe('E2E: squads status workflow', () => {
+  let testDir: string;
+  let squads: string[];
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `squads-e2e-status-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    execSync('git init -q', { cwd: testDir });
+    // Set up a project via init
+    runCli('init --yes --provider none --force', testDir);
+    squads = getCreatedSquads(testDir);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits with code 0 when squads exist', () => {
+    const result = runCli('status', testDir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('shows squad count', () => {
+    const result = runCli('status', testDir);
+    const out = stripAnsi(result.stdout);
+    expect(out).toMatch(/\d+\/\d+\s+squads/);
+  });
+
+  it('lists initialized squads in table', () => {
+    const result = runCli('status', testDir);
+    const out = stripAnsi(result.stdout);
+    // At least one created squad should appear in the status table
+    const foundSquad = squads.some(squad => out.includes(squad));
+    expect(foundSquad).toBe(true);
+  });
+
+  it('shows agent count for squads', () => {
+    const result = runCli('status', testDir);
+    const out = stripAnsi(result.stdout);
+    // Should show numbers (agent counts) in the table
+    expect(out).toMatch(/\d+/);
+  });
+
+  it('shows helpful commands in footer', () => {
+    const result = runCli('status', testDir);
+    const out = stripAnsi(result.stdout);
+    expect(out).toContain('squads run');
+  });
+
+  it('exits with error when no squads directory exists', () => {
+    const emptyDir = join(tmpdir(), `squads-e2e-empty-${Date.now()}`);
+    mkdirSync(emptyDir, { recursive: true });
+    try {
+      const result = runCli('status', emptyDir);
+      expect(result.exitCode).not.toBe(0);
+      const out = stripAnsi(result.stdout + result.stderr);
+      expect(out).toContain('squads init');
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('shows specific squad details with squad argument', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`status ${targetSquad}`, testDir);
+    const out = stripAnsi(result.stdout);
+    expect(out.length).toBeGreaterThan(0);
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('E2E: squads run workflow', () => {
+  let testDir: string;
+  let squads: string[];
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `squads-e2e-run-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    execSync('git init -q', { cwd: testDir });
+    runCli('init --yes --provider none --force', testDir);
+    squads = getCreatedSquads(testDir);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits with code 0 in dry-run mode', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('shows squad name in dry-run output', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    const out = stripAnsi(result.stdout);
+    expect(out).toContain(targetSquad);
+  });
+
+  it('shows agents in dry-run output', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    const out = stripAnsi(result.stdout);
+    // Should contain at least one agent name from the squad
+    const { readdirSync } = require('fs');
+    const squadDir = join(testDir, '.agents', 'squads', targetSquad);
+    const agentFiles = (readdirSync(squadDir) as string[]).filter(
+      (f: string) => f.endsWith('.md') && f !== 'SQUAD.md'
+    );
+    const agentNames = agentFiles.map((f: string) => f.replace('.md', ''));
+    const foundAgent = agentNames.some((name: string) => out.includes(name));
+    expect(foundAgent).toBe(true);
+  });
+
+  it('exits with code 0 in dry-run mode (second squad)', () => {
+    // Verify dry-run works for another squad if multiple exist
+    if (squads.length < 2) return;
+    const targetSquad = squads[1];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('shows start time in output', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    const out = stripAnsi(result.stdout);
+    expect(out).toMatch(/\d{4}-\d{2}-\d{2}/);
+  });
+
+  it('exits with error for unknown squad', () => {
+    const result = runCli('run nonexistent-squad --dry-run', testDir);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('exits with error when no squads directory exists', () => {
+    const emptyDir = join(tmpdir(), `squads-e2e-run-empty-${Date.now()}`);
+    mkdirSync(emptyDir, { recursive: true });
+    try {
+      const result = runCli('run demo --dry-run', emptyDir);
+      expect(result.exitCode).not.toBe(0);
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
+  });
+
+  it('shows post-run guidance in output', () => {
+    const targetSquad = squads[0];
+    const result = runCli(`run ${targetSquad} --dry-run`, testDir);
+    const out = stripAnsi(result.stdout);
+    // Should mention feedback or next steps after run
+    expect(out).toContain('feedback');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #85

Adds `test/e2e/workflows.e2e.test.ts` with **24 E2E tests** covering the three critical user workflows identified in the issue:

- **`squads init`** (9 tests): exit code, success message, `.agents/squads/` directory creation, SQUAD.md per squad, agent definition files, memory dir, provider config, next-steps guidance
- **`squads status`** (7 tests): exit code, squad count display, squad table listing, agent counts, footer commands, error state when no project exists, per-squad detail view
- **`squads run --dry-run`** (8 tests): exit code, squad/agent output, start timestamp, error on unknown squad, error when no project, post-run feedback guidance

## Approach

- Runs the actual built CLI binary (`dist/cli.js`) via `execSync`
- Uses isolated `tmpdir` directories with `git init` for each test
- Dynamic squad discovery — tests work regardless of which use-case `init` creates (demo/full-company/etc.)
- ANSI stripping for clean text assertions
- Graceful handling of spinner output (which goes to stderr in non-TTY)

## Test plan

- [x] All 24 E2E tests pass: `npx vitest run test/e2e/workflows.e2e.test.ts`
- [x] Full test suite passes (pre-existing failures in infra.test.ts and verify-token.test.ts are unrelated)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)