### PR TITLE
fix: add verbose logging to 21 silent catch blocks in run.ts

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -126,8 +126,8 @@ async function registerContextWithBridge(ctx: ExecutionContext): Promise<boolean
       return false;
     }
     return true;
-  } catch {
-    // Bridge not available - continue anyway
+  } catch (e) {
+    writeLine(`  ${colors.dim}warn: bridge registration failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
     return false;
   }
 }
@@ -162,8 +162,8 @@ async function checkPreflightGates(squad: string, agent: string): Promise<Prefli
     }
 
     return await response.json() as PreflightResult;
-  } catch {
-    // Fail open if bridge is unavailable
+  } catch (e) {
+    writeLine(`  ${colors.dim}warn: preflight gate check failed (allowing execution): ${e instanceof Error ? e.message : String(e)}${RESET}`);
     return { allowed: true, gates: {} };
   }
 }
@@ -192,7 +192,8 @@ async function fetchLearnings(squad: string, limit = DEFAULT_LEARNINGS_LIMIT): P
 
     const data = await response.json() as { learnings: Learning[] };
     return data.learnings || [];
-  } catch {
+  } catch (e) {
+    writeLine(`  ${colors.dim}warn: learnings fetch failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
     return [];
   }
 }
@@ -211,7 +212,8 @@ function loadApprovalInstructions(): string {
   if (existsSync(instructionsPath)) {
     try {
       return readFileSync(instructionsPath, 'utf-8');
-    } catch {
+    } catch (e) {
+      writeLine(`  ${colors.dim}warn: failed reading approval instructions: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       return '';
     }
   }
@@ -234,7 +236,9 @@ function loadPostExecution(squadName: string, agentName: string): string {
         return template
           .replace(/\{\{squadName\}\}/g, squadName)
           .replace(/\{\{agentName\}\}/g, agentName);
-      } catch { /* fall through */ }
+      } catch (e) {
+          writeLine(`  ${colors.dim}warn: failed reading post-execution template: ${e instanceof Error ? e.message : String(e)}${RESET}`);
+        }
     }
   }
   // Minimal fallback if template file missing
@@ -294,8 +298,8 @@ function gatherSquadContext(
           estimatedTokens += tokens;
         }
       }
-    } catch {
-      // Ignore read errors
+    } catch (e) {
+      if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading SQUAD.md: ${e instanceof Error ? e.message : String(e)}${RESET}`);
     }
   }
 
@@ -310,8 +314,8 @@ function gatherSquadContext(
           sections.push(`## Squad Goals (${squadName})\n${goalsContent.trim()}`);
           estimatedTokens += tokens;
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading squad goals: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -327,8 +331,8 @@ function gatherSquadContext(
           sections.push(`## Company Directives\n${directivesContent.trim()}`);
           estimatedTokens += tokens;
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading company directives: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -345,8 +349,8 @@ function gatherSquadContext(
           sections.push(`## Your Previous State\nThis is your memory from your last execution:\n\n${stateContent.trim()}`);
           estimatedTokens += tokens;
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading agent state: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -372,8 +376,8 @@ function gatherSquadContext(
             break; // Stop adding briefs if we're over budget
           }
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading agent briefs: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -399,8 +403,8 @@ function gatherSquadContext(
             break;
           }
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading squad briefs: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -418,8 +422,8 @@ function gatherSquadContext(
             estimatedTokens += tokens;
           }
         }
-      } catch {
-        // Ignore read errors
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading daily briefing: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
   }
@@ -444,8 +448,8 @@ function gatherSquadContext(
                 estimatedTokens += tokens;
               }
             }
-          } catch {
-            // Ignore read errors
+          } catch (e) {
+            if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading ${relatedSquad} learnings: ${e instanceof Error ? e.message : String(e)}${RESET}`);
           }
         }
 
@@ -464,8 +468,8 @@ function gatherSquadContext(
                 estimatedTokens += tokens;
               }
             }
-          } catch {
-            // Ignore read errors
+          } catch (e) {
+            if (options.verbose) writeLine(`  ${colors.dim}warn: failed reading ${relatedSquad} lead state: ${e instanceof Error ? e.message : String(e)}${RESET}`);
           }
         }
       }
@@ -652,9 +656,9 @@ function ensureProjectTrusted(projectPath: string): void {
       config.projects[projectPath].hasTrustDialogAccepted = true;
       writeFileSync(configPath, JSON.stringify(config, null, 2));
     }
-  } catch {
-    // Don't fail execution if we can't update config
-    // The dialog will just appear
+  } catch (e) {
+    // Don't fail execution if we can't update config — the trust dialog will just appear
+    writeLine(`  ${colors.dim}warn: config update failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
   }
 }
 
