### PR TITLE
ux(dash): fix confusing Token Economics + Infrastructure for new users

### DIFF
--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -631,12 +631,19 @@ function renderTokenEconomicsCached(cache: DashboardCache, goalCount?: { active:
   const tier = parseInt(process.env.ANTHROPIC_TIER || '0', 10);
 
   if (planType === 'unknown') {
-    writeLine(`  ${colors.dim}○${RESET} ${bold}Plan${RESET} ${colors.yellow}not configured${RESET}`);
-    writeLine();
-    writeLine(`  ${colors.dim}Set your Claude plan:${RESET}`);
-    writeLine(`  ${colors.dim}$${RESET} export SQUADS_PLAN_TYPE=max   ${colors.dim}# $200/mo flat${RESET}`);
-    writeLine(`  ${colors.dim}$${RESET} export SQUADS_PLAN_TYPE=usage ${colors.dim}# pay-per-token${RESET}`);
-    writeLine();
+    // If no API key is set, user is likely on OAuth (Claude Code subscription)
+    const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
+    if (!hasApiKey) {
+      writeLine(`  ${colors.purple}◆${RESET} ${bold}Claude Code${RESET} ${colors.dim}(subscription)${RESET}`);
+      writeLine();
+    } else {
+      writeLine(`  ${colors.dim}○${RESET} ${bold}Plan${RESET} ${colors.dim}not configured${RESET}`);
+      writeLine();
+      writeLine(`  ${colors.dim}Set your Claude plan:${RESET}`);
+      writeLine(`  ${colors.dim}$${RESET} export SQUADS_PLAN_TYPE=max   ${colors.dim}# $200/mo flat${RESET}`);
+      writeLine(`  ${colors.dim}$${RESET} export SQUADS_PLAN_TYPE=usage ${colors.dim}# pay-per-token${RESET}`);
+      writeLine();
+    }
   } else {
     const maxPlan = planType === 'max';
     const planIcon = maxPlan ? `${colors.purple}◆${RESET}` : `${colors.dim}○${RESET}`;
@@ -832,11 +839,10 @@ function renderInfrastructureCached(cache: DashboardCache): void {
   const hasInfra = hasLocalInfraConfig();
 
   if (!hasInfra || !stats) {
-    writeLine(`  ${bold}Infrastructure${RESET} ${colors.dim}(not connected)${RESET}`);
+    writeLine(`  ${bold}Infrastructure${RESET} ${colors.dim}(local only)${RESET}`);
     writeLine();
-    writeLine(`  ${colors.dim}○${RESET} postgres  ${colors.dim}○${RESET} redis  ${colors.dim}○${RESET} otel`);
-    writeLine();
-    writeLine(`  ${colors.dim}Setup:${RESET} github.com/agents-squads/squads-cli#infrastructure`);
+    writeLine(`  ${colors.dim}Running locally — no cloud connection needed to get started.${RESET}`);
+    writeLine(`  ${colors.dim}Optional: connect for remote execution and team sharing.${RESET}`);
     writeLine();
     return;
   }

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -57,8 +57,14 @@ export function detectPlan(): PlanDetection {
     return { plan: 'usage', confidence: 'inferred', reason: `Tier ${tier} (new user)` };
   }
 
-  // 5. Default: unknown - prompt user to configure
-  return { plan: 'unknown', confidence: 'inferred', reason: 'Not configured' };
+  // 5. No API key = OAuth (Claude Code subscription) → treat as Max plan
+  // Users authenticated via OAuth have a flat subscription and don't need cost tracking.
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return { plan: 'max', confidence: 'inferred', reason: 'OAuth (Claude Code subscription)' };
+  }
+
+  // 6. API key set but no other signals → usage plan (pay-per-token)
+  return { plan: 'usage', confidence: 'inferred', reason: 'API key (pay-per-token)' };
 }
 
 /**

--- a/test/plan-type.test.ts
+++ b/test/plan-type.test.ts
@@ -12,6 +12,8 @@ describe('plan type detection', () => {
     delete process.env.ANTHROPIC_BUDGET_DAILY;
     delete process.env.SQUADS_DAILY_BUDGET;
     delete process.env.ANTHROPIC_TIER;
+    // Clear API key so default tests use OAuth path (no API key = subscription)
+    delete process.env.ANTHROPIC_API_KEY;
   });
 
   afterEach(() => {
@@ -103,17 +105,25 @@ describe('plan type detection', () => {
   });
 
   describe('detectPlan - defaults', () => {
-    it('defaults to unknown plan when no signals (prompts user to configure)', () => {
+    it('defaults to max plan for OAuth users (no API key = subscription)', () => {
+      // No API key = OAuth (Claude Code subscription) = max plan
       const result = detectPlan();
-      expect(result.plan).toBe('unknown');
+      expect(result.plan).toBe('max');
       expect(result.confidence).toBe('inferred');
-      expect(result.reason).toContain('Not configured');
+      expect(result.reason).toContain('OAuth');
     });
 
-    it('defaults to unknown for Tier 3 (middle tier, ambiguous)', () => {
+    it('defaults to usage plan when API key is set with no other signals', () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test-key';
+      const result = detectPlan();
+      expect(result.plan).toBe('usage');
+      expect(result.confidence).toBe('inferred');
+    });
+
+    it('defaults to max for Tier 3 OAuth users (no API key)', () => {
       process.env.ANTHROPIC_TIER = '3';
       const result = detectPlan();
-      expect(result.plan).toBe('unknown');
+      expect(result.plan).toBe('max');
       expect(result.confidence).toBe('inferred');
     });
   });
@@ -139,8 +149,8 @@ describe('plan type detection', () => {
       expect(isMaxPlan()).toBe(false);
     });
 
-    it('returns false by default (unknown plan is not max)', () => {
-      expect(isMaxPlan()).toBe(false);
+    it('returns true by default for OAuth users (no API key = subscription = max)', () => {
+      expect(isMaxPlan()).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- **Token Economics**: OAuth users (no `ANTHROPIC_API_KEY`) now auto-detect as 'max' plan (Claude Code subscription) instead of showing 'not configured' with export instructions. API key users default to 'usage'. Eliminates immediate confusion for new users who just ran `squads init`.
- **Infrastructure**: 'not connected' → 'local only' with friendly message explaining no cloud connection is needed to get started. Removes the misleading broken-setup appearance on fresh installs.

## Before / After

**Token Economics (before, fresh install)**
```
○ Plan  not configured
$ export SQUADS_PLAN_TYPE=max   # $200/mo flat
$ export SQUADS_PLAN_TYPE=usage # pay-per-token
```

**Token Economics (after, fresh install)**
```
◆ Claude Code  (subscription)
```

**Infrastructure (before)**
```
Infrastructure (not connected)
○ postgres  ○ redis  ○ otel
Setup: github.com/agents-squads/squads-cli#infrastructure
```

**Infrastructure (after)**
```
Infrastructure (local only)
Running locally — no cloud connection needed to get started.
Optional: connect for remote execution and team sharing.
```

## Issues
- Closes #528

---
Agent: cli/issue-solver
Squad: cli
Execution: exec_1773012855523