### PR TITLE
docs: fix CLAUDE.md and README.md documentation errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Persistent state across sessions at `.agents/memory/<squad>/<agent>/`.
 ```bash
 squads memory write <squad> [agent] "insight"   # Save a learning
 squads memory read <squad> [agent]               # Load context
-squads memory search "query"                     # Search across squads
+squads memory query "query"                      # Search across squads
 ```
 
 ### Milestones & PRs
@@ -71,7 +71,7 @@ This works with any git hosting that supports the `gh` CLI or equivalent.
 |---------|-------------|
 | `squads memory write <squad> [agent] "text"` | Persist a learning |
 | `squads memory read <squad> [agent]` | Load agent memory |
-| `squads memory search "query"` | Search all memory |
+| `squads memory query "query"` | Search all memory |
 | `squads memory list` | List all entries |
 
 ### Infrastructure
@@ -172,7 +172,7 @@ import { searchMemory, appendToMemory, listMemoryEntries } from '../lib/memory.j
 - **Agent definitions:** `.agents/squads/<squad>/<agent>.md`
 - **Memory files:** `.agents/memory/<squad>/<agent>/<type>.md`
 - **Session history:** `.agents/sessions/history.jsonl`
-- **CLI config:** `~/.squadsrc`
+- **CLI config:** `~/.squads/config.json` (managed via `squads config use local|staging|prod`)
 
 ### Git Workflow
 - Conventional Commits format (`feat:`, `fix:`, `docs:`, `chore:`)

--- a/README.md
+++ b/README.md
@@ -191,28 +191,81 @@ Add hooks to `.claude/settings.json` so every Claude Code session starts with sq
 
 ## Commands
 
+### Setup & Auth
 | Command | Description |
 |---------|-------------|
-| `squads init` | Initialize squads in your project |
-| `squads status [squad]` | Overview of all squads and active sessions |
+| `squads init` | Initialize project with squads structure and hooks |
+| `squads create <name>` | Create a new squad |
+| `squads login` | Authenticate with the Squads platform |
+| `squads logout` | Sign out |
+| `squads whoami` | Show current authenticated user |
+| `squads doctor` | Check local tools, auth, and readiness |
+
+### Squads & Agents
+| Command | Description |
+|---------|-------------|
+| `squads list` | List agents and squads |
 | `squads run <target>` | Run a squad or specific agent |
+| `squads orchestrate <squad>` | Lead agent orchestration across a squad |
+| `squads detect-squad` | Detect squad from current directory |
+
+### Monitoring & Dashboards
+| Command | Description |
+|---------|-------------|
+| `squads status [squad]` | Overview of all squads and active sessions |
 | `squads dash [name]` | Dashboard with goals, metrics, and git activity |
-| `squads env show <squad>` | View squad execution environment |
-| `squads env prompt <squad> -a <agent>` | Generate agent execution prompt |
+| `squads sessions` | Show active AI coding sessions |
+| `squads stats [squad]` | Agent outcome scorecards |
+| `squads results [squad]` | Git activity and KPI goals vs actuals |
+| `squads history` | Recent execution history |
+| `squads exec list` | View execution log |
+| `squads progress` | Track active and completed tasks |
+
+### Goals & KPIs
+| Command | Description |
+|---------|-------------|
+| `squads goal set <squad> <goal>` | Set a squad objective |
+| `squads goal list` | View all goals and progress |
+| `squads kpi show <squad>` | Track squad KPIs |
+| `squads budget` | Check budget status |
+| `squads cost` | Cost summary by squad and time period |
+
+### Memory & Learning
+| Command | Description |
+|---------|-------------|
 | `squads memory query <q>` | Search across all agent memory |
 | `squads memory write <squad> <insight>` | Persist a learning |
 | `squads memory read <squad>` | View squad memory |
-| `squads goal set <squad> <goal>` | Set a squad objective |
-| `squads goal list` | View all goals and progress |
-| `squads exec list` | View recent execution history |
-| `squads sessions` | Show active AI coding sessions |
+| `squads memory sync` | Sync memory to/from remote |
+| `squads learn` | Capture a learning |
+| `squads feedback` | Record or view execution feedback |
+| `squads cognition` | Business cognition engine (beliefs, signals, decisions) |
+
+### Context & Alignment
+| Command | Description |
+|---------|-------------|
+| `squads context` | View current business context |
+| `squads context feed` | Feed business context for agent alignment |
+
+### Automation
+| Command | Description |
+|---------|-------------|
 | `squads autonomous start` | Start the local execution daemon |
-| `squads providers` | List available LLM providers |
+| `squads autopilot` | Full autopilot mode alias |
+| `squads trigger` | Smart triggers for agent execution |
+| `squads approval` | Manage approval requests |
 | `squads eval <target>` | Evaluate agent readiness |
-| `squads cost` | Cost summary by squad and time period |
-| `squads kpi show <squad>` | Track squad KPIs |
-| `squads sync` | Synchronize memory state |
+
+### Environment & Infra
+| Command | Description |
+|---------|-------------|
+| `squads env show <squad>` | View squad execution environment |
+| `squads env prompt <squad> -a <agent>` | Generate agent execution prompt |
 | `squads health` | Infrastructure health check |
+| `squads providers` | List available LLM providers |
+| `squads config use <env>` | Switch environment (local\|staging\|prod) |
+| `squads deploy` | Deploy to platform |
+| `squads sync` | Sync memory state to git and optionally Postgres |
 | `squads update` | Check for and install updates |
 
 Run `squads --help` for the full command reference, or `squads <command> --help` for detailed options.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ squads autonomous status
 
 ### Claude Code Integration
 
-Add hooks to `.claude/settings.json` so every Claude Code session starts with squad context:
+Add hooks to `.claude/settings.json` so every Claude Code session starts with squad context. Run `squads init` to set this up automatically, or add it manually:
 
 ```json
 {
@@ -170,8 +170,19 @@ Add hooks to `.claude/settings.json` so every Claude Code session starts with sq
     "SessionStart": [{
       "hooks": [{
         "type": "command",
-        "command": "squads session start",
+        "command": "squads status",
         "timeout": 10
+      }, {
+        "type": "command",
+        "command": "squads memory sync --no-push",
+        "timeout": 15
+      }]
+    }],
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "squads memory sync --push",
+        "timeout": 15
       }]
     }]
   }


### PR DESCRIPTION
## Summary
- Fix `memory search` → `memory query` in CLAUDE.md (lines 41, 74) — `memory search` is bridge-specific, `memory query` is the general search
- Fix CLI config path `~/.squadsrc` → `~/.squads/config.json` in CLAUDE.md — legacy path sends developers down the wrong path
- Fix README Claude Code hooks to match what `squads init` actually generates (was `session start`, now correct `status` + `memory sync`)

## Issues
- Closes #448
- Closes #450
- Closes #453

---
Agent: cli/issue-solver
Squad: cli