### PR TITLE
ux(init): fix getting-started ordering and add squad descriptions

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -55,6 +55,7 @@ interface SquadConfig {
   name: string;
   agentCount: number;
   agentSummary: string;
+  description?: string;
   dirs: string[];
   files: [string, string][];       // [destPath, templatePath]
   memoryFiles: [string, string][]; // [destPath, templatePath]
@@ -100,6 +101,7 @@ function getEngineeringSquad(): SquadConfig {
     name: 'engineering',
     agentCount: 3,
     agentSummary: 'issue-solver, code-reviewer, test-writer',
+    description: 'Solves GitHub issues and reviews code',
     dirs: [
       '.agents/squads/engineering',
       '.agents/memory/engineering/issue-solver',
@@ -123,6 +125,7 @@ function getMarketingSquad(): SquadConfig {
     name: 'marketing',
     agentCount: 3,
     agentSummary: 'content-drafter, social-poster, growth-analyst',
+    description: 'Creates content and grows your audience',
     dirs: [
       '.agents/squads/marketing',
       '.agents/memory/marketing/content-drafter',
@@ -146,6 +149,7 @@ function getOperationsSquad(): SquadConfig {
     name: 'operations',
     agentCount: 3,
     agentSummary: 'ops-lead, finance-tracker, goal-tracker',
+    description: 'Tracks finances, goals, and daily operations',
     dirs: [
       '.agents/squads/operations',
       '.agents/memory/operations/ops-lead',
@@ -580,14 +584,15 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine(chalk.dim('  Created:'));
 
   // Core squads (always present)
-  writeLine(chalk.dim('  • .agents/squads/company/       5 agents (manager, dispatcher, tracker, eval, critic)'));
-  writeLine(chalk.dim('  • .agents/squads/research/      4 agents (researcher, analyst, eval, critic)'));
-  writeLine(chalk.dim('  • .agents/squads/intelligence/  3 agents (intel-lead, eval, critic)'));
+  writeLine(chalk.dim('  • .agents/squads/company/       5 agents — Manages your AI workforce day-to-day'));
+  writeLine(chalk.dim('  • .agents/squads/research/      4 agents — Researches your market and competitors'));
+  writeLine(chalk.dim('  • .agents/squads/intelligence/  3 agents — Monitors trends and signals'));
 
   // Use-case specific squads
   for (const squad of useCaseConfig.squads) {
     const padding = ' '.repeat(Math.max(0, 22 - squad.name.length));
-    writeLine(chalk.dim(`  • .agents/squads/${squad.name}/${padding}${squad.agentCount} agents (${squad.agentSummary})`));
+    const desc = squad.description ? ` — ${squad.description}` : ` (${squad.agentSummary})`;
+    writeLine(chalk.dim(`  • .agents/squads/${squad.name}/${padding}${squad.agentCount} agents${desc}`));
   }
 
   writeLine(chalk.dim('  • .agents/skills/               CLI + GitHub workflow skills'));
@@ -600,18 +605,19 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine();
   writeLine(chalk.bold('  Getting started:'));
   writeLine();
-  // Dynamic "first run" suggestion based on use case
+  // Step 1: Customize context FIRST — agents are only as good as their context
+  writeLine(`     ${chalk.cyan('1.')} ${chalk.yellow('$EDITOR .agents/BUSINESS_BRIEF.md')}`);
+  writeLine(chalk.dim('        Add your business details so agents have real context to work with'));
+  writeLine();
+  // Step 2: Run the first agent with context already set
   const firstRunCommand = getFirstRunCommand(selectedUseCase);
   const squadCommand = firstRunCommand.command.replace(/\/[^/]+$/, '');
-  writeLine(`     ${chalk.cyan('1.')} ${chalk.yellow(firstRunCommand.command)}`);
+  writeLine(`     ${chalk.cyan('2.')} ${chalk.yellow(firstRunCommand.command)}`);
   writeLine(chalk.dim(`        ${firstRunCommand.description}`));
   writeLine(chalk.dim(`        Full squad (4+ agents, longer): ${squadCommand}`));
   writeLine();
-  writeLine(`     ${chalk.cyan('2.')} ${chalk.yellow(`squads dash`)}`);
+  writeLine(`     ${chalk.cyan('3.')} ${chalk.yellow(`squads dash`)}`);
   writeLine(chalk.dim('        See all your squads and agents at a glance'));
-  writeLine();
-  writeLine(`     ${chalk.cyan('3.')} ${chalk.yellow('$EDITOR .agents/BUSINESS_BRIEF.md')}`);
-  writeLine(chalk.dim('        Customize your business context for better results'));
   writeLine();
   writeLine(chalk.dim('  Docs: https://agents-squads.com/docs/getting-started'));
   writeLine();


### PR DESCRIPTION
## Summary

- **#525**: Reorder getting-started steps — editing `BUSINESS_BRIEF.md` is now step 1 (was step 3). Agents need context before the first run; sending users to `squads run research/researcher` before they've set any context produces generic, low-value output.
- **#524**: Add 1-line value descriptions to all squad entries in the init success output. New users can now see at a glance what each squad does before deciding which to run first.

## Changes

- `init.ts`: Reorder getting-started steps (edit → run → dash)
- `init.ts`: Core squad lines now show what each squad does (Manages, Researches, Monitors)
- `init.ts`: Add optional `description` field to `SquadConfig` for use-case squads
- `init.ts`: Engineering, Marketing, Operations squad definitions include descriptions

## Issues
- Closes #525
- Closes #524

---
Agent: cli/issue-solver
