### PR TITLE
fix(workflow,conversation): address issues #415 #417 #419

### DIFF
--- a/src/lib/conversation.ts
+++ b/src/lib/conversation.ts
@@ -127,6 +127,19 @@ const CONVERGENCE_PHRASES = [
   'no open issues', 'no pending tasks', 'no pending issues',
 ];
 
+/** Phrases in a verifier turn that signal approval → converge */
+const VERIFIER_APPROVAL_PHRASES = [
+  'approved', 'lgtm', 'looks good',
+  'all checks pass', 'all tests pass', 'tests pass',
+  'passed', 'quality standards met',
+];
+
+/** Phrases in a verifier turn that signal rejection → continue cycle */
+const VERIFIER_REJECTION_PHRASES = [
+  'failed', 'rejected', 'needs fixes', 'needs changes',
+  'does not pass', 'did not pass', 'failing',
+];
+
 /** Phrases that indicate more work needed */
 const CONTINUATION_PHRASES = [
   'needs review', 'needs feedback', 'needs input', 'need clarification',
@@ -166,9 +179,21 @@ export function detectConvergence(
 
   const lastTurn = transcript.turns[transcript.turns.length - 1];
   const content = lastTurn.content;
+  const lower = content.toLowerCase();
+
+  // Verifier turns: check approval/rejection before generic signals
+  if (lastTurn.role === 'verifier') {
+    const rejected = VERIFIER_REJECTION_PHRASES.some(phrase => lower.includes(phrase));
+    if (rejected) {
+      return { converged: false, reason: 'Verifier rejected — continuing cycle' };
+    }
+    const approved = VERIFIER_APPROVAL_PHRASES.some(phrase => lower.includes(phrase));
+    if (approved) {
+      return { converged: true, reason: 'Verifier approved' };
+    }
+  }
 
   // Continuation signals beat convergence (bias toward completing work)
-  const lower = content.toLowerCase();
   const hasContinuation = CONTINUATION_PHRASES.some(phrase => lower.includes(phrase));
   if (hasContinuation) {
     return { converged: false, reason: 'Continuation signal detected' };

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -27,7 +27,6 @@ import {
 import {
   type Squad,
   findSquadsDir,
-  loadAgentDefinition,
 } from './squad-parser.js';
 
 // =============================================================================
@@ -74,7 +73,6 @@ function executeAgentTurn(config: AgentTurnConfig): string {
   const { agentName, agentPath, role, squadName, model, transcript, task } = config;
 
   // Build the prompt: agent definition + transcript context + role instructions
-  const definition = loadAgentDefinition(agentPath);
   const transcriptContext = serializeTranscript(transcript);
 
   let roleInstructions: string;
@@ -411,6 +409,9 @@ export async function runConversation(
         transcript,
         cwd: squadCwd,
       });
+      if (output.startsWith('[ERROR]')) {
+        process.stderr.write(`  [WARN] Worker ${workers[0].name} errored: ${output}\n`);
+      }
       addTurn(transcript, workers[0].name, 'worker', output, estimateTurnCost(options.model || 'sonnet'));
     } else if (workers.length > 1) {
       log(`Turns ${transcript.turns.length + 1}-${transcript.turns.length + workers.length}: ${workers.map(w => w.name).join(', ')} (workers, parallel)`);
@@ -427,6 +428,9 @@ export async function runConversation(
       );
       const workerResults = await Promise.all(workerPromises);
       for (const { agent, output } of workerResults) {
+        if (output.startsWith('[ERROR]')) {
+          process.stderr.write(`  [WARN] Worker ${agent.name} errored: ${output}\n`);
+        }
         addTurn(transcript, agent.name, 'worker', output, estimateTurnCost(options.model || 'sonnet'));
       }
     }


### PR DESCRIPTION
## Summary

- **#419**: Remove unused `loadAgentDefinition()` call in `executeAgentTurn` — file was read from disk on every turn but never used (perf fix)
- **#417**: `detectConvergence` now checks `turn.role === 'verifier'` first — verifier approval phrases now correctly converge the loop; rejection phrases continue the cycle
- **#415**: Worker `[ERROR]` outputs now emit a `[WARN]` to stderr so errors are visible before the lead review turn

## Test plan
- [ ] `npm run build` passes ✓
- [ ] Unit tests pass (68 test files, 1333 tests) ✓
- [ ] e2e test failures are pre-existing (ENOTEMPTY race conditions unrelated to this PR)

Closes #415, #417, #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)