### PR TITLE
fix(init): remove wrong 'git commit' step from getting-started output

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -593,17 +593,16 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine();
   writeLine(chalk.bold('  Getting started:'));
   writeLine();
-  writeLine(`     ${chalk.cyan('1.')} ${chalk.yellow('git add -A && git commit -m "feat: init AI workforce"')}`);
-  writeLine(chalk.dim('        Git is the coordination layer — commit first'));
-  writeLine();
-
   // Dynamic "first run" suggestion based on use case
   const firstRunCommand = getFirstRunCommand(selectedUseCase);
-  writeLine(`     ${chalk.cyan('2.')} ${chalk.yellow(firstRunCommand.command)}`);
+  writeLine(`     ${chalk.cyan('1.')} ${chalk.yellow(firstRunCommand.command)}`);
   writeLine(chalk.dim(`        ${firstRunCommand.description}`));
   writeLine();
-  writeLine(`     ${chalk.cyan('3.')} ${chalk.yellow(`squads dash`)}`);
+  writeLine(`     ${chalk.cyan('2.')} ${chalk.yellow(`squads dash`)}`);
   writeLine(chalk.dim('        See all your squads and agents at a glance'));
+  writeLine();
+  writeLine(`     ${chalk.cyan('3.')} ${chalk.yellow('$EDITOR .agents/BUSINESS_BRIEF.md')}`);
+  writeLine(chalk.dim('        Customize your business context for better results'));
   writeLine();
   writeLine(chalk.dim('  Docs: https://agents-squads.com/docs/getting-started'));
   writeLine();


### PR DESCRIPTION
## Summary

Removes the incorrect step 1 (`git add -A && git commit`) from the getting-started output shown after `squads init`. This step is misleading because init either already commits or the manual commit only captures memory files unrelated to setup.

## Changes

- Removed step 1 "git commit" instruction
- Renumbered: run first agent → step 1, `squads dash` → step 2
- Added new step 3: customize `BUSINESS_BRIEF.md` for better agent results
- Build passes, no test changes needed (output-only change)

## Before → After

**Before:**
```
1. git add -A && git commit -m "feat: init AI workforce"
2. squads run research/researcher
3. squads dash
```

**After:**
```
1. squads run research/researcher
2. squads dash
3. $EDITOR .agents/BUSINESS_BRIEF.md
```

Closes #521

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |
| Target | develop |