### PR TITLE
feat(run): squad conversation protocol

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -276,11 +276,15 @@ program
   .option('--model <model>', 'Model to use (e.g., opus, sonnet, haiku, gemini-2.5-flash, gpt-4o)')
   .option('--trigger <type>', 'Trigger source: manual, scheduled, event, smart (default: manual)')
   .option('--cloud', 'Dispatch execution to cloud worker via API (requires squads login)')
+  .option('--task <directive>', 'Founder directive for conversation mode (replaces lead briefing)')
+  .option('--max-turns <n>', 'Max conversation turns (default: 20)', '20')
+  .option('--cost-ceiling <usd>', 'Cost ceiling in USD (default: 25)', '25')
   .option('--no-verify', 'Skip post-execution verification (Ralph loop)')
   .option('-j, --json', 'Output as JSON')
   .addHelpText('after', `
 Examples:
-  $ squads run engineering              Run whole squad (shows agent list)
+  $ squads run engineering              Run squad conversation (lead → scan → work → review)
+  $ squads run engineering --task "fix CI"  Conversation with founder directive
   $ squads run engineering/code-review  Run specific agent (slash notation)
   $ squads run engineering -a code-review  Same as above (flag notation)
   $ squads run engineering --dry-run    Preview what would run

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -36,6 +36,7 @@ import {
 import { detectProviderFromModel } from '../lib/providers.js';
 import { loadSession, isLoggedIn } from '../lib/auth.js';
 import { getApiUrl, getBridgeUrl } from '../lib/env-config.js';
+import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
 import { homedir } from 'os';
 
 // ── Operational constants (no magic numbers) ──────────────────────────
@@ -78,6 +79,10 @@ interface RunOptions {
   model?: string; // Model to use (Claude aliases or full model IDs like gemini-2.5-flash)
   verify?: boolean; // Post-execution verification (default true, --no-verify to skip)
   cloud?: boolean; // Dispatch to cloud worker via API instead of local execution
+  conversation?: boolean; // Run squad as multi-agent conversation (default for squad runs)
+  task?: string; // Founder directive — replaces lead briefing in conversation mode
+  maxTurns?: number; // Max conversation turns (default: 20)
+  costCeiling?: number; // Cost ceiling in USD (default: 25)
 }
 
 /**
@@ -1426,27 +1431,46 @@ async function runSquad(
         return;
       }
     } else {
-      // Run orchestrator if exists, otherwise list agents
-      const orchestrator = squad.agents.find(a =>
-        a.name.includes('lead') || a.trigger === 'Manual'
-      );
+      // Default: Run squad as multi-agent conversation
+      // Lead briefs → scanners discover → workers execute → lead reviews → converge
+      if (options.execute) {
+        writeLine(`  ${bold}Conversation mode${RESET} ${colors.dim}(lead → scan → work → review → verify)${RESET}`);
+        writeLine();
 
-      if (orchestrator) {
-        const agentPath = join(squadsDir, squad.dir, `${orchestrator.name}.md`);
-        if (existsSync(agentPath)) {
-          await runAgent(orchestrator.name, agentPath, squad.dir, options);
+        const convOptions: ConversationOptions = {
+          task: options.task,
+          maxTurns: options.maxTurns,
+          costCeiling: options.costCeiling,
+          verbose: options.verbose,
+          model: options.model,
+        };
+
+        const result = runConversation(squad, convOptions);
+
+        // Save transcript
+        const transcriptPath = saveTranscript(result.transcript);
+
+        writeLine();
+        writeLine(`  ${result.converged ? icons.success : icons.warning} ${result.converged ? 'Converged' : 'Stopped'}: ${result.reason}`);
+        writeLine(`  ${colors.dim}Turns: ${result.turnCount} | Cost: ~$${result.totalCost.toFixed(2)}${RESET}`);
+        if (transcriptPath) {
+          writeLine(`  ${colors.dim}Transcript: ${transcriptPath}${RESET}`);
         }
+        writeLine();
       } else {
-        writeLine(`  ${colors.dim}No pipeline defined. Available agents:${RESET}`);
+        // Dry-run: show what would happen
+        writeLine(`  ${colors.dim}Default mode: conversation (lead → scan → work → review → verify)${RESET}`);
+        writeLine();
         for (const agent of squad.agents) {
           writeLine(`  ${icons.empty} ${colors.cyan}${agent.name}${RESET} ${colors.dim}${agent.role}${RESET}`);
         }
         writeLine();
-        writeLine(`  ${colors.dim}Run a specific agent:${RESET}`);
-        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --agent ${colors.cyan}<name>${RESET}`);
+        writeLine(`  ${colors.dim}Run conversation:${RESET}`);
+        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET}`);
+        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --task "review and merge open PRs"`);
         writeLine();