@@ -839,8 +843,8 @@ async function autoCommitAgentWork(
       } else {
         spawnSync('git', ['push', 'origin', 'HEAD'], { ...execOpts, stdio: 'pipe' });
       }
-    } catch {
-      // Push failed - continue, the commit is still local
+    } catch (e) {
+      writeLine(`  ${colors.dim}warn: git push failed (commit is still local): ${e instanceof Error ? e.message : String(e)}${RESET}`);
     }
 
     return { committed: true, message: `Committed changes from ${agentName}` };
@@ -1032,8 +1036,8 @@ async function emitExecutionEvent(
         signal: AbortSignal.timeout(EXECUTION_EVENT_TIMEOUT_MS),
       });
       return;
-    } catch {
-      // API unavailable — fall through to file
+    } catch (e) {
+      // API unavailable — fall through to file-based event recording
     }
   }
 
@@ -1056,7 +1060,7 @@ async function emitExecutionEvent(
       existing = readFileSync(eventsPath, 'utf-8');
     }
     writeFileSync(eventsPath, existing + entry);
-  } catch {
+  } catch (e) {
     // Truly fail-safe — never block execution
   }
 }
@@ -1090,7 +1094,8 @@ async function verifyExecution(
       encoding: 'utf-8',
       cwd: projectRoot,
     }).trim();
-  } catch {
+  } catch (e) {
+    if (options.verbose) writeLine(`  ${colors.dim}warn: git log failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
     recentCommits = '(no commits found)';
   }
 
@@ -1289,8 +1294,8 @@ async function runCloudDispatch(
             }
           }
         }
-      } catch {
-        // Poll failures are non-fatal — retry on next interval
+      } catch (e) {
+        if (options.verbose) writeLine(`  ${colors.dim}warn: cloud poll failed (retrying): ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
 
       await new Promise(resolve => setTimeout(resolve, CLOUD_POLL_INTERVAL_MS));
@@ -1919,8 +1924,8 @@ async function runAgent(
         }
       }
     }
-  } catch {
-    // Silent — cognition injection is best-effort
+  } catch (e) {
+    if (options.verbose) writeLine(`  ${colors.dim}warn: cognition fetch failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
   }
 
   // Generate the Claude Code prompt with timeout awareness
@@ -2251,8 +2256,9 @@ function createAgentWorktree(projectRoot: string, squadName: string, agentName: 
     mkdirSync(join(projectRoot, '..', '.worktrees'), { recursive: true });
     execSync(`git worktree add '${worktreePath}' -b '${branchName}' HEAD`, { cwd: projectRoot, stdio: 'pipe' });
     return worktreePath;
-  } catch {
-    return projectRoot; // Fall back to project root
+  } catch (e) {
+    writeLine(`  ${colors.dim}warn: worktree creation failed, using project root: ${e instanceof Error ? e.message : String(e)}${RESET}`);
+    return projectRoot;
   }
 }
 
@@ -2570,8 +2576,8 @@ async function executeWithProvider(
     mkdirSync(join(projectRoot, '..', '.worktrees'), { recursive: true });
     execSync(`git worktree add '${worktreePath}' -b '${branchName}' HEAD`, { cwd: projectRoot, stdio: 'pipe' });
     workDir = worktreePath;
-  } catch {
-    // Worktree creation failed — fall back to project root
+  } catch (e) {
+    writeLine(`  ${colors.dim}warn: worktree creation failed, using project root: ${e instanceof Error ? e.message : String(e)}${RESET}`);
   }
 
   // Copy .agents directory into worktree so sandboxed providers can access
@@ -2584,8 +2590,8 @@ async function executeWithProvider(
     if (existsSync(agentsDir) && !existsSync(targetAgentsDir)) {
       try {
         cpSync(agentsDir, targetAgentsDir, { recursive: true });
-      } catch {
-        // Non-fatal: agent def may still be accessible if tracked in git
+      } catch (e) {
+        writeLine(`  ${colors.dim}warn: .agents copy failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
       }
     }
     // Rewrite absolute paths in prompt so sandboxed providers can resolve them


### PR DESCRIPTION
## Summary
- Replaces 21 silent `catch {}` blocks in `run.ts` with error-capturing catches that surface failure details
- **Critical path** catches (bridge registration, preflight gate, learnings fetch) now always log warnings — these mask real failures during agent execution
- **Context-gathering** catches (SQUAD.md, goals, directives, state, briefs) log when `--verbose` is enabled
- **Operational** catches (worktree creation, git push, config update) log at info level
- Left `unlinkSync` temp file cleanup and fail-safe event recording as-is (truly trivial)

## Changes
- `src/commands/run.ts` — 21 catch blocks updated

## Testing
- [x] `npm run build` passes
- [x] All 1440 tests pass (0 failures)
- [x] No new dependencies added

Closes #452

---
Agent: engineering/issue-solver
Squad: engineering
Model: claude-opus-4-6