### PR TITLE
test(commands): add unit tests for results, cost, and trigger commands

### DIFF
--- a/test/commands/cost.test.ts
+++ b/test/commands/cost.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/lib/telemetry.js', () => ({
+  track: vi.fn().mockResolvedValue(undefined),
+  Events: { CLI_COST: 'cli_cost' },
+}));
+
+vi.mock('../../src/lib/costs.js', () => ({
+  fetchBridgeStats: vi.fn(),
+  detectPlan: vi.fn(),
+}));
+
+vi.mock('../../src/lib/squad-parser.js', () => ({
+  findSquadsDir: vi.fn(),
+  listSquads: vi.fn(),
+  loadSquad: vi.fn(),
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: { dim: '', red: '', green: '', yellow: '', purple: '', cyan: '' },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  box: {
+    topLeft: '┌', topRight: '┐', bottomLeft: '└', bottomRight: '┘',
+    vertical: '│', horizontal: '─', teeLeft: '┤', teeRight: '├',
+  },
+  padEnd: vi.fn((s: string, n: number) => s.padEnd(n)),
+}));
+
+import { costCommand, budgetCheckCommand } from '../../src/commands/cost.js';
+import { fetchBridgeStats, detectPlan } from '../../src/lib/costs.js';
+import { findSquadsDir, listSquads, loadSquad } from '../../src/lib/squad-parser.js';
+
+const mockFetchBridgeStats = vi.mocked(fetchBridgeStats);
+const mockDetectPlan = vi.mocked(detectPlan);
+const mockFindSquadsDir = vi.mocked(findSquadsDir);
+const mockListSquads = vi.mocked(listSquads);
+const mockLoadSquad = vi.mocked(loadSquad);
+
+const sampleStats = {
+  today: { costUsd: 1.50, generations: 25, inputTokens: 100000, outputTokens: 20000 },
+  week: { costUsd: 8.75, generations: 120, inputTokens: 500000, outputTokens: 100000 },
+  budget: { used: 1.50, daily: 10, usedPct: 15 },
+  bySquad: [
+    { squad: 'engineering', costUsd: 0.80, generations: 15 },
+    { squad: 'marketing', costUsd: 0.70, generations: 10 },
+  ],
+  byModel: [
+    { model: 'claude-sonnet-4-5', costUsd: 1.20, generations: 20 },
+    { model: 'claude-haiku-4-5', costUsd: 0.30, generations: 5 },
+  ],
+  source: 'bridge' as const,
+};
+
+const samplePlan = {
+  plan: 'max' as const,
+  reason: 'CLAUDE_MAX_SUBSCRIPTION=true',
+  costPerToken: null,
+};
+
+const squadWithBudget = {
+  name: 'engineering',
+  goals: [],
+  context: { budget: { daily: 5, weekly: 25 } },
+  agents: [],
+  routines: [],
+};
+
+describe('costCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDetectPlan.mockReturnValue(samplePlan);
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockListSquads.mockReturnValue(['engineering']);
+    mockLoadSquad.mockReturnValue(squadWithBudget as ReturnType<typeof loadSquad>);
+  });
+
+  it('resolves without error with valid stats', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+
+    await expect(costCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles bridge unavailable (null stats)', async () => {
+    mockFetchBridgeStats.mockResolvedValue(null);
+
+    await expect(costCommand()).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when --json option is set', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await costCommand({ json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output).toHaveProperty('today');
+    consoleSpy.mockRestore();
+  });
+
+  it('outputs JSON for null stats when --json is set', async () => {
+    mockFetchBridgeStats.mockResolvedValue(null);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await costCommand({ json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output).toHaveProperty('error');
+    consoleSpy.mockRestore();
+  });
+
+  it('shows squad detail when squad option provided', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+
+    await expect(costCommand({ squad: 'engineering' })).resolves.toBeUndefined();
+  });
+
+  it('handles squad not found in stats', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+
+    await expect(costCommand({ squad: 'unknown-squad' })).resolves.toBeUndefined();
+  });
+
+  it('handles budget over 100%', async () => {
+    mockFetchBridgeStats.mockResolvedValue({
+      ...sampleStats,
+      budget: { used: 12, daily: 10, usedPct: 120 },
+    });
+
+    await expect(costCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles stats without week data', async () => {
+    const statsWithoutWeek = { ...sampleStats, week: undefined };
+    mockFetchBridgeStats.mockResolvedValue(statsWithoutWeek as typeof sampleStats);
+
+    await expect(costCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles squad with no budget defined', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+    mockLoadSquad.mockReturnValue({
+      ...squadWithBudget,
+      context: {},
+    } as ReturnType<typeof loadSquad>);
+
+    await expect(costCommand({ squad: 'engineering' })).resolves.toBeUndefined();
+  });
+
+  it('outputs squad JSON when squad + json options set', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await costCommand({ squad: 'engineering', json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('budgetCheckCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDetectPlan.mockReturnValue(samplePlan);
+    mockLoadSquad.mockReturnValue(squadWithBudget as ReturnType<typeof loadSquad>);
+  });
+
+  it('resolves without error when bridge is available', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+
+    await expect(budgetCheckCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('handles bridge unavailable', async () => {
+    mockFetchBridgeStats.mockResolvedValue(null);
+
+    await expect(budgetCheckCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when bridge unavailable and json set', async () => {
+    mockFetchBridgeStats.mockResolvedValue(null);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await budgetCheckCommand('engineering', { json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output).toHaveProperty('error');
+    consoleSpy.mockRestore();
+  });
+
+  it('shows warning when approaching budget limit', async () => {
+    mockFetchBridgeStats.mockResolvedValue({
+      ...sampleStats,
+      bySquad: [{ squad: 'engineering', costUsd: 4.5, generations: 50 }],
+    });
+
+    await expect(budgetCheckCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('shows over-budget status', async () => {
+    mockFetchBridgeStats.mockResolvedValue({
+      ...sampleStats,
+      bySquad: [{ squad: 'engineering', costUsd: 6.0, generations: 80 }],
+    });
+
+    await expect(budgetCheckCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('shows no-budget status when squad has no budget', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+    mockLoadSquad.mockReturnValue({
+      ...squadWithBudget,
+      context: {},
+    } as ReturnType<typeof loadSquad>);
+
+    await expect(budgetCheckCommand('unknown')).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON with budget status', async () => {
+    mockFetchBridgeStats.mockResolvedValue(sampleStats);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await budgetCheckCommand('engineering', { json: true });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(output).toHaveProperty('squad', 'engineering');
+    consoleSpy.mockRestore();
+  });
+});

--- a/test/commands/results.test.ts
+++ b/test/commands/results.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('../../src/lib/squad-parser.js', () => ({
+  findSquadsDir: vi.fn(),
+  listSquads: vi.fn(),
+  loadSquad: vi.fn(),
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: { dim: '', red: '', green: '', yellow: '', purple: '', cyan: '' },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  box: {
+    topLeft: '┌', topRight: '┐', bottomLeft: '└', bottomRight: '┘',
+    vertical: '│', horizontal: '─', teeLeft: '┤', teeRight: '├',
+  },
+  padEnd: vi.fn((s: string, n: number) => s.padEnd(n)),
+  truncate: vi.fn((s: string) => s),
+  icons: { progress: '◉', empty: '○' },
+}));
+
+import { resultsCommand } from '../../src/commands/results.js';
+import { findSquadsDir, listSquads, loadSquad } from '../../src/lib/squad-parser.js';
+import { execSync } from 'child_process';
+
+const mockFindSquadsDir = vi.mocked(findSquadsDir);
+const mockListSquads = vi.mocked(listSquads);
+const mockLoadSquad = vi.mocked(loadSquad);
+const mockExecSync = vi.mocked(execSync);
+
+const sampleSquad = {
+  name: 'engineering',
+  goals: [
+    { description: 'Ship v0.7.0', metrics: ['prs_merged'], completed: false },
+    { description: 'Reduce costs', metrics: ['cost_usd'], completed: true },
+  ],
+  context: {},
+  agents: [],
+  routines: [],
+};
+
+describe('resultsCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockListSquads.mockReturnValue(['engineering']);
+    mockLoadSquad.mockReturnValue(sampleSquad as ReturnType<typeof loadSquad>);
+    mockExecSync.mockReturnValue('' as ReturnType<typeof execSync>);
+  });
+
+  it('resolves without error with default options', async () => {
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('resolves when no .agents directory found', async () => {
+    mockFindSquadsDir.mockReturnValue(null);
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('resolves for a specific squad', async () => {
+    await expect(resultsCommand({ squad: 'engineering' })).resolves.toBeUndefined();
+  });
+
+  it('resolves with verbose mode', async () => {
+    await expect(resultsCommand({ verbose: true })).resolves.toBeUndefined();
+  });
+
+  it('resolves with custom days option', async () => {
+    await expect(resultsCommand({ days: '30' })).resolves.toBeUndefined();
+  });
+
+  it('handles squad with no goals', async () => {
+    mockLoadSquad.mockReturnValue({ ...sampleSquad, goals: [] } as ReturnType<typeof loadSquad>);
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles squad with only completed goals', async () => {
+    mockLoadSquad.mockReturnValue({
+      ...sampleSquad,
+      goals: [{ description: 'Done', metrics: [], completed: true }],
+    } as ReturnType<typeof loadSquad>);
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles squad not found via loadSquad', async () => {
+    mockLoadSquad.mockReturnValue(null);
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('handles execSync throwing (not in git repo)', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+
+  it('uses metrics from goal.metrics when present', async () => {
+    mockLoadSquad.mockReturnValue({
+      ...sampleSquad,
+      goals: [{ description: 'Revenue goal', metrics: ['revenue_usd', 'leads'], completed: false }],
+    } as ReturnType<typeof loadSquad>);
+
+    await expect(resultsCommand({ squad: 'engineering', verbose: true })).resolves.toBeUndefined();
+  });
+
+  it('infers metrics from goal description when no metrics defined', async () => {
+    mockLoadSquad.mockReturnValue({
+      ...sampleSquad,
+      goals: [{ description: 'Increase revenue and leads', metrics: [], completed: false }],
+    } as ReturnType<typeof loadSquad>);
+
+    await expect(resultsCommand({ squad: 'engineering', verbose: true })).resolves.toBeUndefined();
+  });
+
+  it('handles multiple squads', async () => {
+    mockListSquads.mockReturnValue(['engineering', 'marketing', 'product']);
+    mockLoadSquad.mockReturnValue(sampleSquad as ReturnType<typeof loadSquad>);
+
+    await expect(resultsCommand()).resolves.toBeUndefined();
+  });
+});

--- a/test/commands/trigger.test.ts
+++ b/test/commands/trigger.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+}));
+
+// Mock chalk since trigger.ts uses it directly
+vi.mock('chalk', () => {
+  const identity = (s: string) => s;
+  const chalk = new Proxy(identity, {
+    get: () => new Proxy(identity, { get: () => identity }),
+  });
+  chalk.bold = identity;
+  chalk.gray = identity;
+  chalk.red = identity;
+  chalk.green = identity;
+  chalk.yellow = identity;
+  chalk.cyan = identity;
+  return { default: chalk };
+});
+
+import { registerTriggerCommand } from '../../src/commands/trigger.js';
+
+const sampleTriggers = [
+  {
+    id: 'trig-001',
+    name: 'issue_labeled_squad',
+    squad: 'engineering',
+    agent: 'issue-solver',
+    enabled: true,
+    priority: 1,
+    cooldown: '30m',
+    last_fired: '2026-03-06T10:00:00Z',
+    fire_count: 5,
+  },
+  {
+    id: 'trig-002',
+    name: 'daily_standup',
+    squad: 'marketing',
+    agent: null,
+    enabled: false,
+    priority: 2,
+    cooldown: '24h',
+    last_fired: null,
+    fire_count: 0,
+  },
+];
+
+const sampleStats = {
+  triggers: { total: 2, enabled: 1, fired_24h: 3 },
+  executions_24h: { total_24h: 5, completed: 4, failed: 1, running: 0, queued: 0 },
+};
+
+describe('registerTriggerCommand', () => {
+  let program: Command;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    vi.clearAllMocks();
+    program = new Command();
+    program.exitOverride(); // prevent process.exit in tests
+    registerTriggerCommand(program);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('registers the trigger command on the program', () => {
+    const triggerCmd = program.commands.find(c => c.name() === 'trigger');
+    expect(triggerCmd).toBeDefined();
+  });
+
+  it('registers all expected subcommands', () => {
+    const triggerCmd = program.commands.find(c => c.name() === 'trigger')!;
+    const subcommandNames = triggerCmd.commands.map(c => c.name());
+    expect(subcommandNames).toContain('list');
+    expect(subcommandNames).toContain('sync');
+    expect(subcommandNames).toContain('fire');
+    expect(subcommandNames).toContain('enable');
+    expect(subcommandNames).toContain('disable');
+    expect(subcommandNames).toContain('status');
+  });
+
+  it('trigger list succeeds when scheduler returns triggers', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(sampleTriggers),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'list'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger list handles empty triggers list', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([]),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'list'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger list handles scheduler offline (connection refused)', async () => {
+    const connError = new Error('fetch failed');
+    (connError as NodeJS.ErrnoException).cause = new Error('ECONNREFUSED');
+    global.fetch = vi.fn().mockRejectedValue(connError);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'list'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger list filters by squad', async () => {
+    let capturedUrl = '';
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      capturedUrl = url;
+      return Promise.resolve({
+        ok: true,
+        json: vi.fn().mockResolvedValue(sampleTriggers),
+      });
+    });
+
+    await program.parseAsync(['node', 'squads', 'trigger', 'list', 'engineering']);
+
+    expect(capturedUrl).toContain('squad=engineering');
+  });
+
+  it('trigger sync handles scheduler offline', async () => {
+    const connError = new Error('fetch failed');
+    global.fetch = vi.fn().mockRejectedValue(connError);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'sync'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger sync succeeds with valid response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ synced: 3, triggers: ['t1', 't2', 't3'], errors: [] }),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'sync'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger sync shows errors when sync has partial failures', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        synced: 1,
+        triggers: ['t1'],
+        errors: [{ name: 'broken-trigger', error: 'Invalid config' }],
+      }),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'sync'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger status shows scheduler stats', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(sampleStats),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'status'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger status handles scheduler offline', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'status'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger enable updates trigger', async () => {
+    // First fetch: list triggers, second fetch: patch trigger
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(sampleTriggers),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ ...sampleTriggers[0], enabled: true }),
+      });
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'enable', 'issue_labeled_squad'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger disable updates trigger', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(sampleTriggers),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ ...sampleTriggers[0], enabled: false }),
+      });
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'disable', 'issue_labeled_squad'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger enable handles unknown trigger name', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(sampleTriggers),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'enable', 'nonexistent'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger fire queues an execution', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue(sampleTriggers),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ id: 'exec-abc123', status: 'queued' }),
+      });
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'fire', 'issue_labeled_squad'])
+    ).resolves.toBeDefined();
+  });
+
+  it('trigger fire handles unknown trigger', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(sampleTriggers),
+    } as unknown as Response);
+
+    await expect(
+      program.parseAsync(['node', 'squads', 'trigger', 'fire', 'nonexistent'])
+    ).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds 45 unit tests covering 3 previously untested command files for issue #47:

- **results.test.ts** (12 tests): `resultsCommand` — squads results display, squad-parser mocks, execSync error handling, verbose mode, multi-squad, goals without metrics
- **cost.test.ts** (17 tests): `costCommand` + `budgetCheckCommand` — bridge stats mocking, bridge unavailable, JSON output, budget warning/over thresholds, squad filter, plan detection
- **trigger.test.ts** (16 tests): `registerTriggerCommand` via Commander `parseAsync` — all 6 subcommands (list, sync, fire, enable, disable, status) with fetch mocking for online/offline scheduler scenarios

## Test counts

- Before: 1170 tests (from develop)
- After: 1215 tests (+45)
- All passing

## Commands now tested (test/commands/)

create, feedback, goal, history, learn, list, login, progress, providers, session, update, autonomy, exec + **results, cost, trigger** = **16 of ~34 command files**

## Issues

Closes #47 (partial — 16/~34 command files tested)

Part of v0.7.0 milestone (76% complete, 10/13).

---

| Attribution | Value |
|-------------|-------|
| Agent | cli/issue-solver |
| Squad | cli |
| Model | claude-sonnet-4-6 |