### PR TITLE
fix(run): remove spurious auth warning for OAuth users

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -41,7 +41,6 @@ import { getApiUrl, getBridgeUrl } from '../lib/env-config.js';
 import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
 import { reportExecutionStart, reportConversationResult, pushCognitionSignal } from '../lib/api-client.js';
 import { getBotGitEnv, getBotPushUrl, getCoAuthorTrailer } from '../lib/github.js';
-import { homedir } from 'os';
 
 // ── Operational constants (no magic numbers) ──────────────────────────
 const CLOUD_POLL_INTERVAL_MS = 3000;
@@ -2151,25 +2150,9 @@ async function preflightExecutorCheck(provider: string): Promise<boolean> {
     return false;
   }
 
-  // --- Check 2: Authentication (Anthropic only — other providers handle auth internally) ---
-  if (isAnthropic) {
-    const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
-
-    // Check for OAuth credentials (Max subscription or claude login)
-    const home = homedir();
-    const credentialsPath = join(home, '.claude', '.credentials.json');
-    const hasOAuthCreds = existsSync(credentialsPath);
-
-    if (!hasApiKey && !hasOAuthCreds) {
-      writeLine();
-      writeLine(`  ${icons.warning} ${colors.yellow}Claude not authenticated${RESET}`);
-      writeLine(`  ${colors.dim}No API key or credentials found. To authenticate:${RESET}`);
-      writeLine(`  ${colors.dim}  Option 1 (Max subscription): run ${colors.cyan}claude${colors.dim} and log in${RESET}`);
-      writeLine(`  ${colors.dim}  Option 2 (API key): export ANTHROPIC_API_KEY=sk-ant-...${RESET}`);
-      writeLine(`  ${colors.dim}  Option 3 (check status): run ${colors.cyan}squads doctor${colors.dim} to diagnose${RESET}`);
-      writeLine();
-    }
-  }
+  // Auth check removed: Claude CLI handles its own auth errors with clear messages.
+  // Pre-checking here caused false warnings for OAuth users (keychain auth works
+  // without .credentials.json or ANTHROPIC_API_KEY). See #520.
 
   return true;
 }


### PR DESCRIPTION
## Summary

Removes the misleading "Claude not authenticated" warning from `preflightExecutorCheck`. The check only looked for `.credentials.json` or `ANTHROPIC_API_KEY`, but OAuth via keychain (Max subscription) works without either file. This caused auth anxiety on every typo or error.

## Changes

- Removed auth pre-check in `preflightExecutorCheck` (Claude CLI handles its own auth errors)
- Removed unused `homedir` import from `os`

## Rationale

Claude CLI already provides clear auth errors when actually unauthenticated. Pre-checking created false positives for the majority of users who authenticate via OAuth/keychain.

Closes #520

---
🤖 Generated with [Agents Squads](https://agents-squads.com)

| Attribution | Value |
|-------------|-------|
| Agent | engineering/issue-solver |
| Squad | engineering |
| Model | claude-opus-4-6 |
| Target | develop |