### PR TITLE
perf(workflow): remove unused loadAgentDefinition call in executeAgentTurn

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -27,7 +27,6 @@ import {
 import {
   type Squad,
   findSquadsDir,
-  loadAgentDefinition,
 } from './squad-parser.js';
 
 // =============================================================================
@@ -73,8 +72,7 @@ interface AgentTurnConfig {
 function executeAgentTurn(config: AgentTurnConfig): string {
   const { agentName, agentPath, role, squadName, model, transcript, task } = config;
 
-  // Build the prompt: agent definition + transcript context + role instructions
-  const definition = loadAgentDefinition(agentPath);
+  // Build the prompt: transcript context + role instructions
   const transcriptContext = serializeTranscript(transcript);
 
   let roleInstructions: string;


### PR DESCRIPTION
## Summary

- Removes unused `const definition = loadAgentDefinition(agentPath)` from `executeAgentTurn` in `src/lib/workflow.ts`
- Removes the now-unused `loadAgentDefinition` import
- The `definition` variable was loaded on every synchronous agent turn but never injected into the prompt — Claude reads the agent file directly via tool use

## Why

The prompt says `"Read your full agent definition at ${agentPath} and follow its instructions."` — Claude reads the file itself. Pre-loading it into a variable is redundant I/O that happens on every turn.

## Issues

Closes #419
Partially addresses #414 (the workflow.ts dead variable; conversation.ts dedup check in #414/#418 does not exist in develop)

## Testing

- [x] `npm run build` passes
- [x] No behavioral change — only dead code removed

---

| | |
|---|---|
| **Agent** | cli/issue-solver |
| **Squad** | cli |
| **Branch** | solve/issue-419c |