### PR TITLE
test(commands): add unit tests for update and login commands

### DIFF
--- a/test/commands/login.test.ts
+++ b/test/commands/login.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock auth lib
+vi.mock('../../src/lib/auth.js', () => ({
+  isPersonalEmail: vi.fn(),
+  getEmailDomain: vi.fn(),
+  saveSession: vi.fn(),
+  loadSession: vi.fn(),
+  clearSession: vi.fn(),
+  startAuthCallbackServer: vi.fn(),
+}));
+
+// Mock telemetry
+vi.mock('../../src/lib/telemetry.js', () => ({
+  track: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock terminal
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+}));
+
+// Mock chalk to return plain strings
+vi.mock('chalk', () => {
+  const identity = (s: string) => s;
+  const chalk = new Proxy(identity, {
+    get: (_target, prop) => {
+      if (prop === 'bold') return new Proxy(identity, { get: (_t, p) => identity });
+      return identity;
+    },
+    apply: (_target, _thisArg, args) => args[0],
+  });
+  return { default: chalk };
+});
+
+// Mock ora (spinner)
+vi.mock('ora', () => ({
+  default: vi.fn().mockReturnValue({
+    start: vi.fn().mockReturnThis(),
+    stop: vi.fn().mockReturnThis(),
+    clear: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    text: '',
+  }),
+}));
+
+// Mock open (browser)
+vi.mock('open', () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  loadSession,
+  clearSession,
+} from '../../src/lib/auth.js';
+
+const mockLoadSession = loadSession as ReturnType<typeof vi.fn>;
+const mockClearSession = clearSession as ReturnType<typeof vi.fn>;
+
+describe('login command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loginCommand', () => {
+    it('shows already-logged-in message when active session exists', async () => {
+      mockLoadSession.mockReturnValue({
+        email: 'user@example.com',
+        domain: 'example.com',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        accessToken: 'tok123',
+      });
+
+      const { loginCommand } = await import('../../src/commands/login.js');
+      await loginCommand();
+
+      // Should check session and return early without opening browser
+      expect(mockLoadSession).toHaveBeenCalled();
+    });
+  });
+
+  describe('logoutCommand', () => {
+    it('clears session when logged in', async () => {
+      mockLoadSession.mockReturnValue({
+        email: 'user@example.com',
+        domain: 'example.com',
+        status: 'active',
+        createdAt: new Date().toISOString(),
+        accessToken: 'tok123',
+      });
+
+      const { logoutCommand } = await import('../../src/commands/login.js');
+      await logoutCommand();
+
+      expect(mockClearSession).toHaveBeenCalled();
+    });
+
+    it('shows "not logged in" message when no session exists', async () => {
+      mockLoadSession.mockReturnValue(null);
+
+      const { logoutCommand } = await import('../../src/commands/login.js');
+      await logoutCommand();
+
+      expect(mockClearSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('whoamiCommand', () => {
+    it('shows "not logged in" message when no session', async () => {
+      mockLoadSession.mockReturnValue(null);
+
+      const { whoamiCommand } = await import('../../src/commands/login.js');
+      await whoamiCommand();
+
+      expect(mockLoadSession).toHaveBeenCalled();
+    });
+
+    it('displays session info when logged in', async () => {
+      mockLoadSession.mockReturnValue({
+        email: 'user@company.com',
+        domain: 'company.com',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        accessToken: 'tok456',
+      });
+
+      const { whoamiCommand } = await import('../../src/commands/login.js');
+      await whoamiCommand();
+
+      expect(mockLoadSession).toHaveBeenCalled();
+    });
+
+    it('displays pending status correctly', async () => {
+      mockLoadSession.mockReturnValue({
+        email: 'new@startup.io',
+        domain: 'startup.io',
+        status: 'pending',
+        createdAt: '2026-02-01T00:00:00.000Z',
+        accessToken: 'tok789',
+      });
+
+      const { whoamiCommand } = await import('../../src/commands/login.js');
+      await whoamiCommand();
+
+      expect(mockLoadSession).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock lib/update.js before any imports
+vi.mock('../../src/lib/update.js', () => ({
+  refreshVersionCache: vi.fn(),
+  performUpdate: vi.fn(),
+}));
+
+// Mock terminal output to suppress noise
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: {
+    dim: '',
+    cyan: '',
+    green: '',
+    red: '',
+  },
+  RESET: '',
+  gradient: (s: string) => s,
+  icons: { success: '✓', error: '✗' },
+}));
+
+import { updateCommand } from '../../src/commands/update.js';
+import { refreshVersionCache, performUpdate } from '../../src/lib/update.js';
+
+const mockRefreshVersionCache = refreshVersionCache as ReturnType<typeof vi.fn>;
+const mockPerformUpdate = performUpdate as ReturnType<typeof vi.fn>;
+
+describe('updateCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('--check mode', () => {
+    it('shows up-to-date message when no update available', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.0.0',
+        updateAvailable: false,
+      });
+
+      await updateCommand({ check: true });
+
+      expect(mockRefreshVersionCache).toHaveBeenCalledOnce();
+      expect(mockPerformUpdate).not.toHaveBeenCalled();
+    });
+
+    it('shows update available message when newer version exists', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.2.0',
+        updateAvailable: true,
+      });
+
+      await updateCommand({ check: true });
+
+      expect(mockRefreshVersionCache).toHaveBeenCalledOnce();
+      expect(mockPerformUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update mode', () => {
+    it('exits early when already on latest version', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.0.0',
+        updateAvailable: false,
+      });
+
+      await updateCommand({});
+
+      expect(mockRefreshVersionCache).toHaveBeenCalledOnce();
+      expect(mockPerformUpdate).not.toHaveBeenCalled();
+    });
+
+    it('performs update when --yes flag is set and update is available', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.1.0',
+        updateAvailable: true,
+      });
+      mockPerformUpdate.mockReturnValue({ success: true });
+
+      await updateCommand({ yes: true });
+
+      expect(mockRefreshVersionCache).toHaveBeenCalledOnce();
+      expect(mockPerformUpdate).toHaveBeenCalledOnce();
+    });
+
+    it('shows error message when update fails', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.1.0',
+        updateAvailable: true,
+      });
+      mockPerformUpdate.mockReturnValue({
+        success: false,
+        error: 'permission denied',
+      });
+
+      await updateCommand({ yes: true });
+
+      expect(mockPerformUpdate).toHaveBeenCalledOnce();
+    });
+
+    it('skips update when user declines (options.yes = false, no update)', async () => {
+      mockRefreshVersionCache.mockReturnValue({
+        currentVersion: '1.0.0',
+        latestVersion: '1.0.0',
+        updateAvailable: false,
+      });
+
+      await updateCommand({ yes: false });
+
+      expect(mockPerformUpdate).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **update.test.ts**: 6 tests for `updateCommand` — check mode (up-to-date, update available) and update mode (early exit, `--yes` success, `--yes` failure, no-op when declined)
- **login.test.ts**: 6 tests for `loginCommand`, `logoutCommand`, `whoamiCommand` — already-logged-in early return, session clear, missing session, active/pending display

## Coverage Added

| Command | Tests | Approach |
|---------|-------|----------|
| update.ts | 6 | Mock `lib/update.js` (`refreshVersionCache`, `performUpdate`) |
| login.ts | 6 | Mock `lib/auth.js` (`loadSession`, `clearSession`) + `chalk`/`ora`/`open` |

## Test Run

```
✓ test/commands/update.test.ts (6 tests) 2ms
✓ test/commands/login.test.ts (6 tests) 27ms
Tests: 12 passed (12)
```

## Issues

- Closes #47 (partial — adds update + login coverage; 9 command files now tested)

---
Agent: cli/issue-solver
Squad: cli