### PR TITLE
code(sync): replace hardcoded squad mappings with dynamic discovery

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { findMemoryDir } from '../lib/memory.js';
-import { findSquadsDir } from '../lib/squad-parser.js';
+import { findSquadsDir, listSquads, parseSquadFile } from '../lib/squad-parser.js';
 import { syncAllCycleData, isPostgresAvailable, closeCycleSyncPool, SyncResult } from '../lib/cycle-sync.js';
 import {
   colors,
@@ -26,35 +26,81 @@ interface _SquadUpdate {
   summary: string;
 }
 
-// Map file paths to squads
-const PATH_TO_SQUAD: Record<string, string> = {
-  'squads-cli': 'product',
-  'agents-squads-web': 'website',
-  'research': 'research',
-  'intelligence': 'intelligence',
-  'customer': 'customer',
-  'finance': 'finance',
-  'engineering': 'engineering',
-  'product': 'product',
-  'company': 'company',
-  '.agents/squads': 'engineering',
-  '.agents/memory': 'engineering',
-};
+interface SquadMappings {
+  pathToSquad: Record<string, string>;
+  messageToSquad: Record<string, string>;
+}
 
-// Keywords in commit messages that map to squads
-const MESSAGE_TO_SQUAD: Record<string, string> = {
-  'cli': 'product',
-  'website': 'website',
-  'web': 'website',
-  'homepage': 'website',
-  'research': 'research',
-  'intel': 'intelligence',
-  'lead': 'customer',
-  'finance': 'finance',
-  'cost': 'finance',
-  'engineering': 'engineering',
-  'infra': 'engineering',
-};
+/**
+ * Build squad mappings dynamically from the current project's squad definitions.
+ * Uses `repo:` frontmatter field for path mapping and squad dir name as keyword fallback.
+ * Falls back to static defaults when no squads directory is found (e.g., fresh installs).
+ */
+function buildSquadMappings(): SquadMappings {
+  const pathToSquad: Record<string, string> = {};
+  const messageToSquad: Record<string, string> = {};
+
+  const squadsDir = findSquadsDir();
+  if (squadsDir) {
+    const squadNames = listSquads(squadsDir);
+    for (const name of squadNames) {
+      const squadFile = `${squadsDir}/${name}/SQUAD.md`;
+      try {
+        const squad = parseSquadFile(squadFile);
+        // repo: field maps a repo name to this squad
+        if (squad.repo) {
+          pathToSquad[squad.repo] = name;
+        }
+        // Squad dir name matches itself as a path pattern and keyword
+        pathToSquad[name] = name;
+        messageToSquad[name] = name;
+      } catch {
+        // Corrupt SQUAD.md — skip silently, dir name still usable
+        pathToSquad[name] = name;
+        messageToSquad[name] = name;
+      }
+    }
+    // Always map .agents dirs to engineering (structural convention)
+    if (squadNames.includes('engineering')) {
+      pathToSquad['.agents/squads'] = 'engineering';
+      pathToSquad['.agents/memory'] = 'engineering';
+    }
+  }
+
+  // If dynamic discovery found nothing (no squads dir), fall back to static defaults
+  if (Object.keys(pathToSquad).length === 0) {
+    return {
+      pathToSquad: {
+        'squads-cli': 'product',
+        'agents-squads-web': 'website',
+        'research': 'research',
+        'intelligence': 'intelligence',
+        'customer': 'customer',
+        'finance': 'finance',
+        'engineering': 'engineering',
+        'product': 'product',
+        'company': 'company',
+        '.agents/squads': 'engineering',
+        '.agents/memory': 'engineering',
+      },
+      messageToSquad: {
+        'cli': 'product',
+        'website': 'website',
+        'web': 'website',
+        'homepage': 'website',
+        'research': 'research',
+        'intel': 'intelligence',
+        'lead': 'customer',
+        'finance': 'finance',
+        'cost': 'finance',
+        'engineering': 'engineering',
+        'infra': 'engineering',
+      },
+    };
+  }
+
+  return { pathToSquad, messageToSquad };
+}
 
 function getLastSyncTime(memoryDir: string): string | null {
   const syncFile = join(memoryDir, '.last-sync');
@@ -110,12 +156,12 @@ function getRecentCommits(since?: string): CommitInfo[] {
   return commits;
 }
 
-function detectSquadsFromCommit(commit: CommitInfo): string[] {
+function detectSquadsFromCommit(commit: CommitInfo, mappings: SquadMappings): string[] {
   const squads = new Set<string>();
 
   // Check file paths
   for (const file of commit.files) {
-    for (const [pathPattern, squad] of Object.entries(PATH_TO_SQUAD)) {
+    for (const [pathPattern, squad] of Object.entries(mappings.pathToSquad)) {
       if (file.includes(pathPattern)) {
         squads.add(squad);
       }
@@ -124,7 +170,7 @@ function detectSquadsFromCommit(commit: CommitInfo): string[] {
 
   // Check commit message
   const msgLower = commit.message.toLowerCase();
-  for (const [keyword, squad] of Object.entries(MESSAGE_TO_SQUAD)) {
+  for (const [keyword, squad] of Object.entries(mappings.messageToSquad)) {
     if (msgLower.includes(keyword)) {
       squads.add(squad);
     }
@@ -133,11 +179,11 @@ function detectSquadsFromCommit(commit: CommitInfo): string[] {
   return Array.from(squads);
 }
 
-function groupCommitsBySquad(commits: CommitInfo[]): Map<string, CommitInfo[]> {
+function groupCommitsBySquad(commits: CommitInfo[], mappings: SquadMappings): Map<string, CommitInfo[]> {
   const grouped = new Map<string, CommitInfo[]>();
 
   for (const commit of commits) {
-    const squads = detectSquadsFromCommit(commit);
+    const squads = detectSquadsFromCommit(commit, mappings);
 
     for (const squad of squads) {
       if (!grouped.has(squad)) {
@@ -463,9 +509,9 @@ const SIGNIFICANT_PATTERNS = [
 /**
  * Analyze commits and generate learnings based on patterns
  */
-function analyzeCommitsForLearnings(commits: CommitInfo[]): GeneratedLearning[] {
+function analyzeCommitsForLearnings(commits: CommitInfo[], mappings: SquadMappings): GeneratedLearning[] {
   const learnings: GeneratedLearning[] = [];
-  const squadCommits = groupCommitsBySquad(commits);
+  const squadCommits = groupCommitsBySquad(commits, mappings);
 
   for (const [squad, squadCommitList] of squadCommits) {
     // Group by category (feat, fix, etc.)
@@ -814,7 +860,7 @@ export async function syncCommand(options: { verbose?: boolean; push?: boolean; 
     writeLine(`  ${icons.progress} Analyzing ${colors.cyan}${commits.length}${RESET} commits...`);
 
     // Analyze and generate learnings
-    const learnings = analyzeCommitsForLearnings(commits);
+    const learnings = analyzeCommitsForLearnings(commits, buildSquadMappings());
 
     if (learnings.length === 0) {
       writeLine(`  ${colors.dim}No significant patterns detected${RESET}`);
@@ -964,8 +1010,8 @@ export async function syncCommand(options: { verbose?: boolean; push?: boolean; 
   writeLine(`  ${colors.cyan}${commits.length}${RESET} commits to process`);
   writeLine();
 
-  // Group by squad
-  const bySquad = groupCommitsBySquad(commits);
+  // Group by squad (mappings built dynamically from local squad definitions)
+  const bySquad = groupCommitsBySquad(commits, buildSquadMappings());
 
   if (bySquad.size === 0) {
     writeLine(`  ${colors.yellow}No squad-related commits found${RESET}`);


### PR DESCRIPTION
## Summary

- Replaces static `PATH_TO_SQUAD` and `MESSAGE_TO_SQUAD` tables with `buildSquadMappings()` — built at runtime from the local `.agents/squads/` directory
- Uses `listSquads()` to discover all squad names without hardcoding
- Reads `repo:` frontmatter field from each `SQUAD.md` for path mapping
- Falls back to static defaults when no squads dir is found (fresh installs, CI)

## Before

```typescript
// Hardcoded — requires code change for every new squad
const PATH_TO_SQUAD = {
  'squads-cli': 'product',
  'agents-squads-web': 'website',
  // ...
};
```

## After

```typescript
// Dynamic — reads from .agents/squads/ at runtime
function buildSquadMappings(): SquadMappings {
  const squadsDir = findSquadsDir();
  const squadNames = listSquads(squadsDir);
  for (const name of squadNames) {
    const squad = parseSquadFile(...);
    if (squad.repo) pathToSquad[squad.repo] = name; // repo: field in SQUAD.md
    pathToSquad[name] = name;   // dir name as fallback
    messageToSquad[name] = name; // keyword fallback
  }
}
```

Adding `repo: squads-cli` to a SQUAD.md now immediately maps that repo to the squad — no code change required.

## Issues

- Closes #454

---
Agent: cli/issue-solver