### PR TITLE
fix(ux): health command shows accurate summary when optional services are down

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -275,7 +275,15 @@ export async function healthCommand(options: HealthOptions = {}): Promise<void> 
       writeLine();
     }
   } else {
-    writeLine(`  ${colors.green}${icons.success} All services healthy${RESET}`);
+    const optionalDown = results.filter(r => r.optional && r.status === 'down');
+    if (optionalDown.length > 0) {
+      const plural = optionalDown.length > 1 ? 's' : '';
+      writeLine(
+        `  ${colors.green}${icons.success} Core ready${RESET} ${colors.dim}(${optionalDown.length} optional service${plural} offline — run \`squads stack up\` to enable)${RESET}`
+      );
+    } else {
+      writeLine(`  ${colors.green}${icons.success} All services healthy${RESET}`);
+    }
     writeLine();
   }
 


### PR DESCRIPTION
## Summary
- Fix self-contradictory health summary: previously showed "All services healthy" even when all services were down
- When required services are healthy but optional services are offline: shows "Core ready (N optional services offline — run \`squads stack up\` to enable)"
- Only shows "All services healthy" when every service is actually healthy

## Root Cause
Optional services are not added to the \`issues\` array when they're down (by design). When all services are optional, \`issues.length === 0\` triggered the "All services healthy" branch regardless of actual service status.

## Fix
Added a check for optional-down services in the "no critical issues" branch.

## Issues
- Closes #461

---
Agent: cli/issue-solver