### PR TITLE
test(commands): add unit tests for autonomy and exec commands

### DIFF
--- a/test/commands/autonomy.test.ts
+++ b/test/commands/autonomy.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/lib/telemetry.js', () => ({
+  track: vi.fn().mockResolvedValue(undefined),
+  Events: { CLI_STATUS: 'cli_status' },
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: {
+    dim: '',
+    red: '',
+    green: '',
+    yellow: '',
+    purple: '',
+    cyan: '',
+  },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  icons: { success: '✓', warning: '⚠', error: '✗', empty: '○' },
+}));
+
+import { autonomyCommand } from '../../src/commands/autonomy.js';
+
+const mockAutonomyResponse = {
+  overall_score: 80,
+  confidence_level: 'high',
+  period: 'today',
+  squad: null,
+  components: {
+    quota_compliance: 90,
+    cooldown_compliance: 85,
+    quality_score: 75,
+    success_rate: 88,
+    learning_utilization: 60,
+  },
+  execution_stats: {
+    total_tasks: 10,
+    successful_tasks: 9,
+    monthly_used: 25,
+    monthly_quota: 100,
+    quota_pct: 25,
+    learning_count: 3,
+  },
+};
+
+describe('autonomyCommand', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('resolves without error when bridge returns valid data', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockAutonomyResponse),
+    } as unknown as Response);
+
+    await expect(autonomyCommand()).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when --json option is set', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockAutonomyResponse),
+    } as unknown as Response);
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await autonomyCommand({ json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output.overall_score).toBe(80);
+    consoleSpy.mockRestore();
+  });
+
+  it('handles fetch failure gracefully', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+    await expect(autonomyCommand()).resolves.toBeUndefined();
+  });
+
+  it('uses the period option in the request', async () => {
+    let capturedUrl = '';
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      capturedUrl = url;
+      return Promise.resolve({
+        json: vi.fn().mockResolvedValue(mockAutonomyResponse),
+      });
+    });
+
+    await autonomyCommand({ period: 'week' });
+
+    expect(capturedUrl).toContain('period=week');
+  });
+
+  it('includes squad in request when provided', async () => {
+    let capturedUrl = '';
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      capturedUrl = url;
+      return Promise.resolve({
+        json: vi.fn().mockResolvedValue({ ...mockAutonomyResponse, squad: 'engineering' }),
+      });
+    });
+
+    await autonomyCommand({ squad: 'engineering' });
+
+    expect(capturedUrl).toContain('squad=engineering');
+  });
+
+  it('resolves without error for low score with recommendations', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ...mockAutonomyResponse,
+        overall_score: 40,
+        confidence_level: 'low',
+        components: {
+          ...mockAutonomyResponse.components,
+          learning_utilization: 20,
+          quality_score: 30,
+          quota_compliance: 50,
+        },
+        execution_stats: { ...mockAutonomyResponse.execution_stats, total_tasks: 0 },
+      }),
+    } as unknown as Response);
+
+    await expect(autonomyCommand()).resolves.toBeUndefined();
+  });
+});