-        writeLine(`  ${colors.dim}Run all agents in parallel:${RESET}`);
-        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --parallel`);
+        writeLine(`  ${colors.dim}Run single agent:${RESET}`);
+        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} -a ${colors.cyan}<agent>${RESET}`);
       }
     }
   }

--- a/src/lib/conversation.ts
+++ b/src/lib/conversation.ts
@@ -1,0 +1,189 @@
+/**
+ * Squad Conversation Protocol — Types, transcript management, and convergence detection.
+ *
+ * Agents share a conversation transcript. Lead briefs first, workers execute,
+ * lead iterates with workers until quality converges, verifiers check final output.
+ * CLI manages turns (deterministic), lead manages content (creative).
+ */
+
+// =============================================================================
+// Agent Classification
+// =============================================================================
+
+export type AgentRole = 'lead' | 'scanner' | 'worker' | 'verifier';
+
+const ROLE_PATTERNS: Record<AgentRole, RegExp> = {
+  scanner: /scanner|scout|monitor/i,
+  worker: /worker|researcher|poster|solver|writer|analyst|builder/i,
+  lead: /lead|orchestrator/i,
+  verifier: /verifier|critic|eval|reviewer/i,
+};
+
+/** Classify an agent name into a conversation role */
+export function classifyAgent(agentName: string): AgentRole | null {
+  for (const [role, pattern] of Object.entries(ROLE_PATTERNS)) {
+    if (pattern.test(agentName)) return role as AgentRole;
+  }
+  return null; // Unclassified — excluded from conversation
+}
+
+/** Map roles to model tiers for cost routing */
+export function modelForRole(role: AgentRole): string {
+  switch (role) {
+    case 'lead': return 'sonnet';
+    case 'worker': return 'sonnet';
+    case 'scanner': return 'haiku';
+    case 'verifier': return 'haiku';
+  }
+}
+
+// =============================================================================
+// Transcript
+// =============================================================================
+
+export interface Turn {
+  /** Which agent produced this turn */
+  agent: string;
+  /** Classified role */
+  role: AgentRole;
+  /** The agent's full output */
+  content: string;
+  /** Timestamp */
+  timestamp: string;
+  /** Estimated cost for this turn */
+  estimatedCost: number;
+}
+
+export interface Transcript {
+  squad: string;
+  turns: Turn[];
+  startedAt: string;
+  /** Running cost estimate */
+  totalCost: number;
+}
+
+export function createTranscript(squad: string): Transcript {
+  return {
+    squad,
+    turns: [],
+    startedAt: new Date().toISOString(),
+    totalCost: 0,
+  };
+}
+
+/** Serialize transcript for prompt injection */
+export function serializeTranscript(transcript: Transcript): string {
+  if (transcript.turns.length === 0) return '';
+
+  const lines = ['## Conversation So Far\n'];
+  for (const turn of transcript.turns) {
+    lines.push(`### ${turn.agent} (${turn.role}) — ${turn.timestamp}`);
+    lines.push(turn.content);
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export function addTurn(
+  transcript: Transcript,
+  agent: string,
+  role: AgentRole,
+  content: string,
+  estimatedCost: number,
+): void {
+  transcript.turns.push({
+    agent,
+    role,
+    content,
+    timestamp: new Date().toISOString(),
+    estimatedCost,
+  });
+  transcript.totalCost += estimatedCost;
+}
+
+// =============================================================================
+// Convergence Detection
+// =============================================================================
+
+/** Signals that indicate work is done */
+const CONVERGENCE_SIGNALS = [
+  /PR\s*#?\d+\s*created/i,
+  /issue\s*#?\d+\s*(closed|resolved)/i,
+  /all\s*(tasks?|items?|issues?)\s*(complete|done|resolved)/i,
+  /nothing\s*(left|remaining|more)\s*to\s*(do|process)/i,
+  /session\s*complete/i,
+  /queue\s*empty/i,
+  /no\s*(open|pending)\s*(issues?|tasks?|items?)/i,
+];
+
+/** Signals that indicate more work needed */
+const CONTINUATION_SIGNALS = [
+  /needs?\s*(review|feedback|input|clarification)/i,
+  /TODO|FIXME|BLOCKED/,
+  /waiting\s*(for|on)/i,
+  /will\s*(continue|proceed|work\s*on)/i,
+  /next\s*step/i,
+  /in\s*progress/i,
+];
+
+export interface ConvergenceResult {
+  converged: boolean;
+  reason: string;
+}
+
+/**
+ * Detect if the conversation has converged.
+ * Continuation signals beat convergence signals (bias toward more work).
+ */
+export function detectConvergence(
+  transcript: Transcript,
+  maxTurns: number,
+  costCeiling: number,
+): ConvergenceResult {
+  // Hard limits
+  if (transcript.turns.length >= maxTurns) {
+    return { converged: true, reason: `Max turns reached (${maxTurns})` };
+  }
+  if (transcript.totalCost >= costCeiling) {
+    return { converged: true, reason: `Cost ceiling reached ($${transcript.totalCost.toFixed(2)}/$${costCeiling})` };
+  }
+
+  // Check last turn content
+  if (transcript.turns.length === 0) {
+    return { converged: false, reason: 'No turns yet' };
+  }
+
+  const lastTurn = transcript.turns[transcript.turns.length - 1];
+  const content = lastTurn.content;
+
+  // Continuation signals beat convergence (bias toward completing work)
+  const hasContinuation = CONTINUATION_SIGNALS.some(p => p.test(content));
+  if (hasContinuation) {
+    return { converged: false, reason: 'Continuation signal detected' };
+  }
+
+  const hasConvergence = CONVERGENCE_SIGNALS.some(p => p.test(content));
+  if (hasConvergence) {
+    return { converged: true, reason: 'Convergence signal detected' };
+  }
+
+  return { converged: false, reason: 'No signals detected, continuing' };
+}
+
+// =============================================================================
+// Cost Estimation
+// =============================================================================
+
+/** Rough cost estimates per model per turn (input + output) */
+const COST_PER_TURN: Record<string, number> = {
+  opus: 2.50,
+  sonnet: 0.75,
+  haiku: 0.10,
+};
+
+export function estimateTurnCost(model: string): number {
+  const key = model.includes('opus') ? 'opus'
+    : model.includes('haiku') ? 'haiku'
+    : 'sonnet';
+  return COST_PER_TURN[key] || COST_PER_TURN.sonnet;
+}

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -1,0 +1,395 @@
+/**
+ * Squad Conversation Workflow — Orchestrates multi-agent conversations.
+ *
+ * Lead briefs → scanners discover → workers execute → lead reviews →
+ * loop until convergence or budget exhausted.
+ *
+ * CLI manages turns (deterministic), lead manages content (creative).
+ */
+
+import { join } from 'path';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
+import {
+  type AgentRole,
+  type Transcript,
+  classifyAgent,
+  modelForRole,
+  createTranscript,
+  serializeTranscript,
+  addTurn,
+  detectConvergence,
+  estimateTurnCost,
+} from './conversation.js';
+import {
+  type Squad,
+  findSquadsDir,
+  loadAgentDefinition,
+} from './squad-parser.js';
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+export interface ConversationOptions {
+  /** Override lead's briefing with a founder directive */
+  task?: string;
+  /** Maximum turns before stopping (default: 20) */
+  maxTurns?: number;
+  /** Cost ceiling in USD (default: 25) */
+  costCeiling?: number;
+  /** Verbose logging */
+  verbose?: boolean;
+  /** Model override for all agents */
+  model?: string;
+}
+
+const DEFAULT_MAX_TURNS = 20;
+const DEFAULT_COST_CEILING = 25;
+
+// =============================================================================
+// Agent Turn Execution
+// =============================================================================
+
+interface AgentTurnConfig {
+  agentName: string;
+  agentPath: string;
+  role: AgentRole;
+  squadName: string;
+  model: string;
+  transcript: Transcript;
+  task?: string;
+}
+
+/**
+ * Execute a single agent turn via `claude --print`.
+ * Returns the agent's text output.
+ */
+function executeAgentTurn(config: AgentTurnConfig): string {
+  const { agentName, agentPath, role, squadName, model, transcript, task } = config;
+
+  // Build the prompt: agent definition + transcript context + role instructions
+  const definition = loadAgentDefinition(agentPath);
+  const transcriptContext = serializeTranscript(transcript);
+
+  let roleInstructions: string;
+  switch (role) {
+    case 'lead':
+      if (transcript.turns.length === 0 && task) {
+        // First turn with founder directive — replaces lead briefing
+        roleInstructions = `## Founder Directive\n\n${task}\n\nBrief the team on this directive. Set priorities and assign work.`;
+      } else if (transcript.turns.length === 0) {
+        roleInstructions = `## Your Role: Lead\n\nYou are starting a new squad session. Brief the team:\n1. Review open issues and PRs\n2. Set priorities for this session\n3. Assign work to workers\n4. Be specific about what each worker should do`;
+      } else {
+        roleInstructions = `## Your Role: Lead (Review)\n\nReview the work done so far. Either:\n- Request specific changes from workers\n- Approve and signal completion if quality is sufficient\n- Merge PRs that pass CI using \`gh pr merge --squash --delete-branch\``;
+      }
+      break;
+    case 'scanner':
+      roleInstructions = `## Your Role: Scanner\n\nScan for issues, gaps, and opportunities. Report findings concisely. Do NOT fix anything — just discover and report.`;
+      break;
+    case 'worker':
+      roleInstructions = `## Your Role: Worker\n\nExecute the work assigned by the lead. Create branches, write code, open PRs to develop. Be focused and efficient.`;
+      break;
+    case 'verifier':
+      roleInstructions = `## Your Role: Verifier\n\nVerify that work meets quality standards. Check PRs, run tests, validate output. Report pass/fail with specifics.`;
+      break;
+  }
+
+  const prompt = `You are ${agentName} (${role}) in squad ${squadName}.
+
+Read your full agent definition at ${agentPath} and follow its instructions.
+
+${roleInstructions}
+
+${transcriptContext}
+
+IMPORTANT:
+- Be concise. Your output becomes part of a shared transcript.
+- Reference specific issue numbers, PR numbers, and file paths.
+- If you create a PR, include the PR number in your output.
+- If there's nothing to do, say "Nothing to do" clearly.
+- When done, summarize what you did in 2-3 sentences.`;
+
+  // Resolve model: CLI override > role default
+  const resolvedModel = config.model || modelForRole(role);
+
+  // Execute via claude --print (captures output)
+  const escapedPrompt = prompt.replace(/'/g, "'\\''");
+
+  try {
+    const output = execSync(
+      `claude --print --dangerously-skip-permissions --model ${resolvedModel} -- '${escapedPrompt}'`,
+      {
+        cwd: process.cwd(),
+        timeout: 15 * 60 * 1000, // 15 min per turn
+        maxBuffer: 10 * 1024 * 1024, // 10MB
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          CLAUDECODE: '', // Allow nested sessions
+          ANTHROPIC_API_KEY: undefined, // Use Max subscription
+        },
+      }
+    );
+    return output.trim();
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; message?: string };
+    // If the command produced output before failing, use it
+    if (error.stdout && error.stdout.trim().length > 0) {
+      return error.stdout.trim();
+    }
+    return `[ERROR] Agent ${agentName} failed: ${error.message || 'unknown error'}`;
+  }
+}
+
+// =============================================================================
+// Conversation Orchestrator
+// =============================================================================
+
+interface ClassifiedAgent {
+  name: string;
+  role: AgentRole;
+  path: string;
+}
+
+/**
+ * Build the turn order for a squad conversation.
+ * Returns agents grouped by role in execution order.
+ */
+function buildTurnPlan(squad: Squad, squadsDir: string): ClassifiedAgent[] {
+  const agents: ClassifiedAgent[] = [];
+
+  for (const agent of squad.agents) {
+    const role = classifyAgent(agent.name);
+    if (!role) continue; // Unclassified agents are excluded
+
+    const agentPath = join(squadsDir, squad.dir, `${agent.name}.md`);
+    if (!existsSync(agentPath)) continue;
+
+    agents.push({ name: agent.name, role, path: agentPath });
+  }
+
+  return agents;
+}
+
+export interface ConversationResult {
+  transcript: Transcript;
+  turnCount: number;
+  totalCost: number;
+  converged: boolean;
+  reason: string;
+}
+
+/**
+ * Run a full squad conversation.
+ *
+ * Turn order per cycle:
+ * 1. Lead briefs (or founder directive on first turn)
+ * 2. Scanners discover (parallel-safe but run sequentially for simplicity)
+ * 3. Workers execute
+ * 4. Lead reviews
+ * 5. Verifiers check (if workers produced output)
+ * 6. Check convergence → loop or exit
+ */
+export function runConversation(
+  squad: Squad,
+  options: ConversationOptions = {},
+): ConversationResult {
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) {
+    return {
+      transcript: createTranscript(squad.name),
+      turnCount: 0,
+      totalCost: 0,
+      converged: true,
+      reason: 'No squads directory found',
+    };
+  }
+
+  const maxTurns = options.maxTurns || DEFAULT_MAX_TURNS;
+  const costCeiling = options.costCeiling || DEFAULT_COST_CEILING;
+  const transcript = createTranscript(squad.name);
+
+  // Classify all agents
+  const allAgents = buildTurnPlan(squad, squadsDir);
+  const leads = allAgents.filter(a => a.role === 'lead');
+  const scanners = allAgents.filter(a => a.role === 'scanner');
+  const workers = allAgents.filter(a => a.role === 'worker');
+  const verifiers = allAgents.filter(a => a.role === 'verifier');
+
+  if (leads.length === 0) {
+    return {
+      transcript,
+      turnCount: 0,
+      totalCost: 0,
+      converged: true,
+      reason: 'No lead agent found — cannot orchestrate conversation',
+    };
+  }
+
+  const lead = leads[0]; // Primary lead
+  const log = (msg: string) => {
+    if (options.verbose) {
+      const ts = new Date().toISOString().slice(11, 19);
+      process.stderr.write(`  [${ts}] ${msg}\n`);
+    }
+  };
+
+  log(`Conversation: ${squad.name} | ${allAgents.length} agents | max ${maxTurns} turns | $${costCeiling} ceiling`);
+  log(`  Lead: ${lead.name} | Scanners: ${scanners.map(s => s.name).join(', ') || 'none'} | Workers: ${workers.map(w => w.name).join(', ') || 'none'} | Verifiers: ${verifiers.map(v => v.name).join(', ') || 'none'}`);
+
+  // === CYCLE LOOP ===
+  let cycleCount = 0;
+  const MAX_CYCLES = 5; // Safety: max 5 full cycles (lead→scan→work→review→verify)
+
+  while (cycleCount < MAX_CYCLES) {
+    cycleCount++;
+    log(`\n--- Cycle ${cycleCount} ---`);
+
+    // Step 1: Lead briefs
+    log(`Turn ${transcript.turns.length + 1}: ${lead.name} (lead)`);
+    const leadOutput = executeAgentTurn({
+      agentName: lead.name,
+      agentPath: lead.path,
+      role: 'lead',
+      squadName: squad.name,
+      model: options.model || modelForRole('lead'),
+      transcript,
+      task: cycleCount === 1 ? options.task : undefined,
+    });
+    addTurn(transcript, lead.name, 'lead', leadOutput, estimateTurnCost(options.model || 'sonnet'));
+
+    // Check convergence after lead
+    let conv = detectConvergence(transcript, maxTurns, costCeiling);
+    if (conv.converged) {
+      log(`Converged after lead: ${conv.reason}`);
+      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+    }
+
+    // Step 2: Scanners (only on first cycle)
+    if (cycleCount === 1 && scanners.length > 0) {
+      for (const scanner of scanners) {
+        log(`Turn ${transcript.turns.length + 1}: ${scanner.name} (scanner)`);
+        const output = executeAgentTurn({
+          agentName: scanner.name,
+          agentPath: scanner.path,
+          role: 'scanner',
+          squadName: squad.name,
+          model: options.model || modelForRole('scanner'),
+          transcript,
+        });
+        addTurn(transcript, scanner.name, 'scanner', output, estimateTurnCost(options.model || 'haiku'));
+
+        conv = detectConvergence(transcript, maxTurns, costCeiling);
+        if (conv.converged) {
+          return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+        }
+      }
+    }
+
+    // Step 3: Workers execute
+    for (const worker of workers) {
+      log(`Turn ${transcript.turns.length + 1}: ${worker.name} (worker)`);
+      const output = executeAgentTurn({
+        agentName: worker.name,
+        agentPath: worker.path,
+        role: 'worker',
+        squadName: squad.name,
+        model: options.model || modelForRole('worker'),
+        transcript,
+      });
+      addTurn(transcript, worker.name, 'worker', output, estimateTurnCost(options.model || 'sonnet'));
+
+      conv = detectConvergence(transcript, maxTurns, costCeiling);
+      if (conv.converged) {
+        return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+      }
+    }
+
+    // Step 4: Lead reviews worker output
+    log(`Turn ${transcript.turns.length + 1}: ${lead.name} (lead review)`);
+    const reviewOutput = executeAgentTurn({
+      agentName: lead.name,
+      agentPath: lead.path,
+      role: 'lead',
+      squadName: squad.name,
+      model: options.model || modelForRole('lead'),
+      transcript,
+    });
+    addTurn(transcript, lead.name, 'lead', reviewOutput, estimateTurnCost(options.model || 'sonnet'));
+
+    conv = detectConvergence(transcript, maxTurns, costCeiling);
+    if (conv.converged) {
+      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+    }
+
+    // Step 5: Verifiers (if we have them)
+    if (verifiers.length > 0) {
+      for (const verifier of verifiers) {
+        log(`Turn ${transcript.turns.length + 1}: ${verifier.name} (verifier)`);
+        const output = executeAgentTurn({
+          agentName: verifier.name,
+          agentPath: verifier.path,
+          role: 'verifier',
+          squadName: squad.name,
+          model: options.model || modelForRole('verifier'),
+          transcript,
+        });
+        addTurn(transcript, verifier.name, 'verifier', output, estimateTurnCost(options.model || 'haiku'));
+
+        conv = detectConvergence(transcript, maxTurns, costCeiling);
+        if (conv.converged) {
+          return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+        }
+      }
+    }
+  }
+
+  return {
+    transcript,
+    turnCount: transcript.turns.length,
+    totalCost: transcript.totalCost,
+    converged: false,
+    reason: `Max cycles reached (${MAX_CYCLES})`,
+  };
+}
+
+// =============================================================================
+// Transcript Persistence
+// =============================================================================
+
+/** Save conversation transcript to .agents/conversations/{squad}/ */
+export function saveTranscript(transcript: Transcript): string | null {
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return null;
+
+  const convDir = join(squadsDir, '..', 'conversations', transcript.squad);
+  if (!existsSync(convDir)) {
+    mkdirSync(convDir, { recursive: true });
+  }
+
+  const id = Date.now().toString(36);
+  const filePath = join(convDir, `${id}.md`);
+
+  const lines = [
+    `# Conversation: ${transcript.squad}`,
+    `Started: ${transcript.startedAt}`,
+    `Turns: ${transcript.turns.length}`,
+    `Estimated cost: $${transcript.totalCost.toFixed(2)}`,
+    '',
+    '---',
+    '',
+  ];
+
+  for (const turn of transcript.turns) {
+    lines.push(`## ${turn.agent} (${turn.role}) — ${turn.timestamp}`);
+    lines.push('');
+    lines.push(turn.content);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+  }
+
+  writeFileSync(filePath, lines.join('\n'));
+  return filePath;
+}


