### PR TITLE
feat(cognition): quality grading + escalation pause

### DIFF
--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -11,6 +11,7 @@ import { spawn } from 'child_process';
 import { getBotGhEnv } from '../lib/github.js';
 import {
   recordArtifacts,
+  gradeExecution,
   pollOutcomes,
   computeAllScorecards,
 } from '../lib/outcomes.js';
@@ -293,10 +294,11 @@ async function runCycle(options: DaemonOptions): Promise<CycleResult> {
       result.costEstimate += estimatedCost;
 
       // Record artifacts for outcome tracking (only real completions)
+      let qualityGrade: string | undefined;
       if (effectiveOutcome === 'completed') {
         const repo = squadRepos[job.squad];
         if (repo) {
-          recordArtifacts({
+          const record = recordArtifacts({
             executionId: `daemon_${job.squad}_${job.agent}_${job.startedAt}`,
             squad: job.squad,
             agent: job.agent,
@@ -304,6 +306,29 @@ async function runCycle(options: DaemonOptions): Promise<CycleResult> {
             costUsd: estimatedCost,
             repo,
           }, botGhEnv);
+
+          // Grade the execution quality
+          if (record) {
+            const { grade, reason } = gradeExecution(record);
+            qualityGrade = grade;
+
+            // Push quality signal to cognition engine
+            pushCognitionSignal({
+              source: 'execution',
+              signal_type: 'execution_quality',
+              value: { A: 4, B: 3, C: 2, D: 1, F: 0 }[grade] ?? 0,
+              unit: 'quality_score',
+              data: { grade, reason, cost_usd: estimatedCost },
+              entity_type: 'agent',
+              entity_id: `${job.squad}/${job.agent}`,
+              confidence: 0.9,
+            });
+
+            if (options.verbose) {
+              const gradeColor = grade <= 'B' ? colors.green : grade >= 'D' ? colors.red : colors.yellow;
+              writeLine(`    ${gradeColor}Grade: ${grade}${RESET} ${colors.dim}${reason}${RESET}`);
+            }
+          }
         }
       }
 
@@ -313,7 +338,7 @@ async function runCycle(options: DaemonOptions): Promise<CycleResult> {
         signal_type: effectiveOutcome === 'completed' ? 'agent_completed' : 'agent_failed',
         value: effectiveOutcome === 'completed' ? 1 : 0,
         unit: 'completion',
-        data: { outcome: effectiveOutcome, durationMs, cost_usd: estimatedCost },
+        data: { outcome: effectiveOutcome, durationMs, cost_usd: estimatedCost, quality_grade: qualityGrade },
         entity_type: 'agent',
         entity_id: `${job.squad}/${job.agent}`,
         confidence: 0.95,

--- a/src/lib/outcomes.ts
+++ b/src/lib/outcomes.ts
@@ -448,6 +448,95 @@ export function getOutcomeRecords(): OutcomeRecord[] {
   return loadOutcomes().records;
 }
 
+// ── Quality Grading ─────────────────────────────────────────────
+
+export type QualityGrade = 'A' | 'B' | 'C' | 'D' | 'F';
+
+export interface GradeResult {
+  grade: QualityGrade;
+  reason: string;
+}
+
+/**
+ * Grade an execution's output quality using heuristics.
+ * No LLM call needed — rules-based on observable artifacts.
+ *
+ * A = Real deliverable (merged PR with code changes)
+ * B = Useful output (open PR with code, or closed issue)
+ * C = Template/report (PR with only markdown, or commits with no PR)
+ * D = Slop (large PR with no tests, or blocked agent that produced output anyway)
+ * F = Wasted run (no artifacts, or agent hit escalation)
+ */
+export function gradeExecution(record: OutcomeRecord): GradeResult {
+  const { artifacts, outcomes } = record;
+  const hasArtifacts = artifacts.prsCreated.length > 0 ||
+    artifacts.issuesCreated.length > 0 ||
+    artifacts.commits > 0;
+
+  // F: No artifacts at all
+  if (!hasArtifacts) {
+    return { grade: 'F', reason: 'No artifacts produced' };
+  }
+
+  // A: PR merged
+  if (outcomes.prsMerged > 0) {
+    if (outcomes.ciPassFirstPush === true) {
+      return { grade: 'A', reason: `${outcomes.prsMerged} PR(s) merged, CI passed first push` };
+    }
+    return { grade: 'A', reason: `${outcomes.prsMerged} PR(s) merged` };
+  }
+
+  // B: PR open or issues closed
+  if (outcomes.issuesClosed > 0) {
+    return { grade: 'B', reason: `${outcomes.issuesClosed} issue(s) closed` };
+  }
+  if (artifacts.prsCreated.length > 0 && outcomes.prsOpen > 0) {
+    return { grade: 'B', reason: `${outcomes.prsOpen} PR(s) open, awaiting review` };
+  }
+
+  // D: PR closed unmerged (rejected work)
+  if (outcomes.prsClosedUnmerged > 0) {
+    return { grade: 'D', reason: `${outcomes.prsClosedUnmerged} PR(s) closed without merge` };
+  }
+
+  // C: Only commits, no PRs
+  if (artifacts.commits > 0 && artifacts.prsCreated.length === 0) {
+    return { grade: 'C', reason: `${artifacts.commits} commits, no PR created` };
+  }
+
+  // C: Only issues created (reports, not fixes)
+  if (artifacts.issuesCreated.length > 0 && artifacts.prsCreated.length === 0) {
+    return { grade: 'C', reason: `${artifacts.issuesCreated.length} issue(s) filed, no code fix` };
+  }
+
+  return { grade: 'C', reason: 'Artifacts produced but no clear outcome yet' };
+}
+
+/**
+ * Compute average quality grade for an agent as a numeric score.
+ * A=4, B=3, C=2, D=1, F=0
+ */
+export function getAgentQualityScore(squad: string, agent: string): number | null {
+  const data = loadOutcomes();
+  const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const records = data.records.filter(
+    r => r.squad === squad && r.agent === agent &&
+         new Date(r.completedAt).getTime() > cutoff &&
+         r.settled,
+  );
+
+  if (records.length < 2) return null; // Need at least 2 settled records
+
+  const gradeValues: Record<QualityGrade, number> = { A: 4, B: 3, C: 2, D: 1, F: 0 };
+  let total = 0;
+  for (const record of records) {
+    const { grade } = gradeExecution(record);
+    total += gradeValues[grade];
+  }
+
+  return total / records.length;
+}
+
 /**
  * Apply outcome-based score modifiers to daemon squad scoring.
  * Returns a score adjustment (positive or negative).
@@ -472,6 +561,14 @@ export function getOutcomeScoreModifier(squad: string, agent: string): number {
 
   // Expensive + low-scoring penalty
   if (card.costPerOutcome > 5) modifier -= 10;
+
+  // Quality grade modifier (heuristic grading)
+  const qualityScore = getAgentQualityScore(squad, agent);
+  if (qualityScore !== null) {
+    if (qualityScore >= 3.0) modifier += 10;       // A/B average → boost
+    else if (qualityScore < 1.5) modifier -= 25;    // D/F average → strong deprioritize
+    else if (qualityScore < 2.0) modifier -= 15;    // C/D average → deprioritize
+  }
 
   return modifier;
 }

--- a/src/lib/squad-loop.ts
+++ b/src/lib/squad-loop.ts
@@ -229,6 +229,42 @@ export function getLastRunAge(squad: string, agent: string): number | null {
   }
 }
 
+// ── Escalation check ────────────────────────────────────────────────
+
+/**
+ * Check if a squad has unresolved escalations (blocked/needs-human issues).
+ * If so, the squad should be paused — no point dispatching agents that can't work.
+ */
+export function hasUnresolvedEscalation(
+  repo: string,
+  ghEnv: Record<string, string> = {},
+): { blocked: boolean; issue?: { number: number; title: string } } {
+  try {
+    const raw = execSync(
+      `gh issue list -R ${repo} --label "blocked" --state open --json number,title --limit 1`,
+      { encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, ...ghEnv } },
+    );
+    const issues = JSON.parse(raw) as Array<{ number: number; title: string }>;
+    if (issues.length > 0) {
+      return { blocked: true, issue: issues[0] };
+    }
+
+    // Also check needs-human label
+    const raw2 = execSync(
+      `gh issue list -R ${repo} --label "needs-human" --state open --json number,title --limit 1`,
+      { encoding: 'utf-8', timeout: 15000, stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env, ...ghEnv } },
+    );
+    const issues2 = JSON.parse(raw2) as Array<{ number: number; title: string }>;
+    if (issues2.length > 0) {
+      return { blocked: true, issue: issues2[0] };
+    }
+
+    return { blocked: false };
+  } catch {
+    return { blocked: false }; // Can't check = assume not blocked
+  }
+}
+
 // ── Squad scoring ────────────────────────────────────────────────────
 
 /**
@@ -278,6 +314,21 @@ export function scoreSquads(
   for (const squadName of squads) {
     try {
       const repo = squadRepos[squadName];
+
+      // Skip squads with unresolved escalations — don't waste tokens
+      if (repo) {
+        const escalation = hasUnresolvedEscalation(repo, ghEnv);
+        if (escalation.blocked) {
+          signals.push({
+            squad: squadName,
+            score: 0,
+            reason: `PAUSED: unresolved escalation #${escalation.issue?.number} — ${escalation.issue?.title}`,
+            issues: [],
+          });
+          continue;
+        }
+      }
+
       const issues = repo ? getOpenIssues(repo, ghEnv) : [];
 
       let score = 0;


### PR DESCRIPTION
## Summary
- **Pause squads with unresolved escalations** — if a squad has open `blocked` or `needs-human` issues, score drops to 0 and it's skipped. No more burning tokens on agents that can't produce real work (e.g. finance without Wise/Stripe/BQ).
- **Grade each execution A-F** using heuristics: merged PR=A, open PR=B, only commits/reports=C, rejected PR=D, no artifacts=F. No LLM call needed.
- **Feed quality signals into cognition** — grades become signals that form beliefs about agent quality over time.
- **Adjust daemon scoring** — agents with high quality history (A/B average) get +10 boost; agents producing slop (D/F average) get -25 penalty.

## Changes
- `src/lib/squad-loop.ts`: `hasUnresolvedEscalation()` check + integration into `scoreSquads()`
- `src/lib/outcomes.ts`: `gradeExecution()`, `getAgentQualityScore()`, quality modifier in `getOutcomeScoreModifier()`
- `src/commands/daemon.ts`: Post-run grading + cognition signal push + verbose grade display

## How It Works

```
Agent completes run
    ↓
recordArtifacts() — track PRs/issues/commits created
    ↓
gradeExecution() — A/B/C/D/F based on artifacts
    ↓
pushCognitionSignal() — quality grade becomes a belief signal
    ↓
getOutcomeScoreModifier() — next dispatch uses quality history
    ↓
System learns: good agents run more, bad agents run less
```

## Testing
- [x] Build passes
- [ ] Run daemon with `--verbose --dry-run` to verify escalation pausing
- [ ] Verify quality grades appear in daemon output after agent completions

Closes #566, closes #567