### PR TITLE
docs: fix stale CLAUDE.md and README references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Persistent state across sessions at `.agents/memory/<squad>/<agent>/`.
 ```bash
 squads memory write <squad> [agent] "insight"   # Save a learning
 squads memory read <squad> [agent]               # Load context
-squads memory search "query"                     # Search across squads
+squads memory query "query"                      # Search across squads
 ```
 
 ### Milestones & PRs
@@ -71,7 +71,7 @@ This works with any git hosting that supports the `gh` CLI or equivalent.
 |---------|-------------|
 | `squads memory write <squad> [agent] "text"` | Persist a learning |
 | `squads memory read <squad> [agent]` | Load agent memory |
-| `squads memory search "query"` | Search all memory |
+| `squads memory query "query"` | Search all memory |
 | `squads memory list` | List all entries |
 
 ### Infrastructure
@@ -172,7 +172,7 @@ import { searchMemory, appendToMemory, listMemoryEntries } from '../lib/memory.j
 - **Agent definitions:** `.agents/squads/<squad>/<agent>.md`
 - **Memory files:** `.agents/memory/<squad>/<agent>/<type>.md`
 - **Session history:** `.agents/sessions/history.jsonl`
-- **CLI config:** `~/.squadsrc`
+- **CLI config:** `~/.squads/config.json` (named environments, managed via `squads config`)
 
 ### Git Workflow
 - Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ squads autonomous status
 
 ### Claude Code Integration
 
-Add hooks to `.claude/settings.json` so every Claude Code session starts with squad context:
+Run `squads init` to set this up automatically, or add hooks to `.claude/settings.json` manually:
 
 ```json
 {
@@ -170,8 +170,19 @@ Add hooks to `.claude/settings.json` so every Claude Code session starts with sq
     "SessionStart": [{
       "hooks": [{
         "type": "command",
-        "command": "squads session start",
+        "command": "squads status",
         "timeout": 10
+      }, {
+        "type": "command",
+        "command": "squads memory sync --no-push",
+        "timeout": 15
+      }]
+    }],
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "squads memory sync --push",
+        "timeout": 15
       }]
     }]
   }


### PR DESCRIPTION
## Summary
- Fix `memory search` → `memory query` in CLAUDE.md (lines 41, 74) — `memory search` is bridge-only, not general search
- Update CLI config path from legacy `~/.squadsrc` to `~/.squads/config.json` with note on `squads config`
- Update README hooks example to match what `squads init` actually generates: `squads status` + `squads memory sync` hooks, plus `Stop` hook for session end

## Issues
- Closes #448
- Closes #450
- Closes #453

---
Agent: cli/issue-solver