### PR TITLE
feat: add --repo flag to squads create for GitHub repo creation

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -244,11 +244,15 @@ program
   .option('-m, --model <model>', 'Default model (default: sonnet)')
   .option('-f, --force', 'Overwrite existing squad')
   .option('-y, --yes', 'Accept all defaults (non-interactive)')
+  .option('-r, --repo', 'Create a GitHub repository for the squad')
+  .option('-o, --org <org>', 'GitHub organization for --repo (default: detected from git remote)')
   .addHelpText('after', `
 Examples:
   $ squads create marketing                          Create with interactive prompts
   $ squads create marketing -d "Drive growth" -y     Create non-interactively
   $ squads create marketing --force                  Overwrite existing squad
+  $ squads create marketing --repo                   Create with GitHub repo
+  $ squads create marketing --repo --org myorg       Create with GitHub repo in specific org
 `)
   .action(async (...args) => {
     const { createCommand } = await import('./commands/create.js');

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -16,6 +16,7 @@ import chalk from 'chalk';
 import { findSquadsDir, findProjectRoot, listSquads } from '../lib/squad-parser.js';
 import { loadTemplate, toKebabCase, toTitleCase, type TemplateVariables } from '../lib/templates.js';
 import { track } from '../lib/telemetry.js';
+import { createGitHubRepo, detectGitHubOrg } from '../lib/github.js';
 
 interface CreateOptions {
   description?: string;
@@ -23,6 +24,8 @@ interface CreateOptions {
   model?: string;
   force?: boolean;
   yes?: boolean;
+  repo?: boolean;
+  org?: string;
 }
 
 export async function createCommand(name: string, options: CreateOptions): Promise<void> {
@@ -128,9 +131,25 @@ export async function createCommand(name: string, options: CreateOptions): Promi
     hasDescription: !!options.description,
     hasGoal: !!options.goal,
     force: !!options.force,
+    repo: !!options.repo,
   }).catch(() => {});
 
-  // 5. Show success
+  // 5. Create GitHub repo if --repo flag is set
+  let repoUrl: string | undefined;
+  if (options.repo) {
+    const org = options.org ?? detectGitHubOrg();
+    try {
+      const result = createGitHubRepo(squadId, { org, description });
+      repoUrl = result.url;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(chalk.red(`\n  GitHub repo creation failed: ${message}\n`));
+      console.error(chalk.dim('  Local squad was created. Create the repo manually with:'));
+      console.error(chalk.dim(`  gh repo create ${org ? `${org}/` : ''}${squadId} --private\n`));
+    }
+  }
+
+  // 6. Show success
   const existing = listSquads(squadsDir);
   console.log();
   console.log(chalk.green('  ✓ Squad created:'), chalk.cyan(squadId));
@@ -139,6 +158,11 @@ export async function createCommand(name: string, options: CreateOptions): Promi
   console.log(`    .agents/squads/${squadId}/SQUAD.md`);
   console.log(`    .agents/squads/${squadId}/lead.md`);
   console.log(`    .agents/memory/${squadId}/lead/`);
+  if (repoUrl) {
+    console.log();
+    console.log(chalk.dim('  GitHub repo:'));
+    console.log(`    ${chalk.cyan(repoUrl)}`);
+  }
   console.log();
   console.log(chalk.dim('  Next steps:'));
   console.log(`    ${chalk.cyan('$')} squads run ${squadId}              ${chalk.dim('# run the squad')}`);

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,77 @@
+import { execSync } from 'child_process';
+
+export interface GitHubRepoResult {
+  url: string;
+  fullName: string;
+}
+
+/**
+ * Detect GitHub org from the current project's git remote.
+ * Falls back to undefined if not in a git repo or remote is not GitHub.
+ */
+export function detectGitHubOrg(cwd: string = process.cwd()): string | undefined {
+  try {
+    const remote = execSync('git remote get-url origin', {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    // Match github.com/<org>/<repo>
+    const match = remote.match(/github\.com[:/]([^/]+)\//);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Create a GitHub repository using the gh CLI.
+ * Requires gh CLI to be installed and authenticated.
+ */
+export function createGitHubRepo(
+  name: string,
+  options: {
+    org?: string;
+    description?: string;
+    isPrivate?: boolean;
+  } = {}
+): GitHubRepoResult {
+  const { org, description, isPrivate = true } = options;
+  const fullName = org ? `${org}/${name}` : name;
+
+  // Verify gh is available
+  try {
+    execSync('gh --version', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+  } catch {
+    throw new Error('gh CLI not found. Install it from https://cli.github.com/');
+  }
+
+  // Check if repo already exists
+  try {
+    execSync(`gh repo view ${fullName} --json name`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    throw new Error(`Repository "${fullName}" already exists on GitHub`);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('already exists')) {
+      throw err;
+    }
+    // Repo doesn't exist — proceed
+  }
+
+  // Build gh repo create command
+  const args = ['gh', 'repo', 'create', fullName, isPrivate ? '--private' : '--public'];
+  if (description) {
+    args.push('--description', description);
+  }
+
+  const output = execSync(args.join(' '), {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+  const url = output || `https://github.com/${fullName}`;
+  return { url, fullName };
+}

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -3,6 +3,21 @@ import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+// Mock child_process for --repo tests
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execSync: vi.fn((cmd: string) => {
+      if (cmd.startsWith('gh --version')) return 'gh version 2.0.0';
+      if (cmd.startsWith('gh repo view')) throw new Error('Not found');
+      if (cmd.startsWith('gh repo create')) return 'https://github.com/test-org/my-squad\n';
+      if (cmd.startsWith('git remote get-url')) return 'git@github.com:test-org/other-repo.git\n';
+      return actual.execSync(cmd);
+    }),
+  };
+});
+
 describe('create command', () => {
   let testDir: string;
   let originalCwd: string;
@@ -149,6 +164,57 @@ describe('create command', () => {
       const squadsDir = join(testDir, '.agents', 'squads');
       const squads = listSquads(squadsDir);
       expect(squads).toContain('new-squad');
+    });
+  });
+
+  describe('--repo flag', () => {
+    it('creates local squad files even with --repo', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('my-squad', { yes: true, repo: true, org: 'test-org' });
+
+      const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
+      expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
+      expect(existsSync(join(squadDir, 'lead.md'))).toBe(true);
+    });
+
+    it('calls createGitHubRepo with correct org and name', async () => {
+      const { execSync } = await import('child_process');
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      await createCommand('my-squad', { yes: true, repo: true, org: 'test-org' });
+
+      const calls = vi.mocked(execSync).mock.calls.map(c => c[0] as string);
+      const createCall = calls.find(c => c.startsWith('gh repo create'));
+      expect(createCall).toBeDefined();
+      expect(createCall).toContain('test-org/my-squad');
+    });
+
+    it('creates private repo by default', async () => {
+      const { execSync } = await import('child_process');
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      await createCommand('my-squad', { yes: true, repo: true, org: 'test-org' });
+
+      const calls = vi.mocked(execSync).mock.calls.map(c => c[0] as string);
+      const createCall = calls.find(c => c.startsWith('gh repo create'));
+      expect(createCall).toContain('--private');
+    });
+
+    it('continues gracefully if GitHub repo creation fails', async () => {
+      const { execSync } = await import('child_process');
+      vi.mocked(execSync).mockImplementationOnce((cmd: string) => {
+        if ((cmd as string).startsWith('gh --version')) return 'gh version 2.0.0';
+        throw new Error('API error');
+      });
+
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      // Should not throw — creates local squad even if GitHub fails
+      await expect(createCommand('my-squad', { yes: true, repo: true, org: 'test-org' })).resolves.toBeUndefined();
+
+      // Local files still exist
+      const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
+      expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `--repo` flag to `squads create` to create a GitHub repository alongside the local squad
- Adds `--org <org>` flag to specify the GitHub organization (auto-detected from git remote if omitted)
- Creates a new `src/lib/github.ts` module with `createGitHubRepo()` and `detectGitHubOrg()` utilities
- Graceful error handling: local squad is always created, GitHub failure is non-fatal

## Usage

```bash
squads create marketing --repo                    # creates repo in detected org
squads create marketing --repo --org agents-squads  # creates repo in specific org
```

## Test plan

- [x] 4 new tests in `test/commands/create.test.ts` (15 total, all passing)
- [x] Tests verify: local files created, gh CLI called with correct org/name, private by default, graceful failure handling
- [x] `npm run build` passes

Closes #281

🤖 Generated with [Agents Squads](https://agents-squads.com)

| Field | Value |
|-------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Model | claude-sonnet-4-6 |