### PR TITLE
ux(init): collect competitors during init and inject into BUSINESS_BRIEF.md

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -352,12 +352,14 @@ export async function initCommand(options: InitOptions): Promise<void> {
   let businessName: string;
   let businessDescription: string;
   let businessFocus: string;
+  let businessCompetitors: string;
   let selectedUseCase: UseCase;
 
   if (options.yes || options.quick || !isInteractive()) {
     businessName = path.basename(cwd);
     businessDescription = 'General business operations';
     businessFocus = 'Our market, competitors, and growth opportunities';
+    businessCompetitors = '';
     selectedUseCase = 'full-company';
   } else {
     const dirName = path.basename(cwd);
@@ -389,6 +391,13 @@ export async function initCommand(options: InitOptions): Promise<void> {
       'Our market position, top competitors, and biggest growth opportunity'
     );
 
+    writeLine();
+    writeLine(chalk.dim('    e.g., "BlueCart, MarketMan" — leave blank to skip'));
+    businessCompetitors = await prompt(
+      'Who are your main competitors? (optional)',
+      ''
+    );
+
     // 4b. Use-case selection
     selectedUseCase = await promptUseCase();
   }
@@ -406,6 +415,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine(`  ${chalk.green('✓')} Business: ${chalk.cyan(businessName)}${businessDescription ? chalk.dim(` — ${businessDescription}`) : ''}`);
   writeLine(`  ${chalk.green('✓')} Provider: ${chalk.cyan(provider?.name || selectedProvider)}`);
   writeLine(`  ${chalk.green('✓')} Research focus: ${chalk.cyan(businessFocus)}`);
+  if (businessCompetitors) {
+    writeLine(`  ${chalk.green('✓')} Competitors: ${chalk.cyan(businessCompetitors)}`);
+  }
   writeLine(`  ${chalk.green('✓')} Use case: ${chalk.cyan(useCaseConfig.label)} ${chalk.dim(`— ${useCaseConfig.description}`)}`);
   writeLine();
 
@@ -417,6 +429,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
       BUSINESS_NAME: businessName,
       BUSINESS_DESCRIPTION: businessDescription || `${businessName} — details to be added by the manager agent.`,
       BUSINESS_FOCUS: businessFocus,
+      COMPETITORS_SECTION: businessCompetitors
+        ? `## Competitors\n\n${businessCompetitors}\n\n`
+        : '',
       PROVIDER: selectedProvider,
       PROVIDER_NAME: provider?.name || 'Unknown',
     };

--- a/templates/seed/BUSINESS_BRIEF.md.template
+++ b/templates/seed/BUSINESS_BRIEF.md.template
@@ -8,7 +8,7 @@
 
 {{BUSINESS_FOCUS}}
 
-## Priority
+{{COMPETITORS_SECTION}}## Priority
 
 **#1**: Deliver value in the research focus above.
 


### PR DESCRIPTION
## Summary

Adds an optional competitors question to `squads init` so agents have real context when researching the market on the first run.

- Prompts: "Who are your main competitors? (optional)" with an example hint
- If provided, injects a `## Competitors` section into `BUSINESS_BRIEF.md`
- If skipped, no empty section is generated (template uses a block variable)
- Shows competitors in the init confirmation summary when provided

## Before

First run output was generic: *"Our market, competitors, and growth opportunities"* — the researcher had no names to search for.

## After

User enters "BlueCart, MarketMan" → BUSINESS_BRIEF.md includes:
```markdown
## Competitors

BlueCart, MarketMan
```
First research output is specific and useful.

## Issues
- Closes #513

---
Agent: cli/issue-solver
