### PR TITLE
test(commands): add unit tests for approval and context commands

### DIFF
--- a/test/commands/approval.test.ts
+++ b/test/commands/approval.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: { dim: '', red: '', green: '', yellow: '', cyan: '' },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  icons: { success: '✓', error: '✗' },
+}));
+
+vi.mock('chalk', () => ({
+  default: new Proxy(
+    (s: string) => s,
+    {
+      get(_, _prop) {
+        const fn = (s: string) => s;
+        return new Proxy(fn, {
+          get(_, _p2) { return (s: string) => s; },
+          apply(_, __, [s]) { return s; },
+        });
+      },
+    }
+  ),
+}));
+
+import { registerApprovalCommand } from '../../src/commands/approval.js';
+
+const mockApproval = {
+  approval_id: 'appr_test_123',
+  type: 'pr' as const,
+  squad: 'cli',
+  agent: 'issue-solver',
+  title: 'Merge PR #42',
+  description: 'Merge feature PR',
+  payload: {},
+  status: 'pending' as const,
+  created_at: new Date().toISOString(),
+  expires_at: new Date(Date.now() + 86400000).toISOString(),
+};
+
+function makeProgram() {
+  const program = new Command();
+  program.exitOverride();
+  registerApprovalCommand(program);
+  return program;
+}
+
+describe('registerApprovalCommand', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    delete process.env.SQUADS_AGENT;
+    delete process.env.SQUADS_SQUAD;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers the approval command', () => {
+    const program = makeProgram();
+    const cmd = program.commands.find((c) => c.name() === 'approval');
+    expect(cmd).toBeDefined();
+  });
+
+  it('registers send, list, check, cancel subcommands', () => {
+    const program = makeProgram();
+    const approval = program.commands.find((c) => c.name() === 'approval')!;
+    const subNames = approval.commands.map((c) => c.name());
+    expect(subNames).toContain('send');
+    expect(subNames).toContain('list');
+    expect(subNames).toContain('check');
+    expect(subNames).toContain('cancel');
+  });
+
+  // ── approval list ──────────────────────────────────────────────────────────
+
+  it('approval list shows pending approvals', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [mockApproval],
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'list']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/approvals')
+    );
+  });
+
+  it('approval list shows empty message when none pending', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'list']);
+    const { writeLine } = await import('../../src/lib/terminal.js');
+    expect(writeLine).toHaveBeenCalled();
+  });
+
+  it('approval list --json outputs raw JSON', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [mockApproval],
+    });
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'list', '--json']);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('approval list filters by squad', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => [mockApproval],
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'list', '-s', 'cli']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('squad=cli')
+    );
+  });
+
+  it('approval list with multiple approval types', async () => {
+    const approvals = [
+      { ...mockApproval, type: 'issue' as const, approval_id: 'appr_1' },
+      { ...mockApproval, type: 'content' as const, approval_id: 'appr_2' },
+      { ...mockApproval, type: 'run' as const, approval_id: 'appr_3' },
+    ];
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => approvals,
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'list']);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  // ── approval check ─────────────────────────────────────────────────────────
+
+  it('approval check calls process.exit(0) for approved status', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...mockApproval, status: 'approved' }),
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const program = makeProgram();
+    await expect(
+      program.parseAsync(['node', 'cli', 'approval', 'check', 'appr_test_123'])
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    exitSpy.mockRestore();
+  });
+
+  it('approval check calls process.exit(1) for rejected status', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...mockApproval, status: 'rejected' }),
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const program = makeProgram();
+    await expect(
+      program.parseAsync(['node', 'cli', 'approval', 'check', 'appr_test_123'])
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('approval check calls process.exit(2) for pending (no --wait)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ ...mockApproval, status: 'pending' }),
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const program = makeProgram();
+    await expect(
+      program.parseAsync(['node', 'cli', 'approval', 'check', 'appr_test_123'])
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    exitSpy.mockRestore();
+  });
+
+  it('approval check calls process.exit(1) when approval not found (404)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => null, text: async () => 'Not found' });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const program = makeProgram();
+    await expect(
+      program.parseAsync(['node', 'cli', 'approval', 'check', 'missing_id'])
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  // ── approval send ──────────────────────────────────────────────────────────
+
+  it('approval send creates approval with defaults', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, approval_id: 'appr_new_123' }),
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'send', 'pr', '--title', 'Merge PR #1']);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/approvals'),
+      expect.objectContaining({ method: 'POST' })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.type).toBe('pr');
+    expect(body.title).toBe('Merge PR #1');
+  });
+
+  it('approval send with json payload', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, approval_id: 'appr_new_456' }),
+    });
+    const program = makeProgram();
+    await program.parseAsync([
+      'node', 'cli', 'approval', 'send', 'issue',
+      '--json', '{"repo":"squads-cli","number":42}',
+    ]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.payload).toEqual({ repo: 'squads-cli', number: 42 });
+  });
+
+  it('approval send uses SQUADS_SQUAD env for squad field', async () => {
+    process.env.SQUADS_SQUAD = 'cli';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, approval_id: 'appr_new_789' }),
+    });
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'send', 'pr', '--title', 'Test']);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.squad).toBe('cli');
+    delete process.env.SQUADS_SQUAD;
+  });
+
+  it('approval send with invalid json exits with error', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const program = makeProgram();
+    await expect(
+      program.parseAsync(['node', 'cli', 'approval', 'send', 'pr', '--json', 'not-json'])
+    ).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  // ── approval cancel ────────────────────────────────────────────────────────
+
+  it('approval cancel shows not-implemented message', async () => {
+    const { writeLine } = await import('../../src/lib/terminal.js');
+    const program = makeProgram();
+    await program.parseAsync(['node', 'cli', 'approval', 'cancel', 'appr_test_123']);
+    expect(writeLine).toHaveBeenCalled();
+  });
+});

