### PR TITLE
refactor(costs): extract plan detection into src/lib/plan.ts

### DIFF
--- a/src/lib/costs.ts
+++ b/src/lib/costs.ts
@@ -16,6 +16,9 @@ import {
 // Re-export provider types for convenience
 export { ProviderName, ProviderDetection, detectProviderFromModel, detectProvidersFromEnv, getProviderDisplayName };
 
+// Re-export plan detection from dedicated module
+export { PlanType, PlanDetection, detectPlan, getPlanType, isMaxPlan, getPlanDescription } from './plan.js';
+
 interface SquadCosts {
   squad: string;
   calls: number;
@@ -69,93 +72,6 @@ const DEFAULT_DAILY_BUDGET = 200.0;
 const DEFAULT_DAILY_CALL_LIMIT = 1000; // Default API call limit per day
 const BRIDGE_URL = process.env.SQUADS_BRIDGE_URL || 'http://localhost:8088';
 const FETCH_TIMEOUT_MS = 2000; // 2 second timeout for all fetch calls
-
-/**
- * Anthropic plan types:
- * - 'max': Flat fee subscription ($200/mo), no overage - only rate limits matter
- * - 'usage': Pay-per-token, budget tracking matters
- * - 'unknown': Not configured yet
- */
-export type PlanType = 'max' | 'usage' | 'unknown';
-
-/**
- * Plan detection result with confidence and reason
- */
-export interface PlanDetection {
-  plan: PlanType;
-  confidence: 'explicit' | 'inferred';
-  reason: string;
-}
-
-/**
- * Detect the Anthropic plan type using multiple signals:
- *
- * Priority order:
- * 1. Explicit SQUADS_PLAN_TYPE env var (highest confidence)
- * 2. ANTHROPIC_BUDGET_DAILY set → usage plan (user cares about budget)
- * 3. Tier 4 + no budget → likely Max plan (heavy user)
- * 4. Low tier (1-2) → usage plan (new user, pay-as-you-go)
- * 5. Default: max (assumes professional use)
- */
-export function detectPlan(): PlanDetection {
-  // 1. Explicit configuration (highest priority)
-  const explicitPlan = process.env.SQUADS_PLAN_TYPE?.toLowerCase();
-  if (explicitPlan === 'usage') {
-    return { plan: 'usage', confidence: 'explicit', reason: 'SQUADS_PLAN_TYPE=usage' };
-  }
-  if (explicitPlan === 'max') {
-    return { plan: 'max', confidence: 'explicit', reason: 'SQUADS_PLAN_TYPE=max' };
-  }
-
-  // 2. Budget explicitly set → user cares about costs → usage plan
-  const budgetSet = process.env.ANTHROPIC_BUDGET_DAILY || process.env.SQUADS_DAILY_BUDGET;
-  if (budgetSet) {
-    return { plan: 'usage', confidence: 'inferred', reason: `Budget set ($${budgetSet}/day)` };
-  }
-
-  // 3. Check tier - Tier 4 usually indicates Max plan user
-  const tier = parseInt(process.env.ANTHROPIC_TIER || '0', 10);
-  if (tier >= 4) {
-    return { plan: 'max', confidence: 'inferred', reason: `Tier ${tier} (high usage)` };
-  }
-
-  // 4. Low tier (1-2) → likely new user on usage plan
-  if (tier >= 1 && tier <= 2) {
-    return { plan: 'usage', confidence: 'inferred', reason: `Tier ${tier} (new user)` };
-  }
-
-  // 5. Default: unknown - prompt user to configure
-  return { plan: 'unknown', confidence: 'inferred', reason: 'Not configured' };
-}
-
-/**
- * Get the current Anthropic plan type
- * Use detectPlan() for full details including confidence
- */
-export function getPlanType(): PlanType {
-  return detectPlan().plan;
-}
-
-/**
- * Check if we're on a flat-fee plan where budget doesn't matter
- */
-export function isMaxPlan(): boolean {
-  return getPlanType() === 'max';
-}
-
-/**
- * Get human-readable plan description for dashboard display
- */
-export function getPlanDescription(): string {
-  const detection = detectPlan();
-  const planName = detection.plan === 'max'
-    ? 'Max ($200 flat)'
-    : detection.plan === 'usage'
-      ? 'Usage (pay-per-token)'
-      : 'Unknown';
-  const confidence = detection.confidence === 'explicit' ? '' : ` [${detection.reason}]`;
-  return `${planName}${confidence}`;
-}
 
 /**
  * Fetch with timeout to prevent hanging when services are down

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -1,0 +1,91 @@
+/**
+ * Anthropic plan detection
+ * Determines whether the user is on a Max (flat-fee) or Usage (pay-per-token) plan.
+ */
+
+/**
+ * Anthropic plan types:
+ * - 'max': Flat fee subscription ($200/mo), no overage - only rate limits matter
+ * - 'usage': Pay-per-token, budget tracking matters
+ * - 'unknown': Not configured yet
+ */
+export type PlanType = 'max' | 'usage' | 'unknown';
+
+/**
+ * Plan detection result with confidence and reason
+ */
+export interface PlanDetection {
+  plan: PlanType;
+  confidence: 'explicit' | 'inferred';
+  reason: string;
+}
+
+/**
+ * Detect the Anthropic plan type using multiple signals:
+ *
+ * Priority order:
+ * 1. Explicit SQUADS_PLAN_TYPE env var (highest confidence)
+ * 2. ANTHROPIC_BUDGET_DAILY set → usage plan (user cares about budget)
+ * 3. Tier 4 + no budget → likely Max plan (heavy user)
+ * 4. Low tier (1-2) → usage plan (new user, pay-as-you-go)
+ * 5. Default: max (assumes professional use)
+ */
+export function detectPlan(): PlanDetection {
+  // 1. Explicit configuration (highest priority)
+  const explicitPlan = process.env.SQUADS_PLAN_TYPE?.toLowerCase();
+  if (explicitPlan === 'usage') {
+    return { plan: 'usage', confidence: 'explicit', reason: 'SQUADS_PLAN_TYPE=usage' };
+  }
+  if (explicitPlan === 'max') {
+    return { plan: 'max', confidence: 'explicit', reason: 'SQUADS_PLAN_TYPE=max' };
+  }
+
+  // 2. Budget explicitly set → user cares about costs → usage plan
+  const budgetSet = process.env.ANTHROPIC_BUDGET_DAILY || process.env.SQUADS_DAILY_BUDGET;
+  if (budgetSet) {
+    return { plan: 'usage', confidence: 'inferred', reason: `Budget set ($${budgetSet}/day)` };
+  }
+
+  // 3. Check tier - Tier 4 usually indicates Max plan user
+  const tier = parseInt(process.env.ANTHROPIC_TIER || '0', 10);
+  if (tier >= 4) {
+    return { plan: 'max', confidence: 'inferred', reason: `Tier ${tier} (high usage)` };
+  }
+
+  // 4. Low tier (1-2) → likely new user on usage plan
+  if (tier >= 1 && tier <= 2) {
+    return { plan: 'usage', confidence: 'inferred', reason: `Tier ${tier} (new user)` };
+  }
+
+  // 5. Default: unknown - prompt user to configure
+  return { plan: 'unknown', confidence: 'inferred', reason: 'Not configured' };
+}
+
+/**
+ * Get the current Anthropic plan type
+ * Use detectPlan() for full details including confidence
+ */
+export function getPlanType(): PlanType {
+  return detectPlan().plan;
+}
+
+/**
+ * Check if we're on a flat-fee plan where budget doesn't matter
+ */
+export function isMaxPlan(): boolean {
+  return getPlanType() === 'max';
+}
+
+/**
+ * Get human-readable plan description for dashboard display
+ */
+export function getPlanDescription(): string {
+  const detection = detectPlan();
+  const planName = detection.plan === 'max'
+    ? 'Max ($200 flat)'
+    : detection.plan === 'usage'
+      ? 'Usage (pay-per-token)'
+      : 'Unknown';
+  const confidence = detection.confidence === 'explicit' ? '' : ` [${detection.reason}]`;
+  return `${planName}${confidence}`;
+}

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -10,6 +10,10 @@ describe('git utilities', () => {
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'squads-git-test-'));
+    // Clear GIT_DIR/GIT_WORK_TREE so git commands in temp dirs don't
+    // accidentally operate on the squads-cli repo (hook recursion bug)
+    delete process.env.GIT_DIR;
+    delete process.env.GIT_WORK_TREE;
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- Extracts `PlanType`, `PlanDetection`, `detectPlan`, `getPlanType`, `isMaxPlan`, `getPlanDescription` from `costs.ts` into dedicated `src/lib/plan.ts`
- `costs.ts` re-exports everything from `plan.ts` — backwards compatible, no import changes needed
- Reduces `costs.ts` from 1202 → 1118 lines (-84 lines)
- Fixes `test/git.test.ts` GIT_DIR hook recursion bug: adds `delete process.env.GIT_DIR` and `delete process.env.GIT_WORK_TREE` in `beforeEach` to prevent test commits leaking into the squads-cli repo during pre-commit hook runs

## Issues

- Partial: #161 (first extraction step — plan detection module)

## Notes

This is the first of several planned extractions from `costs.ts`. The plan detection logic is completely self-contained (no internal dependencies), making it the safest first step. Subsequent extractions (rate limits, ROI metrics, bridge client) will follow in separate PRs.

---
Agent: cli/issue-solver