### PR TITLE
fix(run): provider crash on v0.7.0 — hotfix v0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squads-cli",
-  "version": "0.6.2",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squads-cli",
-      "version": "0.6.2",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squads-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Your AI workforce. Every user gets an AI manager that runs their team — finance, marketing, engineering, operations — for the cost of API calls.",
   "type": "module",
   "bin": {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2418,7 +2418,7 @@ async function executeWithClaude(
 
     return executeForeground({
       prompt, claudeArgs, agentEnv, projectRoot,
-      squadName, agentName, execContext, startMs, provider,
+      squadName, agentName, execContext, startMs, provider: detectedProvider,
     });
   }
 

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,156 @@
+/**
+ * squads stats — AI workforce intelligence.
+ *
+ * Two modes:
+ *   squads stats           → executive summary + scorecard table + insights
+ *   squads stats --json    → machine-readable for dashboards
+ *
+ * The intelligence layer turns raw GitHub outcomes into business language:
+ * ROI, hours saved, recommendations, trends. This is what enterprise
+ * customers see — not merge percentages.
+ */
+
+import {
+  computeAllScorecards,
+  getOutcomeRecords,
+} from '../lib/outcomes.js';
+import {
+  generateWorkforceSummary,
+  generateExecutiveSummary,
+} from '../lib/insights.js';
+import {
+  colors,
+  bold,
+  RESET,
+  writeLine,
+} from '../lib/terminal.js';
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function padRight(str: string, len: number): string {
+  const plain = str.replace(/\x1b\[[0-9;]*m/g, '');
+  const pad = Math.max(0, len - plain.length);
+  return str + ' '.repeat(pad);
+}
+
+function rateColor(rate: number, goodThreshold: number, badThreshold: number): string {
+  if (rate >= goodThreshold) return colors.green;
+  if (rate <= badThreshold) return colors.red;
+  return colors.yellow;
+}
+
+const insightIcons: Record<string, string> = {
+  highlight: `${colors.green}*${RESET}`,
+  warning: `${colors.yellow}!${RESET}`,
+  recommendation: `${colors.cyan}>${RESET}`,
+  trend: `${colors.purple}~${RESET}`,
+};
+
+export async function statsCommand(options: {
+  squad?: string;
+  period?: string;
+  json?: boolean;
+}): Promise<void> {
+  const period = (options.period === '30d' ? '30d' : '7d') as '7d' | '30d';
+  const summary = generateWorkforceSummary(period);
+
+  // Filter scorecards by squad
+  const scorecards = options.squad
+    ? computeAllScorecards(period).filter(s => s.squad === options.squad)
+    : computeAllScorecards(period);
+
+  if (options.json) {
+    writeLine(JSON.stringify({
+      executive_summary: generateExecutiveSummary(period),
+      ...summary,
+      scorecards,
+    }, null, 2));
+    return;
+  }
+
+  const periodLabel = period === '7d' ? 'Last 7 days' : 'Last 30 days';
+
+  writeLine();
+  writeLine(`  ${bold}AI Workforce Intelligence${RESET} ${colors.dim}(${periodLabel})${RESET}`);
+  writeLine();
+
+  // ── Executive summary ──────────────────────────────────────────────
+
+  const execSummary = generateExecutiveSummary(period);
+  writeLine(`  ${execSummary}`);
+  writeLine();
+
+  // ── Key metrics ────────────────────────────────────────────────────
+
+  if (summary.totalExecutions > 0) {
+    writeLine(`  ${bold}Key Metrics${RESET}`);
+    writeLine(`  ${colors.dim}${'─'.repeat(50)}${RESET}`);
+
+    const roiColor = summary.roiMultiplier >= 3 ? colors.green
+      : summary.roiMultiplier >= 1 ? colors.yellow
+      : colors.red;
+
+    writeLine(`  Executions     ${bold}${summary.totalExecutions}${RESET}`);
+    writeLine(`  Issues resolved${bold} ${summary.issuesResolved}${RESET}    PRs merged ${bold}${summary.prsMerged}${RESET}`);
+    writeLine(`  Total cost     ${bold}$${summary.totalCostUsd.toFixed(2)}${RESET}`);
+    writeLine(`  Hours saved    ${bold}~${summary.estimatedHoursSaved.toFixed(0)}h${RESET} ${colors.dim}(at $${parseFloat(process.env.SQUADS_HOURLY_RATE || '75')}/hr)${RESET}`);
+    writeLine(`  ROI            ${roiColor}${bold}${summary.roiMultiplier.toFixed(1)}x${RESET} ${colors.dim}($${summary.estimatedValueUsd.toFixed(0)} estimated value)${RESET}`);
+    writeLine();
+  }
+
+  // ── Scorecard table ────────────────────────────────────────────────
+
+  if (scorecards.length > 0) {
+    writeLine(`  ${bold}Agent Scorecards${RESET}`);
+    writeLine(`  ${colors.dim}${'─'.repeat(82)}${RESET}`);
+
+    const header = [
+      padRight(`${colors.dim}Squad/Agent${RESET}`, 30),
+      padRight(`${colors.dim}Runs${RESET}`, 8),
+      padRight(`${colors.dim}Merge${RESET}`, 10),
+      padRight(`${colors.dim}Resolve${RESET}`, 10),
+      padRight(`${colors.dim}Waste${RESET}`, 10),
+      padRight(`${colors.dim}CI${RESET}`, 8),
+      `${colors.dim}$/out${RESET}`,
+    ].join('');
+    writeLine(`  ${header}`);
+
+    for (const card of scorecards) {
+      const name = `${card.squad}/${card.agent}`;
+      const mergeColor = rateColor(card.mergeRate, 0.7, 0.3);
+      const resolveColor = rateColor(card.issueResolutionRate, 0.5, 0.2);
+      const wasteColor = rateColor(1 - card.wasteRate, 0.7, 0.5);
+      const ciColor = rateColor(card.ciPassRate, 0.8, 0.5);
+      const costColor = card.costPerOutcome > 5 ? colors.red : card.costPerOutcome > 3 ? colors.yellow : colors.green;
+
+      const row = [
+        padRight(`${colors.cyan}${name}${RESET}`, 30),
+        padRight(`${card.executions}`, 8),
+        padRight(`${mergeColor}${pct(card.mergeRate)}${RESET}`, 10),
+        padRight(`${resolveColor}${pct(card.issueResolutionRate)}${RESET}`, 10),
+        padRight(`${wasteColor}${pct(card.wasteRate)}${RESET}`, 10),
+        padRight(`${ciColor}${pct(card.ciPassRate)}${RESET}`, 8),
+        `${costColor}$${card.costPerOutcome.toFixed(2)}${RESET}`,
+      ].join('');
+
+      writeLine(`  ${row}`);
+    }
+    writeLine();
+  }
+
+  // ── Insights ───────────────────────────────────────────────────────
+
+  if (summary.insights.length > 0) {
+    writeLine(`  ${bold}Insights${RESET}`);
+    writeLine(`  ${colors.dim}${'─'.repeat(50)}${RESET}`);
+
+    for (const insight of summary.insights) {
+      const icon = insightIcons[insight.type] || ' ';
+      writeLine(`  ${icon} ${bold}${insight.title}${RESET}`);
+      writeLine(`    ${colors.dim}${insight.detail}${RESET}`);
+    }
+    writeLine();
+  }
+}

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,0 +1,354 @@
+/**
+ * Intelligence layer — turns raw outcome data into executive-grade insights.
+ *
+ * This is the enterprise value: less technical users see plain-language
+ * summaries, ROI calculations, trends, and actionable recommendations
+ * instead of raw merge rates and CI percentages.
+ */
+
+import {
+  computeAllScorecards,
+  getOutcomeRecords,
+  type AgentScorecard,
+  type OutcomeRecord,
+} from './outcomes.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface ExecutiveInsight {
+  type: 'highlight' | 'warning' | 'recommendation' | 'trend';
+  title: string;
+  detail: string;
+  squad?: string;
+  agent?: string;
+  metric?: string;
+  value?: number;
+}
+
+export interface WorkforceSummary {
+  period: '7d' | '30d';
+  totalExecutions: number;
+  totalCostUsd: number;
+  issuesResolved: number;
+  prsMerged: number;
+  estimatedHoursSaved: number;
+  estimatedValueUsd: number;
+  roiMultiplier: number;
+  overallMergeRate: number;
+  overallWasteRate: number;
+  topPerformer: { name: string; mergeRate: number } | null;
+  underperformer: { name: string; reason: string } | null;
+  insights: ExecutiveInsight[];
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+// Configurable via env vars — enterprise customers set their own values
+const HOURS_PER_ISSUE_RESOLVED = parseFloat(process.env.SQUADS_HOURS_PER_ISSUE || '4');
+const HOURS_PER_PR_MERGED = parseFloat(process.env.SQUADS_HOURS_PER_PR || '2');
+const HOURLY_RATE = parseFloat(process.env.SQUADS_HOURLY_RATE || '75');
+
+// ── Core ─────────────────────────────────────────────────────────────
+
+/**
+ * Generate a full workforce summary with insights.
+ * This is what enterprise dashboards and executive reports consume.
+ */
+export function generateWorkforceSummary(period: '7d' | '30d' = '7d'): WorkforceSummary {
+  const scorecards = computeAllScorecards(period);
+  const records = getOutcomeRecords();
+  const periodMs = period === '7d' ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - periodMs;
+
+  const periodRecords = records.filter(
+    r => new Date(r.completedAt).getTime() > cutoff,
+  );
+
+  // Aggregate metrics
+  const totalExecutions = periodRecords.length;
+  const totalCostUsd = periodRecords.reduce((sum, r) => sum + r.costUsd, 0);
+  const issuesResolved = periodRecords.reduce((sum, r) => sum + r.outcomes.issuesClosed, 0);
+  const prsMerged = periodRecords.reduce((sum, r) => sum + r.outcomes.prsMerged, 0);
+
+  // ROI calculation
+  const estimatedHoursSaved =
+    (issuesResolved * HOURS_PER_ISSUE_RESOLVED) +
+    (prsMerged * HOURS_PER_PR_MERGED);
+  const estimatedValueUsd = estimatedHoursSaved * HOURLY_RATE;
+  const roiMultiplier = totalCostUsd > 0 ? estimatedValueUsd / totalCostUsd : 0;
+
+  // Aggregate rates
+  const totalPRs = periodRecords.reduce((sum, r) => sum + r.artifacts.prsCreated.length, 0);
+  const overallMergeRate = totalPRs > 0 ? prsMerged / totalPRs : 0;
+
+  const wasteRuns = periodRecords.filter(
+    r => r.artifacts.prsCreated.length === 0 &&
+         r.artifacts.issuesCreated.length === 0 &&
+         r.artifacts.commits === 0,
+  ).length;
+  const overallWasteRate = totalExecutions > 0 ? wasteRuns / totalExecutions : 0;
+
+  // Find top performer and underperformer
+  const withData = scorecards.filter(s => s.executions >= 2);
+  const topPerformer = findTopPerformer(withData);
+  const underperformer = findUnderperformer(withData);
+
+  // Generate insights
+  const insights = generateInsights(scorecards, periodRecords, {
+    totalCostUsd,
+    issuesResolved,
+    prsMerged,
+    overallMergeRate,
+    overallWasteRate,
+    roiMultiplier,
+    estimatedHoursSaved,
+  });
+
+  return {
+    period,
+    totalExecutions,
+    totalCostUsd,
+    issuesResolved,
+    prsMerged,
+    estimatedHoursSaved,
+    estimatedValueUsd,
+    roiMultiplier,
+    overallMergeRate,
+    overallWasteRate,
+    topPerformer,
+    underperformer,
+    insights,
+  };
+}
+
+// ── Insight generation ───────────────────────────────────────────────
+
+function findTopPerformer(cards: AgentScorecard[]): { name: string; mergeRate: number } | null {
+  if (cards.length === 0) return null;
+
+  // Score by weighted composite: merge rate + resolution rate - waste rate
+  const scored = cards.map(c => ({
+    name: `${c.squad}/${c.agent}`,
+    mergeRate: c.mergeRate,
+    composite: (c.mergeRate * 0.4) + (c.issueResolutionRate * 0.4) - (c.wasteRate * 0.2),
+  }));
+
+  scored.sort((a, b) => b.composite - a.composite);
+  return scored[0] ? { name: scored[0].name, mergeRate: scored[0].mergeRate } : null;
+}
+
+function findUnderperformer(cards: AgentScorecard[]): { name: string; reason: string } | null {
+  if (cards.length === 0) return null;
+
+  for (const c of cards) {
+    if (c.wasteRate > 0.5) {
+      return {
+        name: `${c.squad}/${c.agent}`,
+        reason: `${Math.round(c.wasteRate * 100)}% of runs produce no output`,
+      };
+    }
+    if (c.mergeRate < 0.2 && c.executions >= 3) {
+      return {
+        name: `${c.squad}/${c.agent}`,
+        reason: `Only ${Math.round(c.mergeRate * 100)}% of PRs get merged`,
+      };
+    }
+    if (c.costPerOutcome > 5) {
+      return {
+        name: `${c.squad}/${c.agent}`,
+        reason: `$${c.costPerOutcome.toFixed(2)} per outcome — most expensive agent`,
+      };
+    }
+  }
+
+  return null;
+}
+
+interface AggregateMetrics {
+  totalCostUsd: number;
+  issuesResolved: number;
+  prsMerged: number;
+  overallMergeRate: number;
+  overallWasteRate: number;
+  roiMultiplier: number;
+  estimatedHoursSaved: number;
+}
+
+function generateInsights(
+  scorecards: AgentScorecard[],
+  records: OutcomeRecord[],
+  metrics: AggregateMetrics,
+): ExecutiveInsight[] {
+  const insights: ExecutiveInsight[] = [];
+
+  // ROI insight
+  if (metrics.roiMultiplier > 0) {
+    if (metrics.roiMultiplier >= 3) {
+      insights.push({
+        type: 'highlight',
+        title: 'Strong ROI',
+        detail: `Your AI workforce delivered ${metrics.roiMultiplier.toFixed(1)}x return — $${metrics.totalCostUsd.toFixed(2)} spent, ~$${(metrics.estimatedHoursSaved * HOURLY_RATE).toFixed(0)} in estimated engineering time saved.`,
+        metric: 'roi',
+        value: metrics.roiMultiplier,
+      });
+    } else if (metrics.roiMultiplier >= 1) {
+      insights.push({
+        type: 'highlight',
+        title: 'Positive ROI',
+        detail: `AI workforce is paying for itself at ${metrics.roiMultiplier.toFixed(1)}x. ${metrics.estimatedHoursSaved.toFixed(0)} engineering hours saved.`,
+        metric: 'roi',
+        value: metrics.roiMultiplier,
+      });
+    } else if (metrics.totalCostUsd > 0) {
+      insights.push({
+        type: 'warning',
+        title: 'ROI below breakeven',
+        detail: `Currently at ${metrics.roiMultiplier.toFixed(1)}x — spending more than the estimated value of output. Review agent effectiveness.`,
+        metric: 'roi',
+        value: metrics.roiMultiplier,
+      });
+    }
+  }
+
+  // Productivity highlights
+  if (metrics.issuesResolved > 0 || metrics.prsMerged > 0) {
+    insights.push({
+      type: 'highlight',
+      title: 'Work delivered',
+      detail: `${metrics.issuesResolved} issue${metrics.issuesResolved !== 1 ? 's' : ''} resolved, ${metrics.prsMerged} PR${metrics.prsMerged !== 1 ? 's' : ''} merged — equivalent to ~${metrics.estimatedHoursSaved.toFixed(0)} hours of engineering work.`,
+      metric: 'productivity',
+    });
+  }
+
+  // Waste warning
+  if (metrics.overallWasteRate > 0.3 && records.length >= 3) {
+    insights.push({
+      type: 'warning',
+      title: 'High waste rate',
+      detail: `${Math.round(metrics.overallWasteRate * 100)}% of agent runs produce no output. Review agent prompts, issue quality, or available context.`,
+      metric: 'waste',
+      value: metrics.overallWasteRate,
+    });
+  }
+
+  // Per-agent insights
+  for (const card of scorecards) {
+    if (card.executions < 3) continue;
+
+    // Star performer
+    if (card.mergeRate > 0.8 && card.wasteRate < 0.1) {
+      insights.push({
+        type: 'highlight',
+        title: `${card.squad}/${card.agent} is a star`,
+        detail: `${Math.round(card.mergeRate * 100)}% merge rate with only ${Math.round(card.wasteRate * 100)}% waste across ${card.executions} runs.`,
+        squad: card.squad,
+        agent: card.agent,
+        metric: 'performance',
+      });
+    }
+
+    // Struggling agent
+    if (card.wasteRate > 0.5) {
+      insights.push({
+        type: 'recommendation',
+        title: `Review ${card.squad}/${card.agent}`,
+        detail: `${Math.round(card.wasteRate * 100)}% waste rate. Consider: improving agent prompt, adding more context, or pausing this agent until issues are better-scoped.`,
+        squad: card.squad,
+        agent: card.agent,
+        metric: 'waste',
+      });
+    }
+
+    // Low merge rate with enough data
+    if (card.mergeRate < 0.3 && card.executions >= 5) {
+      insights.push({
+        type: 'recommendation',
+        title: `${card.squad}/${card.agent} PRs rarely merge`,
+        detail: `Only ${Math.round(card.mergeRate * 100)}% merge rate. PRs may need better scoping, testing, or review workflow adjustments.`,
+        squad: card.squad,
+        agent: card.agent,
+        metric: 'merge_rate',
+      });
+    }
+
+    // CI failures
+    if (card.ciPassRate < 0.5 && card.executions >= 3) {
+      insights.push({
+        type: 'recommendation',
+        title: `${card.squad}/${card.agent} CI issues`,
+        detail: `Only ${Math.round(card.ciPassRate * 100)}% of PRs pass CI on first push. Agent may need build/test context in its prompt.`,
+        squad: card.squad,
+        agent: card.agent,
+        metric: 'ci_pass_rate',
+      });
+    }
+  }
+
+  // No data yet
+  if (records.length === 0) {
+    insights.push({
+      type: 'recommendation',
+      title: 'Start tracking',
+      detail: 'No outcome data yet. Run the daemon to start tracking agent productivity automatically.',
+    });
+  } else if (records.length < 5) {
+    insights.push({
+      type: 'recommendation',
+      title: 'Building baseline',
+      detail: `${records.length} execution${records.length !== 1 ? 's' : ''} tracked so far. Insights improve with more data — 10+ executions recommended for reliable patterns.`,
+    });
+  }
+
+  return insights;
+}
+
+/**
+ * Generate a one-paragraph executive summary.
+ * This is the "surprise" for less technical users — plain English.
+ */
+export function generateExecutiveSummary(period: '7d' | '30d' = '7d'): string {
+  const summary = generateWorkforceSummary(period);
+  const periodLabel = period === '7d' ? 'this week' : 'this month';
+
+  if (summary.totalExecutions === 0) {
+    return `No AI workforce activity ${periodLabel}. Start the daemon to begin autonomous operations.`;
+  }
+
+  const parts: string[] = [];
+
+  // Activity
+  parts.push(
+    `Your AI workforce ran ${summary.totalExecutions} time${summary.totalExecutions !== 1 ? 's' : ''} ${periodLabel}`,
+  );
+
+  // Output
+  if (summary.issuesResolved > 0 || summary.prsMerged > 0) {
+    const outputs: string[] = [];
+    if (summary.issuesResolved > 0) outputs.push(`${summary.issuesResolved} issue${summary.issuesResolved !== 1 ? 's' : ''}`);
+    if (summary.prsMerged > 0) outputs.push(`${summary.prsMerged} PR${summary.prsMerged !== 1 ? 's' : ''}`);
+    parts.push(`delivering ${outputs.join(' and ')}`);
+  }
+
+  // Cost and ROI
+  parts.push(`at a cost of $${summary.totalCostUsd.toFixed(2)}`);
+
+  if (summary.roiMultiplier > 0) {
+    parts.push(
+      `— an estimated ${summary.roiMultiplier.toFixed(1)}x return on investment (${summary.estimatedHoursSaved.toFixed(0)} engineering hours saved)`,
+    );
+  }
+
+  let text = parts.join(', ').replace(/, —/, ' —') + '.';
+
+  // Top performer callout
+  if (summary.topPerformer) {
+    text += ` Top performer: ${summary.topPerformer.name} (${Math.round(summary.topPerformer.mergeRate * 100)}% merge rate).`;
+  }
+
+  // Issue callout
+  if (summary.underperformer) {
+    text += ` Needs attention: ${summary.underperformer.name} — ${summary.underperformer.reason}.`;
+  }
+
+  return text;
+}

--- a/src/lib/outcomes.ts
+++ b/src/lib/outcomes.ts
@@ -1,0 +1,477 @@
+/**
+ * Outcome tracking — observes GitHub for artifact outcomes.
+ *
+ * Polls issues/PRs created by agent runs to determine if work
+ * was productive (merged, closed) or wasteful (abandoned, unmerged).
+ * Uses `gh` CLI for GitHub queries — no API keys needed.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface ArtifactRef {
+  repo: string;
+  number: number;
+}
+
+export interface OutcomeRecord {
+  executionId: string;
+  squad: string;
+  agent: string;
+  completedAt: string;
+  costUsd: number;
+  artifacts: {
+    issuesCreated: ArtifactRef[];
+    prsCreated: ArtifactRef[];
+    commits: number;
+  };
+  outcomes: {
+    issuesClosed: number;
+    issuesOpen: number;
+    prsMerged: number;
+    prsClosedUnmerged: number;
+    prsOpen: number;
+    ciPassFirstPush: boolean | null;
+    reviewCycleHours: number | null;
+  };
+  lastPolledAt: string;
+  settled: boolean;
+}
+
+export interface AgentScorecard {
+  squad: string;
+  agent: string;
+  period: '7d' | '30d';
+  executions: number;
+  wasteRate: number;
+  mergeRate: number;
+  issueResolutionRate: number;
+  ciPassRate: number;
+  avgReviewCycleHours: number;
+  costPerOutcome: number;
+}
+
+// ── Storage ──────────────────────────────────────────────────────────
+
+const OUTCOMES_DIR = join(homedir(), '.squads', 'daemon');
+const OUTCOMES_FILE = join(OUTCOMES_DIR, 'outcomes.json');
+
+interface OutcomesData {
+  records: OutcomeRecord[];
+  scorecards: AgentScorecard[];
+  lastUpdated: string;
+}
+
+function loadOutcomes(): OutcomesData {
+  if (!existsSync(OUTCOMES_DIR)) mkdirSync(OUTCOMES_DIR, { recursive: true });
+  if (!existsSync(OUTCOMES_FILE)) {
+    return { records: [], scorecards: [], lastUpdated: '' };
+  }
+  try {
+    return JSON.parse(readFileSync(OUTCOMES_FILE, 'utf-8'));
+  } catch {
+    return { records: [], scorecards: [], lastUpdated: '' };
+  }
+}
+
+function saveOutcomes(data: OutcomesData): void {
+  if (!existsSync(OUTCOMES_DIR)) mkdirSync(OUTCOMES_DIR, { recursive: true });
+  data.lastUpdated = new Date().toISOString();
+  writeFileSync(OUTCOMES_FILE, JSON.stringify(data, null, 2));
+}
+
+// ── GitHub helpers ───────────────────────────────────────────────────
+
+function ghExec(cmd: string, env?: Record<string, string>): string | null {
+  try {
+    return execSync(cmd, {
+      encoding: 'utf-8',
+      timeout: 15000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find PRs created by the bot in the last N minutes for a repo.
+ */
+function findRecentBotPRs(
+  repo: string,
+  sinceMins: number,
+  ghEnv?: Record<string, string>,
+): ArtifactRef[] {
+  const raw = ghExec(
+    `gh pr list -R ${repo} --author "agents-squads[bot]" --state all --json number,createdAt --limit 10`,
+    ghEnv,
+  );
+  if (!raw) return [];
+
+  try {
+    const prs = JSON.parse(raw) as Array<{ number: number; createdAt: string }>;
+    const cutoff = Date.now() - sinceMins * 60 * 1000;
+    return prs
+      .filter(pr => new Date(pr.createdAt).getTime() > cutoff)
+      .map(pr => ({ repo, number: pr.number }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find issues created by the bot in the last N minutes for a repo.
+ */
+function findRecentBotIssues(
+  repo: string,
+  sinceMins: number,
+  ghEnv?: Record<string, string>,
+): ArtifactRef[] {
+  const raw = ghExec(
+    `gh issue list -R ${repo} --author "agents-squads[bot]" --state all --json number,createdAt --limit 10`,
+    ghEnv,
+  );
+  if (!raw) return [];
+
+  try {
+    const issues = JSON.parse(raw) as Array<{ number: number; createdAt: string }>;
+    const cutoff = Date.now() - sinceMins * 60 * 1000;
+    return issues
+      .filter(i => new Date(i.createdAt).getTime() > cutoff)
+      .map(i => ({ repo, number: i.number }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Count commits on the default branch in the last N minutes.
+ */
+function countRecentCommits(
+  repo: string,
+  sinceMins: number,
+  ghEnv?: Record<string, string>,
+): number {
+  const since = new Date(Date.now() - sinceMins * 60 * 1000).toISOString();
+  const raw = ghExec(
+    `gh api repos/${repo}/commits --jq 'length' -f since="${since}" -f per_page=50`,
+    ghEnv,
+  );
+  return raw ? parseInt(raw, 10) || 0 : 0;
+}
+
+// ── Core functions ───────────────────────────────────────────────────
+
+/**
+ * Record artifacts created by a completed agent run.
+ * Called after each `squads run` finishes in the daemon.
+ */
+export function recordArtifacts(
+  exec: {
+    executionId: string;
+    squad: string;
+    agent: string;
+    completedAt: string;
+    costUsd: number;
+    repo?: string;
+  },
+  ghEnv?: Record<string, string>,
+): OutcomeRecord | null {
+  if (!exec.repo) return null;
+
+  const data = loadOutcomes();
+
+  // Don't double-record
+  if (data.records.some(r => r.executionId === exec.executionId)) return null;
+
+  // Look for artifacts created in the last 30 minutes (typical agent run window)
+  const prs = findRecentBotPRs(exec.repo, 30, ghEnv);
+  const issues = findRecentBotIssues(exec.repo, 30, ghEnv);
+  const commits = countRecentCommits(exec.repo, 30, ghEnv);
+
+  const record: OutcomeRecord = {
+    executionId: exec.executionId,
+    squad: exec.squad,
+    agent: exec.agent,
+    completedAt: exec.completedAt,
+    costUsd: exec.costUsd,
+    artifacts: {
+      issuesCreated: issues,
+      prsCreated: prs,
+      commits,
+    },
+    outcomes: {
+      issuesClosed: 0,
+      issuesOpen: issues.length,
+      prsMerged: 0,
+      prsClosedUnmerged: 0,
+      prsOpen: prs.length,
+      ciPassFirstPush: null,
+      reviewCycleHours: null,
+    },
+    lastPolledAt: new Date().toISOString(),
+    settled: prs.length === 0 && issues.length === 0, // No artifacts = settled immediately
+  };
+
+  data.records.push(record);
+
+  // Trim to last 200 records
+  if (data.records.length > 200) {
+    data.records = data.records.slice(-200);
+  }
+
+  saveOutcomes(data);
+  return record;
+}
+
+/**
+ * Poll GitHub for outcome updates on unsettled records.
+ * Rate-limited to 30 API calls per cycle.
+ */
+export function pollOutcomes(ghEnv?: Record<string, string>): {
+  polled: number;
+  settled: number;
+} {
+  const data = loadOutcomes();
+  const unsettled = data.records.filter(r => !r.settled);
+  let apiCalls = 0;
+  let newlySettled = 0;
+  const MAX_CALLS = 30;
+
+  for (const record of unsettled) {
+    if (apiCalls >= MAX_CALLS) break;
+
+    let allTerminal = true;
+
+    // Check PRs
+    for (const pr of record.artifacts.prsCreated) {
+      if (apiCalls >= MAX_CALLS) break;
+      apiCalls++;
+
+      const raw = ghExec(
+        `gh pr view ${pr.number} -R ${pr.repo} --json state,mergedAt,createdAt,statusCheckRollup`,
+        ghEnv,
+      );
+      if (!raw) { allTerminal = false; continue; }
+
+      try {
+        const prData = JSON.parse(raw) as {
+          state: string;
+          mergedAt: string | null;
+          createdAt: string;
+          statusCheckRollup: Array<{ conclusion: string }> | null;
+        };
+
+        if (prData.state === 'MERGED') {
+          record.outcomes.prsMerged++;
+          record.outcomes.prsOpen = Math.max(0, record.outcomes.prsOpen - 1);
+
+          // Calculate review cycle hours
+          if (prData.mergedAt && prData.createdAt) {
+            const created = new Date(prData.createdAt).getTime();
+            const merged = new Date(prData.mergedAt).getTime();
+            record.outcomes.reviewCycleHours = (merged - created) / (1000 * 60 * 60);
+          }
+
+          // CI pass on first push
+          if (record.outcomes.ciPassFirstPush === null && prData.statusCheckRollup) {
+            record.outcomes.ciPassFirstPush = prData.statusCheckRollup.every(
+              c => c.conclusion === 'SUCCESS',
+            );
+          }
+        } else if (prData.state === 'CLOSED') {
+          record.outcomes.prsClosedUnmerged++;
+          record.outcomes.prsOpen = Math.max(0, record.outcomes.prsOpen - 1);
+        } else {
+          allTerminal = false; // Still open
+        }
+      } catch {
+        allTerminal = false;
+      }
+    }
+
+    // Check issues
+    for (const issue of record.artifacts.issuesCreated) {
+      if (apiCalls >= MAX_CALLS) break;
+      apiCalls++;
+
+      const raw = ghExec(
+        `gh issue view ${issue.number} -R ${issue.repo} --json state`,
+        ghEnv,
+      );
+      if (!raw) { allTerminal = false; continue; }
+
+      try {
+        const issueData = JSON.parse(raw) as { state: string };
+        if (issueData.state === 'CLOSED') {
+          record.outcomes.issuesClosed++;
+          record.outcomes.issuesOpen = Math.max(0, record.outcomes.issuesOpen - 1);
+        } else {
+          allTerminal = false;
+        }
+      } catch {
+        allTerminal = false;
+      }
+    }
+
+    // Mark settled if all artifacts reached terminal state
+    if (allTerminal && record.artifacts.prsCreated.length + record.artifacts.issuesCreated.length > 0) {
+      record.settled = true;
+      newlySettled++;
+    }
+
+    // Also settle records older than 30 days regardless
+    const age = Date.now() - new Date(record.completedAt).getTime();
+    if (age > 30 * 24 * 60 * 60 * 1000) {
+      record.settled = true;
+      if (!allTerminal) newlySettled++;
+    }
+
+    record.lastPolledAt = new Date().toISOString();
+  }
+
+  saveOutcomes(data);
+  return { polled: apiCalls, settled: newlySettled };
+}
+
+/**
+ * Compute scorecard for an agent over a time period.
+ */
+export function computeScorecard(
+  squad: string,
+  agent: string,
+  period: '7d' | '30d',
+): AgentScorecard | null {
+  const data = loadOutcomes();
+  const periodMs = period === '7d' ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - periodMs;
+
+  const records = data.records.filter(
+    r => r.squad === squad && r.agent === agent &&
+         new Date(r.completedAt).getTime() > cutoff,
+  );
+
+  if (records.length === 0) return null;
+
+  const totalPRs = records.reduce((sum, r) => sum + r.artifacts.prsCreated.length, 0);
+  const mergedPRs = records.reduce((sum, r) => sum + r.outcomes.prsMerged, 0);
+  const unmergedPRs = records.reduce((sum, r) => sum + r.outcomes.prsClosedUnmerged, 0);
+  const totalIssues = records.reduce((sum, r) => sum + r.artifacts.issuesCreated.length, 0);
+  const closedIssues = records.reduce((sum, r) => sum + r.outcomes.issuesClosed, 0);
+  const totalCost = records.reduce((sum, r) => sum + r.costUsd, 0);
+
+  // Waste = runs with zero artifacts
+  const wasteRuns = records.filter(
+    r => r.artifacts.prsCreated.length === 0 &&
+         r.artifacts.issuesCreated.length === 0 &&
+         r.artifacts.commits === 0,
+  ).length;
+
+  // CI pass rate
+  const ciRecords = records.filter(r => r.outcomes.ciPassFirstPush !== null);
+  const ciPassed = ciRecords.filter(r => r.outcomes.ciPassFirstPush === true).length;
+
+  // Avg review cycle
+  const reviewCycles = records
+    .filter(r => r.outcomes.reviewCycleHours !== null)
+    .map(r => r.outcomes.reviewCycleHours!);
+  const avgReviewCycleHours = reviewCycles.length > 0
+    ? reviewCycles.reduce((a, b) => a + b, 0) / reviewCycles.length
+    : 0;
+
+  // Cost per outcome (issues closed + PRs merged)
+  const outcomes = closedIssues + mergedPRs;
+
+  return {
+    squad,
+    agent,
+    period,
+    executions: records.length,
+    wasteRate: records.length > 0 ? wasteRuns / records.length : 0,
+    mergeRate: totalPRs > 0 ? mergedPRs / totalPRs : 0,
+    issueResolutionRate: totalIssues > 0 ? closedIssues / totalIssues : 0,
+    ciPassRate: ciRecords.length > 0 ? ciPassed / ciRecords.length : 0,
+    avgReviewCycleHours,
+    costPerOutcome: outcomes > 0 ? totalCost / outcomes : totalCost,
+  };
+}
+
+/**
+ * Compute scorecards for all agents that have outcome data.
+ */
+export function computeAllScorecards(period: '7d' | '30d' = '7d'): AgentScorecard[] {
+  const data = loadOutcomes();
+  const periodMs = period === '7d' ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - periodMs;
+
+  // Find unique squad/agent combos in period
+  const agents = new Set<string>();
+  for (const r of data.records) {
+    if (new Date(r.completedAt).getTime() > cutoff) {
+      agents.add(`${r.squad}/${r.agent}`);
+    }
+  }
+
+  const scorecards: AgentScorecard[] = [];
+  for (const key of agents) {
+    const [squad, agent] = key.split('/');
+    const card = computeScorecard(squad, agent, period);
+    if (card) scorecards.push(card);
+  }
+
+  // Sort by executions descending
+  scorecards.sort((a, b) => b.executions - a.executions);
+
+  // Persist
+  data.scorecards = scorecards;
+  saveOutcomes(data);
+
+  return scorecards;
+}
+
+/**
+ * Get cached scorecards (no recompute).
+ */
+export function getScorecards(): AgentScorecard[] {
+  return loadOutcomes().scorecards;
+}
+
+/**
+ * Get all outcome records.
+ */
+export function getOutcomeRecords(): OutcomeRecord[] {
+  return loadOutcomes().records;
+}
+
+/**
+ * Apply outcome-based score modifiers to daemon squad scoring.
+ * Returns a score adjustment (positive or negative).
+ */
+export function getOutcomeScoreModifier(squad: string, agent: string): number {
+  const scorecards = getScorecards();
+  const card = scorecards.find(s => s.squad === squad && s.agent === agent);
+
+  // Minimum data threshold: need 3+ executions for modifiers
+  if (!card || card.executions < 3) return 0;
+
+  let modifier = 0;
+
+  // High waste rate penalty
+  if (card.wasteRate > 0.5) modifier -= 30;
+
+  // Low merge rate penalty
+  if (card.mergeRate < 0.3 && card.executions >= 3) modifier -= 20;
+
+  // High performance bonus
+  if (card.mergeRate > 0.7 && card.issueResolutionRate > 0.5) modifier += 15;
+
+  // Expensive + low-scoring penalty
+  if (card.costPerOutcome > 5) modifier -= 10;
+
+  return modifier;
+}


### PR DESCRIPTION
## P0 Hotfix

**Every `squads run` crashes on v0.7.0** with `ReferenceError: provider is not defined`.

### Root cause
`executeWithClaude()` references bare `provider` variable (undefined) instead of `detectedProvider` when calling `executeForeground()`.

### Fix
- `provider` → `provider: detectedProvider` on the executeForeground call
- Add missing `outcomes.ts`, `insights.ts`, `stats.ts` (referenced by daemon/cli but missing from main)
- Bump to v0.7.1

### Impact
D1 retention effectively 0% until this ships. Every new user hits this crash.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)