### PR TITLE
ux(init): add hints and fallback for empty business description

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -363,6 +363,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
     const dirName = path.basename(cwd);
 
     writeLine(chalk.bold('  Tell us about your business:'));
+    writeLine(chalk.dim('  (Agents read this to produce useful output — be specific)'));
     writeLine();
 
     businessName = await prompt(
@@ -370,16 +371,22 @@ export async function initCommand(options: InitOptions): Promise<void> {
       dirName
     );
 
+    writeLine(chalk.dim('    e.g., "We sell handmade coffee mugs online" or "B2B SaaS for construction teams"'));
     businessDescription = await prompt(
       'What does it do? (one sentence)',
       ''
     );
+    // Require a non-empty description — empty = generic output on first run
+    if (!businessDescription) {
+      writeLine(chalk.dim(`    Tip: Without a description, agents produce generic output. You can edit .agents/BUSINESS_BRIEF.md later.`));
+      businessDescription = `${businessName} — add your business description to .agents/BUSINESS_BRIEF.md`;
+    }
 
     writeLine();
-
+    writeLine(chalk.dim('    e.g., "Identify our top 3 competitors and what they do better than us"'));
     businessFocus = await prompt(
-      'What should your first research squad investigate?',
-      'Our market, competitors, and growth opportunities'
+      'What should your agents research first?',
+      'Our market position, top competitors, and biggest growth opportunity'
     );
 
     // 4b. Use-case selection


### PR DESCRIPTION
## Summary

- Added example hints below business description and research focus prompts
- Require non-empty business description: if user skips it, show actionable message pointing to BUSINESS_BRIEF.md
- Updated research focus question to "What should your agents research first?" (clearer intent)

## Problem

Without a description, agents produce generic, low-value output on first run → user sees no value → churns. Previously, an empty description silently used a "details to be added by the manager agent" fallback with no guidance.

## Before

```
  Tell us about your business:

  Company or project name? (my-project)
  What does it do? (one sentence)          ← no example, user presses Enter
  What should your first research squad investigate? (Our market, competitors...)
```

## After

```
  Tell us about your business:
  (Agents read this to produce useful output — be specific)

  Company or project name? (my-project)
    e.g., "We sell handmade coffee mugs online" or "B2B SaaS for construction teams"
  What does it do? (one sentence)          ← clear example nearby
    Tip: Without a description, agents produce generic output. You can edit .agents/BUSINESS_BRIEF.md later.

    e.g., "Identify our top 3 competitors and what they do better than us"
  What should your agents research first? (Our market position, top competitors...)
```

## Issues

- Closes #517

---
Agent: cli/issue-solver
Squad: cli