### PR DESCRIPTION
## Summary
- Implements the approved Squad Conversation Protocol (from 2026-03-05 plan)
- `squads run <squad>` now orchestrates a multi-agent conversation instead of just running the lead
- Lead briefs → scanners discover → workers execute → lead reviews → verifiers check → converge

## New Files
- `src/lib/conversation.ts` — Agent classification, transcript management, convergence detection
- `src/lib/workflow.ts` — Turn execution loop, orchestration, transcript persistence

## CLI Changes
- `squads run engineering` → runs full conversation (lead→scan→work→review→verify)
- `squads run engineering --task "fix CI"` → conversation with founder directive
- `squads run engineering -a issue-solver` → unchanged (single agent)
- New flags: `--task`, `--max-turns`, `--cost-ceiling`

## Architecture
- CLI manages turns (deterministic): who speaks when, convergence checking, cost limits
- Lead manages content (creative): what to work on, quality assessment, task routing
- Continuation signals beat convergence signals (bias toward completing work)
- Max 5 cycles, 20 turns, $25 cost ceiling (all configurable)
- Transcripts saved to `.agents/conversations/{squad}/`

## Test plan
- [x] `npm run typecheck` passes (0 errors)
- [x] `npm run build` passes
- [ ] CI passes
- [ ] Manual test: `squads run analytics --dry-run`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>