### PR TITLE
feat(create): add --slack flag to create Slack channel for squad

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -247,6 +247,7 @@ program
   .option('-y, --yes', 'Accept all defaults (non-interactive)')
   .option('-r, --repo', 'Create a GitHub repository for the squad')
   .option('-o, --org <org>', 'GitHub organization for --repo (default: detected from git remote)')
+  .option('-s, --slack', 'Create a Slack channel for the squad (requires SLACK_BOT_TOKEN)')
   .addHelpText('after', `
 Examples:
   $ squads create marketing                          Create with interactive prompts
@@ -254,6 +255,7 @@ Examples:
   $ squads create marketing --force                  Overwrite existing squad
   $ squads create marketing --repo                   Create with GitHub repo
   $ squads create marketing --repo --org myorg       Create with GitHub repo in specific org
+  $ squads create marketing --slack                  Create with Slack channel
 `)
   .action(async (...args: any[]) => {
     const { createCommand } = await import('./commands/create.js');

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -17,6 +17,7 @@ import { findSquadsDir, findProjectRoot, listSquads } from '../lib/squad-parser.
 import { loadTemplate, toKebabCase, toTitleCase, type TemplateVariables } from '../lib/templates.js';
 import { track } from '../lib/telemetry.js';
 import { createGitHubRepo, detectGitHubOrg } from '../lib/github.js';
+import { createSquadChannel } from '../lib/slack.js';
 
 interface CreateOptions {
   description?: string;
@@ -26,6 +27,7 @@ interface CreateOptions {
   yes?: boolean;
   repo?: boolean;
   org?: string;
+  slack?: boolean;
 }
 
 export async function createCommand(name: string, options: CreateOptions): Promise<void> {
@@ -134,7 +136,17 @@ export async function createCommand(name: string, options: CreateOptions): Promi
     repo: !!options.repo,
   }).catch(() => {});
 
-  // 5. Create GitHub repo if --repo flag is set
+  // 5. Create Slack channel if --slack flag is set
+  let slackChannelId: string | null = null;
+  if (options.slack) {
+    slackChannelId = await createSquadChannel(squadId, `Channel for the ${squadName} squad`);
+    if (!slackChannelId) {
+      console.error(chalk.red('\n  Slack channel creation failed (check SLACK_BOT_TOKEN).\n'));
+      console.error(chalk.dim('  Local squad was created. Create the channel manually.\n'));
+    }
+  }
+
+  // 6. Create GitHub repo if --repo flag is set
   let repoUrl: string | undefined;
   if (options.repo) {
     const org = options.org ?? detectGitHubOrg();
@@ -149,7 +161,7 @@ export async function createCommand(name: string, options: CreateOptions): Promi
     }
   }
 
-  // 6. Show success
+  // 7. Show success
   const existing = listSquads(squadsDir);
   console.log();
   console.log(chalk.green('  ✓ Squad created:'), chalk.cyan(squadId));
@@ -158,6 +170,11 @@ export async function createCommand(name: string, options: CreateOptions): Promi
   console.log(`    .agents/squads/${squadId}/SQUAD.md`);
   console.log(`    .agents/squads/${squadId}/lead.md`);
   console.log(`    .agents/memory/${squadId}/lead/`);
+  if (slackChannelId) {
+    console.log();
+    console.log(chalk.dim('  Slack channel:'));
+    console.log(`    ${chalk.cyan(`#squad-${squadId}`)}`);
+  }
   if (repoUrl) {
     console.log();
     console.log(chalk.dim('  GitHub repo:'));

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -405,6 +405,39 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Create a Slack channel for a squad (format: squad-<name>).
+ * Returns the channel ID string, or null if creation fails.
+ */
+export async function createSquadChannel(squadId: string, topic?: string): Promise<string | null> {
+  if (!isSlackConfigured()) return null;
+
+  const channelName = `squad-${squadId}`;
+
+  try {
+    const response = await slackApi<SlackApiResponse & { channel?: SlackChannel }>('POST', 'conversations.create', {
+      name: channelName,
+      is_private: false,
+    });
+    const channelId = response.channel?.id || null;
+
+    if (channelId && topic) {
+      await slackApi('POST', 'conversations.setTopic', {
+        channel: channelId,
+        topic,
+      }).catch(() => {});
+    }
+
+    return channelId;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('name_taken')) {
+      return getSquadChannelId(squadId);
+    }
+    return null;
+  }
+}
+
+/**
  * Post a "tonight session started" notification
  */
 export async function notifyTonightStart(

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -3,6 +3,12 @@ import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+// Mock slack lib for --slack tests
+vi.mock('../../src/lib/slack.js', () => ({
+  createSquadChannel: vi.fn().mockResolvedValue('C123'),
+  isSlackConfigured: vi.fn().mockReturnValue(true),
+}));
+
 // Mock child_process for --repo tests
 vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('child_process')>();
@@ -213,6 +219,47 @@ describe('create command', () => {
       await expect(createCommand('my-squad', { yes: true, repo: true, org: 'test-org' })).resolves.toBeUndefined();
 
       // Local files still exist
+      const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
+      expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
+    });
+  });
+
+  describe('--slack flag', () => {
+    it('creates local squad files with --slack flag', async () => {
+      const { createCommand } = await import('../../src/commands/create.js');
+      await createCommand('my-squad', { yes: true, slack: true });
+
+      const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
+      expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
+    });
+
+    it('calls createSquadChannel with correct squadId', async () => {
+      const slack = await import('../../src/lib/slack.js');
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      await createCommand('my-squad', { yes: true, slack: true });
+
+      expect(slack.createSquadChannel).toHaveBeenCalledWith('my-squad', expect.any(String));
+    });
+
+    it('does not call createSquadChannel without --slack flag', async () => {
+      const slack = await import('../../src/lib/slack.js');
+      vi.mocked(slack.createSquadChannel).mockClear();
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      await createCommand('my-squad', { yes: true });
+
+      expect(slack.createSquadChannel).not.toHaveBeenCalled();
+    });
+
+    it('continues gracefully if Slack channel creation returns null', async () => {
+      const slack = await import('../../src/lib/slack.js');
+      vi.mocked(slack.createSquadChannel).mockResolvedValueOnce(null);
+      const { createCommand } = await import('../../src/commands/create.js');
+
+      // Should not throw — local squad is still created
+      await expect(createCommand('my-squad', { yes: true, slack: true })).resolves.toBeUndefined();
+
       const squadDir = join(testDir, '.agents', 'squads', 'my-squad');
       expect(existsSync(join(squadDir, 'SQUAD.md'))).toBe(true);
     });

--- a/test/e2e/cli-commands.e2e.test.ts
+++ b/test/e2e/cli-commands.e2e.test.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { execSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
+
+// Clear git env vars set by pre-commit hook to prevent GIT_DIR pollution
+beforeAll(() => {
+  delete process.env.GIT_DIR;
+  delete process.env.GIT_WORK_TREE;
+  delete process.env.GIT_INDEX_FILE;
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/test/e2e/workflows.e2e.test.ts
+++ b/test/e2e/workflows.e2e.test.ts
@@ -5,12 +5,21 @@
  * to verify that the full user journey produces expected output.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import { mkdirSync, existsSync, readFileSync, rmSync, readdirSync } from 'fs';
 import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
+
+// Clear git env vars set by the pre-commit hook so that git commands
+// executed in temp directories do not accidentally write to the
+// repository running the hook.
+beforeAll(() => {
+  delete process.env.GIT_DIR;
+  delete process.env.GIT_WORK_TREE;
+  delete process.env.GIT_INDEX_FILE;
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
 import { checkGitStatus, checkGitStatusAsync, initGitRepo, getRepoName } from '../src/lib/git';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
+
+// Clear git env vars set by pre-commit hook so that git commands
+// in temp directories do not write to the hook's repository branch.
+beforeAll(() => {
+  delete process.env.GIT_DIR;
+  delete process.env.GIT_WORK_TREE;
+  delete process.env.GIT_INDEX_FILE;
+});
 
 describe('git utilities', () => {
   let tempDir: string;


### PR DESCRIPTION
## Summary

- Adds `--slack` / `-s` flag to `squads create` command
- Adds `createSquadChannel()` to `src/lib/slack.ts` (calls Slack `conversations.create` API)
- Shows `#squad-<name>` in success output when channel created
- Continues gracefully if `SLACK_BOT_TOKEN` is not set or call fails
- Fixes pre-commit hook GIT_DIR pollution that caused spurious commits in test git repositories

## Changes

- `src/lib/slack.ts`: Add `createSquadChannel(squadId, topic?)` function
- `src/commands/create.ts`: Add `--slack` option, call `createSquadChannel` after local files created
- `src/cli.ts`: Register `-s, --slack` option and example
- `test/commands/create.test.ts`: Add 4 tests covering the slack flag
- `test/git.test.ts`, `test/e2e/*.test.ts`: Add `beforeAll` to clear `GIT_DIR` env vars (pre-commit hook GIT pollution fix)

## Usage

\`\`\`bash
squads create marketing --slack
# Creates local squad files + Slack channel #squad-marketing
\`\`\`

## Issues
- Closes #282

---
Agent: cli/issue-solver