--- a/test/commands/context.test.ts
+++ b/test/commands/context.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../src/lib/squad-parser.js', () => ({
+  findSquadsDir: vi.fn(),
+  loadSquad: vi.fn(),
+  listSquads: vi.fn(),
+  resolveExecutionContext: vi.fn(),
+}));
+
+vi.mock('../../src/lib/telemetry.js', () => ({
+  track: vi.fn(),
+  Events: { CLI_CONTEXT: 'cli_context' },
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: { dim: '', red: '', green: '', yellow: '', purple: '', cyan: '', white: '' },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  box: {
+    topLeft: '┌', topRight: '┐', bottomLeft: '└', bottomRight: '┘',
+    vertical: '│', horizontal: '─', teeLeft: '┤', teeRight: '├',
+  },
+  padEnd: vi.fn((s: string, n: number) => s.padEnd(n)),
+  icons: { success: '✓', error: '✗', warning: '!', progress: '›' },
+}));
+
+import {
+  contextShowCommand,
+  contextListCommand,
+  contextActivateCommand,
+  contextPromptCommand,
+} from '../../src/commands/context.js';
+import { findSquadsDir, loadSquad, listSquads, resolveExecutionContext } from '../../src/lib/squad-parser.js';
+
+const mockFindSquadsDir = vi.mocked(findSquadsDir);
+const mockLoadSquad = vi.mocked(loadSquad);
+const mockListSquads = vi.mocked(listSquads);
+const mockResolveExecutionContext = vi.mocked(resolveExecutionContext);
+
+const mockExecContext = {
+  resolved: {
+    mcpServers: [],
+    mcpSource: null as string | null,
+    mcpConfigPath: '/test/.mcp.json',
+    skills: [] as Array<{ name: string; source: string; path: string }>,
+    memoryPaths: [],
+  },
+};
+
+const mockSquad = {
+  name: 'engineering',
+  mission: 'Build great software',
+  repo: 'agents-squads/squads-cli',
+  stack: 'TypeScript, Node.js',
+  effort: 'high' as const,
+  context: {
+    mcp: ['chrome-devtools'],
+    skills: ['gh'],
+    model: { default: 'claude-sonnet-4', expensive: 'claude-opus-4' },
+    budget: { daily: 10 },
+    memory: { load: ['state.md'] },
+  },
+  goals: [],
+  agents: [],
+  pipelines: [],
+  routines: [],
+};
+
+describe('contextShowCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockLoadSquad.mockReturnValue(mockSquad as ReturnType<typeof loadSquad>);
+    mockResolveExecutionContext.mockReturnValue(mockExecContext as ReturnType<typeof resolveExecutionContext>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exits when no squads dir found', async () => {
+    mockFindSquadsDir.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    await expect(contextShowCommand('engineering')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('exits when squad not found', async () => {
+    mockLoadSquad.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    await expect(contextShowCommand('unknown')).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('resolves for a squad with full context', async () => {
+    await expect(contextShowCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('resolves for a squad with no context defined', async () => {
+    mockLoadSquad.mockReturnValue({ ...mockSquad, context: undefined } as ReturnType<typeof loadSquad>);
+    await expect(contextShowCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when json option is set', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await contextShowCommand('engineering', { json: true });
+    expect(consoleSpy).toHaveBeenCalled();
+    const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(output.name).toBe('engineering');
+    consoleSpy.mockRestore();
+  });
+
+  it('shows resolved MCP servers when present', async () => {
+    mockResolveExecutionContext.mockReturnValue({
+      ...mockExecContext,
+      resolved: {
+        ...mockExecContext.resolved,
+        mcpServers: ['chrome-devtools', 'filesystem'],
+        mcpSource: 'squad-local',
+      },
+    } as ReturnType<typeof resolveExecutionContext>);
+    const { writeLine } = await import('../../src/lib/terminal.js');
+    await contextShowCommand('engineering');
+    expect(writeLine).toHaveBeenCalled();
+  });
+
+  it('shows resolved skills when present', async () => {
+    mockResolveExecutionContext.mockReturnValue({
+      ...mockExecContext,
+      resolved: {
+        ...mockExecContext.resolved,
+        skills: [
+          { name: 'gh', source: 'squad-local', path: '/path/to/gh.md' },
+          { name: 'gcloud', source: 'project', path: '/path/to/gcloud.md' },
+        ],
+      },
+    } as ReturnType<typeof resolveExecutionContext>);
+    await expect(contextShowCommand('engineering')).resolves.toBeUndefined();
+  });
+});
+
+describe('contextListCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockListSquads.mockReturnValue(['engineering', 'marketing']);
+    mockLoadSquad.mockReturnValue(mockSquad as ReturnType<typeof loadSquad>);
+    mockResolveExecutionContext.mockReturnValue(mockExecContext as ReturnType<typeof resolveExecutionContext>);
+  });
+
+  it('exits when no squads dir found', async () => {
+    mockFindSquadsDir.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    await expect(contextListCommand()).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('lists all squad contexts', async () => {
+    await expect(contextListCommand()).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON when json option set', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await contextListCommand({ json: true });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('handles squad with no context in list', async () => {
+    mockLoadSquad.mockReturnValue({ ...mockSquad, context: undefined } as ReturnType<typeof loadSquad>);
+    await expect(contextListCommand()).resolves.toBeUndefined();
+  });
+});
+
+describe('contextActivateCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockLoadSquad.mockReturnValue(mockSquad as ReturnType<typeof loadSquad>);
+    mockResolveExecutionContext.mockReturnValue(mockExecContext as ReturnType<typeof resolveExecutionContext>);
+  });
+
+  it('exits when no squads dir found', async () => {
+    mockFindSquadsDir.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    await expect(contextActivateCommand('engineering')).rejects.toThrow('process.exit');
+    exitSpy.mockRestore();
+  });
+
+  it('exits when squad not found', async () => {
+    mockLoadSquad.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    await expect(contextActivateCommand('unknown')).rejects.toThrow('process.exit');
+    exitSpy.mockRestore();
+  });
+
+  it('resolves in dry-run mode', async () => {
+    await expect(contextActivateCommand('engineering', { dryRun: true })).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON in activate json mode', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await contextActivateCommand('engineering', { json: true });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('resolves in normal activate mode', async () => {
+    await expect(contextActivateCommand('engineering')).resolves.toBeUndefined();
+  });
+
+  it('dry-run shows skills when resolved', async () => {
+    mockResolveExecutionContext.mockReturnValue({
+      ...mockExecContext,
+      resolved: {
+        ...mockExecContext.resolved,
+        skills: [{ name: 'gh', source: 'squad-local', path: '/path/to/gh.md' }],
+        memoryPaths: ['/path/to/state.md'],
+        mcpSource: 'generated',
+        mcpServers: ['filesystem'],
+      },
+    } as ReturnType<typeof resolveExecutionContext>);
+    await expect(contextActivateCommand('engineering', { dryRun: true })).resolves.toBeUndefined();
+  });
+});
+
+describe('contextPromptCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindSquadsDir.mockReturnValue('/test/.agents/squads');
+    mockLoadSquad.mockReturnValue(mockSquad as ReturnType<typeof loadSquad>);
+  });
+
+  it('exits when no squads dir found', async () => {
+    mockFindSquadsDir.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(contextPromptCommand('engineering')).rejects.toThrow('process.exit');
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('exits when squad not found', async () => {
+    mockLoadSquad.mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(contextPromptCommand('engineering')).rejects.toThrow('process.exit');
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('exits when no agent specified', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => { throw new Error('process.exit'); });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(contextPromptCommand('engineering', {})).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it('outputs prompt for agent', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await contextPromptCommand('engineering', { agent: 'issue-solver' });
+    expect(consoleSpy).toHaveBeenCalled();
+    const output = consoleSpy.mock.calls[0][0] as string;
+    expect(output).toContain('issue-solver');
+    expect(output).toContain('engineering');
+    consoleSpy.mockRestore();
+  });
+
+  it('outputs JSON when json option set', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await contextPromptCommand('engineering', { agent: 'issue-solver', json: true });
+    const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(output.squad).toBe('engineering');
+    expect(output.agent).toBe('issue-solver');
+    expect(output.prompt).toContain('issue-solver');
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- **approval.test.ts**: 16 tests for `registerApprovalCommand` — covers `list` (pending, empty, json, squad filter, multi-type), `check` (approved/rejected/pending/404 exit codes via throw-on-exit pattern), `send` (defaults, json payload, SQUADS_SQUAD env, invalid json), and `cancel`
- **context.test.ts**: 22 tests for context commands — covers `contextShowCommand`, `contextListCommand`, `contextActivateCommand`, `contextPromptCommand` with json output, dry-run mode, no-squads-dir edge cases, and missing agent errors

## Issues
- Part of #47 (unit tests for commands/ directory — now 23/35 commands covered)

## Test Results
- 38 new tests, all passing
- Build passes (`npm run build`)

---
Agent: cli/issue-solver
Squad: cli