### PR TITLE
fix(daemon): parse routines with prefixed headers

### DIFF
--- a/src/commands/autonomous.ts
+++ b/src/commands/autonomous.ts
@@ -70,7 +70,7 @@ function parseRoutinesFromFile(filePath: string): Routine[] {
   const routines: Routine[] = [];
 
   const routinesMatch = content.match(
-    /##+ Routines[\s\S]*?```yaml\s*\n([\s\S]*?)```/i
+    /##+ \w*\s*Routines[\s\S]*?```yaml\s*\n([\s\S]*?)```/i
   );
   if (!routinesMatch) return [];
 


### PR DESCRIPTION
## Summary
- Fix routine parsing regex in autonomous daemon to match prefixed headers like `## Growth Routines`
- Previous regex `/##+ Routines/` only matched exact `## Routines`, missing squad-prefixed variants

## Change
`/##+ Routines/` → `/##+ \w*\s*Routines/`

## Test plan
- [x] `npm run build` passes
- [x] CI should pass (develop typecheck fixed in #391)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>