### PR TITLE
fix(workflow): prevent [ERROR] worker turns from silently skipping lead review

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -431,9 +431,17 @@ export async function runConversation(
       }
     }
 
-    conv = detectConvergence(transcript, maxTurns, costCeiling);
-    if (conv.converged) {
-      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+    // If any worker returned an error, skip convergence check so the lead always
+    // gets a chance to review the error and decide how to respond.
+    const workerTurnsWithErrors = workers.length > 0
+      ? transcript.turns.filter(t => t.role === 'worker').slice(-workers.length).some(t => t.content.startsWith('[ERROR]'))
+      : false;
+
+    if (!workerTurnsWithErrors) {
+      conv = detectConvergence(transcript, maxTurns, costCeiling);
+      if (conv.converged) {
+        return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+      }
     }
 
     // Step 4: Lead reviews worker output


### PR DESCRIPTION
## Summary

- `detectConvergence` after step 3 (workers) checks only the **last turn** in the transcript. With parallel workers, a successful worker's convergence signal (e.g. "pr created") could cause an early return, silently discarding an `[ERROR]` result from another worker and skipping the lead review step entirely.
- Fix: before calling `detectConvergence` after workers, check whether any worker turn in the current cycle starts with `[ERROR]`. If so, skip convergence and always proceed to lead review.
- This is a minimal, targeted change — no refactoring of surrounding code.

## Test plan

- [ ] Build passes: `npm run build`
- [ ] All tests pass: `npm test`
- [ ] Manual: simulate parallel workers where one returns `[ERROR]` and another returns a convergence phrase — confirm lead review still runs

Fixes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)