### PR TITLE
perf(workflow): remove unused agent definition file read in executeAgentTurn

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -27,7 +27,6 @@ import {
 import {
   type Squad,
   findSquadsDir,
-  loadAgentDefinition,
 } from './squad-parser.js';
 
 // =============================================================================
@@ -73,8 +72,7 @@ interface AgentTurnConfig {
 function executeAgentTurn(config: AgentTurnConfig): string {
   const { agentName, agentPath, role, squadName, model, transcript, task } = config;
 
-  // Build the prompt: agent definition + transcript context + role instructions
-  const definition = loadAgentDefinition(agentPath);
+  // Build the prompt: transcript context + role instructions
   const transcriptContext = serializeTranscript(transcript);
 
   let roleInstructions: string;


### PR DESCRIPTION
## Summary

- Removes unused `const definition = loadAgentDefinition(agentPath)` call in `executeAgentTurn` — the result was never referenced in the prompt or elsewhere in the function
- Removes the now-unused `loadAgentDefinition` import from `./squad-parser.js`
- `loadAgentDefinition` is still correctly used in `executeGeminiTurn`, which embeds the definition directly in the prompt

## Impact

Eliminates one unnecessary disk read per agent turn. Over a full conversation with multiple agents and cycles, this compounds.

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1291 tests pass (`npm test` run directly — 68 test files, 1291 tests)
- [x] No functional change: `executeAgentTurn` builds its prompt the same way (references `agentPath` directly in the prompt string, telling the agent to read its own definition)

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)