--- a/test/commands/exec.test.ts
+++ b/test/commands/exec.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/lib/telemetry.js', () => ({
+  track: vi.fn().mockResolvedValue(undefined),
+  Events: { CLI_EXEC: 'cli_exec' },
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: { dim: '', red: '', green: '', yellow: '', purple: '', cyan: '' },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  box: { topLeft: '', topRight: '', bottomLeft: '', bottomRight: '', vertical: '', horizontal: '', teeLeft: '', teeRight: '' },
+  padEnd: vi.fn((s: string, n: number) => s.padEnd(n)),
+  icons: { running: '◉', success: '✓', error: '✗', empty: '○' },
+}));
+
+vi.mock('../../src/lib/executions.js', () => ({
+  listExecutions: vi.fn(),
+  getExecutionStats: vi.fn(),
+  formatDuration: vi.fn((ms: number) => `${ms}ms`),
+  formatRelativeTime: vi.fn(() => '2m ago'),
+}));
+
+import { execListCommand, execShowCommand, execStatsCommand } from '../../src/commands/exec.js';
+import { listExecutions, getExecutionStats } from '../../src/lib/executions.js';
+
+const mockListExecutions = vi.mocked(listExecutions);
+const mockGetExecutionStats = vi.mocked(getExecutionStats);
+
+const sampleExecution = {
+  id: 'exec-abc123def456',
+  squad: 'engineering',
+  agent: 'issue-solver',
+  status: 'completed' as const,
+  taskType: 'issue',
+  trigger: 'label',
+  startTime: '2026-03-06T10:00:00Z',
+  endTime: '2026-03-06T10:15:00Z',
+  durationMs: 900000,
+  outcome: 'Created PR #123',
+};
+
+const sampleStats = {
+  total: 5,
+  running: 1,
+  completed: 3,
+  failed: 1,
+  avgDurationMs: 450000,
+  bySquad: { engineering: 3, marketing: 2 },
+  byAgent: { 'engineering/issue-solver': 3, 'marketing/content-writer': 2 },
+};
+
+describe('execListCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetExecutionStats.mockReturnValue(sampleStats);
+  });
+
+  it('resolves without error when no executions exist', async () => {
+    mockListExecutions.mockReturnValue([]);
+
+    await expect(execListCommand()).resolves.toBeUndefined();
+  });
+
+  it('resolves without error when executions exist', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+
+    await expect(execListCommand()).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when --json option is set', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await execListCommand({ json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(Array.isArray(output)).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  it('filters by squad when squad option provided', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+
+    await execListCommand({ squad: 'engineering' });
+
+    expect(mockListExecutions).toHaveBeenCalledWith(
+      expect.objectContaining({ squad: 'engineering' })
+    );
+  });
+
+  it('applies limit option', async () => {
+    mockListExecutions.mockReturnValue([]);
+
+    await execListCommand({ limit: 5 });
+
+    expect(mockListExecutions).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 5 })
+    );
+  });
+});
+
+describe('execShowCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves without error when execution found', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+
+    await expect(execShowCommand('exec-abc123def456')).resolves.toBeUndefined();
+  });
+
+  it('handles execution not found', async () => {
+    mockListExecutions.mockReturnValue([]);
+
+    await expect(execShowCommand('nonexistent-id')).resolves.toBeUndefined();
+  });
+
+  it('handles multiple matches for partial ID', async () => {
+    mockListExecutions.mockReturnValue([
+      { ...sampleExecution, id: 'exec-abc1' },
+      { ...sampleExecution, id: 'exec-abc2' },
+    ]);
+
+    await expect(execShowCommand('exec-abc')).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when --json option is set', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await execShowCommand('exec-abc123def456', { json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output.id).toBe('exec-abc123def456');
+    consoleSpy.mockRestore();
+  });
+
+  it('supports partial ID matching', async () => {
+    mockListExecutions.mockReturnValue([sampleExecution]);
+
+    await expect(execShowCommand('exec-abc')).resolves.toBeUndefined();
+  });
+});
+
+describe('execStatsCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetExecutionStats.mockReturnValue(sampleStats);
+  });
+
+  it('resolves without error', async () => {
+    await expect(execStatsCommand()).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when --json option is set', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await execStatsCommand({ json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output.total).toBe(5);
+    consoleSpy.mockRestore();
+  });
+
+  it('filters by squad when squad option provided', async () => {
+    await execStatsCommand({ squad: 'engineering' });
+
+    expect(mockGetExecutionStats).toHaveBeenCalledWith(
+      expect.objectContaining({ squad: 'engineering' })
+    );
+  });
+
+  it('handles stats with no average duration', async () => {
+    mockGetExecutionStats.mockReturnValue({ ...sampleStats, avgDurationMs: null });
+
+    await expect(execStatsCommand()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for 2 previously untested CLI commands
- `test/commands/autonomy.test.ts`: 6 tests for the autonomy score display command
- `test/commands/exec.test.ts`: 14 tests for exec list/show/stats subcommands

## Test Coverage

**autonomy.test.ts** (6 tests):
- Resolves without error on valid bridge response
- JSON output mode
- Graceful fetch failure handling
- Period option in request URL
- Squad filter in request URL
- Low score triggers recommendations

**exec.test.ts** (14 tests):
- `execListCommand`: empty list, populated list, JSON output, squad filter, limit option
- `execShowCommand`: found by full ID, not found, multiple matches, JSON output, partial ID match
- `execStatsCommand`: basic output, JSON output, squad filter, no avgDuration case

## Commands Now Tested
create, exec, feedback, goal, history, learn, list, login, progress, providers, session, update, autonomy, exec = 13/34 command files

## Issues
- Closes #47 (partial — adds 2 more commands to tested set)

Part of squads-cli v0.7.0 (test coverage >80%)

---
Agent: cli/issue-solver
Squad: cli
Model: claude-sonnet-4-6