### PR TITLE
fix(daemon): parse routines with prefixed headers

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -68,7 +68,7 @@ function parseRoutinesFromFile(filePath: string): Routine[] {
   const routines: Routine[] = [];
 
   const routinesMatch = content.match(
-    /##+ Routines[\s\S]*?```yaml\s*\n([\s\S]*?)```/i
+    /##+ \w*\s*Routines[\s\S]*?```yaml\s*\n([\s\S]*?)```/i
   );
   if (!routinesMatch) return [];
 


### PR DESCRIPTION
## Summary
- Regex in `parseRoutinesFromFile()` only matched `## Routines` exactly
- Engineering squad uses `## Growth Routines` — was silently skipped
- Now matches `## {Word} Routines` pattern

## Impact
Engineering squad's 2 routines (weekly-release, readme-polish) were never collected by the daemon.

## Test plan
- [x] Build passes
- [ ] `squads autonomous status` shows engineering routines

---
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>