### PR TITLE
fix(run): inject bot identity into agent subprocess

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2160,7 +2160,7 @@ interface ExecuteWithClaudeOptions {
 function buildAgentEnv(
   baseEnv: Record<string, string>,
   execContext: ExecutionContext,
-  options?: { effort?: EffortLevel; skills?: string[]; includeOtel?: boolean }
+  options?: { effort?: EffortLevel; skills?: string[]; includeOtel?: boolean; ghToken?: string }
 ): Record<string, string> {
   const env: Record<string, string> = {
     ...baseEnv,
@@ -2171,6 +2171,10 @@ function buildAgentEnv(
     SQUADS_EXECUTION_ID: execContext.executionId,
     BRIDGE_API: getBridgeUrl(),
   };
+
+  // Inject bot GH_TOKEN so agents create PRs/issues as the bot identity,
+  // not the user's personal gh auth. This enables founder to review/approve.
+  if (options?.ghToken) env.GH_TOKEN = options.ghToken;
 
   if (options?.includeOtel) {
     env.OTEL_RESOURCE_ATTRIBUTES = `squads.squad=${execContext.squad},squads.agent=${execContext.agent},squads.task_type=${execContext.taskType},squads.trigger=${execContext.trigger},squads.execution_id=${execContext.executionId}`;
@@ -2430,6 +2434,13 @@ async function executeWithClaude(
 
   await registerContextWithBridge(execContext);
 
+  // Get bot token so agents create PRs/issues as bot identity (not user's personal gh auth)
+  let botGhToken: string | undefined;
+  try {
+    const ghEnv = await getBotGhEnv();
+    botGhToken = ghEnv.GH_TOKEN;
+  } catch { /* graceful: falls back to user's gh auth */ }
+
   // ── Foreground mode ──────────────────────────────────────────────────
   if (runInForeground) {
     if (verbose) {
@@ -2448,7 +2459,7 @@ async function executeWithClaude(
     claudeArgs.push('--', prompt);
 
     const agentEnv = buildAgentEnv(spawnEnv as Record<string, string>, execContext, {
-      effort, skills, includeOtel: true,
+      effort, skills, includeOtel: true, ghToken: botGhToken,
     });
 
     return executeForeground({
@@ -2461,7 +2472,7 @@ async function executeWithClaude(
   const timestamp = Date.now();
   const { logFile, pidFile } = prepareLogFiles(projectRoot, squadName, agentName, timestamp);
   const agentEnv = buildAgentEnv(spawnEnv as Record<string, string>, execContext, {
-    effort, skills, includeOtel: !runInWatch,
+    effort, skills, includeOtel: !runInWatch, ghToken: botGhToken,
   });
 
   const wrapperScript = buildDetachedShellScript({

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -84,7 +84,7 @@ function executeAgentTurn(config: AgentTurnConfig): string {
       } else if (transcript.turns.length === 0) {
         roleInstructions = `## Your Role: Lead\n\nYou are starting a new squad session. Brief the team:\n1. Review open issues and PRs\n2. Set priorities for this session\n3. Assign work to workers\n4. Be specific about what each worker should do`;
       } else {
-        roleInstructions = `## Your Role: Lead (Review)\n\nReview the work done so far. Either:\n- Request specific changes from workers\n- Approve and signal completion if quality is sufficient\n- Merge PRs that pass CI using \`gh pr merge --squash --delete-branch\``;
+        roleInstructions = `## Your Role: Lead (Review)\n\nReview the work done so far. Either:\n- Request specific changes from workers\n- Approve and signal completion if quality is sufficient\n- Merge PRs using \`gh pr merge --squash --delete-branch --auto\` (waits for required checks)`;
       }
       break;
     case 'scanner':


### PR DESCRIPTION
## Summary
- Injects GitHub App bot token (`GH_TOKEN`) into agent subprocess env so agents create PRs/issues as bot identity, not founder's personal auth
- Fixes lead merge instruction to use `--auto` flag (waits for CI checks before merging)

## Changes
- `src/commands/run.ts`: Add `ghToken` option to `buildAgentEnv()`, fetch bot token before execution, pass to both foreground and detached code paths
- `src/lib/workflow.ts`: Update lead review instructions to use `gh pr merge --auto`

## Why
Agents using founder's personal `gh auth` meant the founder couldn't review/approve their own PRs (branch protection blocks self-approval). Bot identity enables the proper flow: bot creates PR, founder reviews.

## Testing
- [x] Build passes
- [ ] Verify agents create PRs as `agents-squads[bot]` instead of personal account
- [ ] Verify `--auto` merge waits for Gemini Code Assist review

Closes #533