### PR TITLE
fix: add sequential mode for Ollama/local LLM providers

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -589,6 +589,9 @@ export async function initCommand(options: InitOptions): Promise<void> {
     const skillContent = loadSeedTemplate('skills/squads-cli/SKILL.md', variables);
     await writeFile(path.join(cwd, '.agents/skills/squads-cli/SKILL.md'), skillContent);
 
+    const skillRefContent = loadSeedTemplate('skills/squads-cli/references/commands.md', variables);
+    await writeFile(path.join(cwd, '.agents/skills/squads-cli/references/commands.md'), skillRefContent);
+
     const ghSkillContent = loadSeedTemplate('skills/gh/SKILL.md', variables);
     await writeFile(path.join(cwd, '.agents/skills/gh/SKILL.md'), ghSkillContent);
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -72,6 +72,10 @@ import {
 import { classifyAgent } from '../lib/conversation.js';
 
 // ── Operational constants (no magic numbers) ──────────────────────────
+
+/** Providers that support tool use (sub-agent spawning, conversation orchestration) */
+const TOOL_USE_PROVIDERS = new Set(['anthropic', 'google']);
+
 const CLOUD_POLL_INTERVAL_MS = 3000;
 const CLOUD_POLL_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes max poll
 const DEFAULT_LEARNINGS_LIMIT = 5;
@@ -1167,74 +1171,91 @@ async function runSquad(
         return;
       }
     } else {
-      // Default: Run squad as multi-agent conversation
-      // Lead briefs → scanners discover → workers execute → lead reviews → converge
+      // Default: Run squad as multi-agent conversation (or sequential for non-tool-use providers)
+      const squadProvider = options.provider || squad?.providers?.default || 'anthropic';
+
       if (options.execute) {
-        writeLine(`  ${bold}Conversation mode${RESET} ${colors.dim}(lead → scan → work → review → verify)${RESET}`);
-        writeLine();
+        if (TOOL_USE_PROVIDERS.has(squadProvider)) {
+          // Conversation mode for tool-use providers (Claude, Gemini)
+          writeLine(`  ${bold}Conversation mode${RESET} ${colors.dim}(lead → scan → work → review → verify)${RESET}`);
+          writeLine();
 
-        const convOptions: ConversationOptions = {
-          task: options.task,
-          maxTurns: options.maxTurns,
-          costCeiling: options.costCeiling,
-          verbose: options.verbose,
-          model: options.model,
-        };
+          const convOptions: ConversationOptions = {
+            task: options.task,
+            maxTurns: options.maxTurns,
+            costCeiling: options.costCeiling,
+            verbose: options.verbose,
+            model: options.model,
+          };
 
-        // Report execution start to API (fire-and-forget on failure)
-        const apiExecId = await reportExecutionStart(squad.name, 'conversation', `conv-${Date.now()}`);
+          // Report execution start to API (fire-and-forget on failure)
+          const apiExecId = await reportExecutionStart(squad.name, 'conversation', `conv-${Date.now()}`);
 
-        const result = await runConversation(squad, convOptions);
+          const result = await runConversation(squad, convOptions);
 
-        // Save transcript
-        const transcriptPath = saveTranscript(result.transcript);
+          // Save transcript
+          const transcriptPath = saveTranscript(result.transcript);
 
-        // Report conversation result to API (fire-and-forget)
-        if (apiExecId) {
-          reportConversationResult(apiExecId, {
-            turnCount: result.turnCount,
-            totalCost: result.totalCost,
-            converged: result.converged,
-            reason: result.reason,
-            agentsInvolved: [...new Set(result.transcript.turns.map(t => t.agent))],
+          // Report conversation result to API (fire-and-forget)
+          if (apiExecId) {
+            reportConversationResult(apiExecId, {
+              turnCount: result.turnCount,
+              totalCost: result.totalCost,
+              converged: result.converged,
+              reason: result.reason,
+              agentsInvolved: [...new Set(result.transcript.turns.map(t => t.agent))],
+            });
+          }
+
+          // Push conversation signal to cognition engine (fire-and-forget)
+          pushCognitionSignal({
+            source: 'execution',
+            signal_type: result.converged ? 'conversation_converged' : 'conversation_stopped',
+            value: result.totalCost,
+            unit: 'usd',
+            data: {
+              turn_count: result.turnCount,
+              converged: result.converged,
+              reason: result.reason,
+              agents_involved: [...new Set(result.transcript.turns.map(t => t.agent))],
+            },
+            entity_type: 'squad',
+            entity_id: squad.name,
+            confidence: 0.9,
           });
-        }
 
-        // Push conversation signal to cognition engine (fire-and-forget)
-        pushCognitionSignal({
-          source: 'execution',
-          signal_type: result.converged ? 'conversation_converged' : 'conversation_stopped',
-          value: result.totalCost,
-          unit: 'usd',
-          data: {
-            turn_count: result.turnCount,
-            converged: result.converged,
-            reason: result.reason,
-            agents_involved: [...new Set(result.transcript.turns.map(t => t.agent))],
-          },
-          entity_type: 'squad',
-          entity_id: squad.name,
-          confidence: 0.9,
-        });
-
-        writeLine();
-        writeLine(`  ${result.converged ? icons.success : icons.warning} ${result.converged ? 'Converged' : 'Stopped'}: ${result.reason}`);
-        writeLine(`  ${colors.dim}Turns: ${result.turnCount} | Cost: ~$${result.totalCost.toFixed(2)}${RESET}`);
-        if (transcriptPath) {
-          writeLine(`  ${colors.dim}Transcript: ${transcriptPath}${RESET}`);
+          writeLine();
+          writeLine(`  ${result.converged ? icons.success : icons.warning} ${result.converged ? 'Converged' : 'Stopped'}: ${result.reason}`);
+          writeLine(`  ${colors.dim}Turns: ${result.turnCount} | Cost: ~$${result.totalCost.toFixed(2)}${RESET}`);
+          if (transcriptPath) {
+            writeLine(`  ${colors.dim}Transcript: ${transcriptPath}${RESET}`);
+          }
+          writeLine();
+        } else {
+          // Sequential mode for providers without tool use (Ollama, etc.)
+          await runSequentialMode(squad, squadsDir, squadProvider, options);
         }
-        writeLine();
       } else {
         // Dry-run: show what would happen
-        writeLine(`  ${colors.dim}Default mode: conversation (lead → scan → work → review → verify)${RESET}`);
+        if (TOOL_USE_PROVIDERS.has(squadProvider)) {
+          writeLine(`  ${colors.dim}Default mode: conversation (lead → scan → work → review → verify)${RESET}`);
+        } else {
+          const cliConfig = getCLIConfig(squadProvider);
+          const providerName = cliConfig?.displayName || squadProvider;
+          writeLine(`  ${colors.dim}Default mode: sequential (${providerName} — agents run one at a time)${RESET}`);
+        }
         writeLine();
         for (const agent of squad.agents) {
           writeLine(`  ${icons.empty} ${colors.cyan}${agent.name}${RESET} ${colors.dim}${agent.role}${RESET}`);
         }
         writeLine();
-        writeLine(`  ${colors.dim}Run conversation:${RESET}`);
+        writeLine(`  ${colors.dim}Run squad:${RESET}`);
         writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET}`);
-        writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --task "review and merge open PRs"`);
+        if (!TOOL_USE_PROVIDERS.has(squadProvider)) {
+          writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --provider ${squadProvider}`);
+        } else {
+          writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --task "review and merge open PRs"`);
+        }
         writeLine();
         writeLine(`  ${colors.dim}Run single agent:${RESET}`);
         writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} -a ${colors.cyan}<agent>${RESET}`);
@@ -1859,6 +1880,20 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
   const provider = options.provider || squad?.providers?.default || 'anthropic';
   const isAnthropic = provider === 'anthropic';
 
+  // Block lead mode for providers without tool use support
+  if (!TOOL_USE_PROVIDERS.has(provider)) {
+    const cliConfig = getCLIConfig(provider);
+    const providerName = cliConfig?.displayName || provider;
+    writeLine(`  ${colors.yellow}${icons.warning} Lead mode requires tool-use support (Claude, Gemini)${RESET}`);
+    writeLine(`  ${colors.dim}${providerName} cannot spawn sub-agents via Task tool.${RESET}`);
+    writeLine();
+    writeLine(`  ${colors.dim}Options:${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET}              ${colors.dim}<- sequential mode (recommended)${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}/${agentFiles[0]?.name || 'worker'}${RESET}  ${colors.dim}<- single agent${RESET}`);
+    writeLine();
+    return;
+  }
+
   if (isAnthropic) {
     const claudeAvailable = await checkClaudeCliAvailable();
     if (!claudeAvailable) {
@@ -1913,6 +1948,7 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
         foreground: isForeground || isWatch,
         squadName: squad.dir,
         agentName: leadAgentName,
+        model: options.model,
       });
     }
 
@@ -1936,6 +1972,115 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
     writeLine(`  ${colors.dim}${msg}${RESET}`);
     writeLine(`  ${colors.dim}Run \`squads doctor\` to check your setup.${RESET}`);
   }
+}
+
+/**
+ * Sequential mode: run each agent one at a time through executeWithProvider.
+ * Used for providers without tool-use support (Ollama, etc.) that cannot
+ * orchestrate sub-agents or participate in conversation mode.
+ */
+async function runSequentialMode(
+  squad: ReturnType<typeof loadSquad>,
+  squadsDir: string,
+  provider: string,
+  options: RunOptions
+): Promise<void> {
+  if (!squad) return;
+
+  const agentFiles = squad.agents
+    .map(a => ({
+      name: a.name,
+      path: join(squadsDir, squad.dir, `${a.name}.md`),
+      role: a.role || '',
+    }))
+    .filter(a => existsSync(a.path));
+
+  if (agentFiles.length === 0) {
+    writeLine(`  ${icons.error} ${colors.red}No agent files found${RESET}`);
+    return;
+  }
+
+  const cliConfig = getCLIConfig(provider);
+  const providerName = cliConfig?.displayName || provider;
+
+  writeLine(`  ${bold}Sequential mode${RESET} ${colors.dim}(${providerName} — agents run one at a time)${RESET}`);
+  writeLine();
+
+  for (const agent of agentFiles) {
+    writeLine(`  ${icons.empty} ${colors.cyan}${agent.name}${RESET} ${colors.dim}${agent.role}${RESET}`);
+  }
+  writeLine();
+
+  // Check CLI availability
+  if (!isProviderCLIAvailable(provider)) {
+    writeLine(`  ${colors.yellow}${cliConfig?.command || provider} CLI not found${RESET}`);
+    if (cliConfig?.install) {
+      writeLine(`  ${colors.dim}Install: ${cliConfig.install}${RESET}`);
+    }
+    return;
+  }
+
+  const startMs = Date.now();
+  let completed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < agentFiles.length; i++) {
+    const agent = agentFiles[i];
+    const agentDef = loadAgentDefinition(agent.path);
+
+    // Derive context role from agent name
+    const agentRole = classifyAgent(agent.name);
+    const contextRole: ContextRole = agent.name.includes('lead') ? 'coo'
+      : (agentRole as ContextRole | null) ?? 'worker';
+
+    // Gather squad context (role-based)
+    const squadContext = gatherSquadContext(squad.name, agent.name, {
+      verbose: options.verbose,
+      agentPath: agent.path,
+      role: contextRole,
+    });
+
+    // Resolve per-agent model (from frontmatter or --model flag)
+    const frontmatter = parseAgentFrontmatter(agent.path);
+    const agentModel = frontmatter.model || options.model;
+
+    // Build prompt: agent definition + squad context
+    const prompt = `Execute the ${agent.name} agent from squad ${squad.name}.
+
+## Agent Definition
+${agentDef}
+
+${squadContext ? `## Squad Context\n${squadContext}\n` : ''}
+## Instructions
+Follow the agent definition above. Work autonomously. Output results directly.
+${options.task ? `\n## Task Directive\n${options.task}\n` : ''}`;
+
+    writeLine(`  ${colors.dim}[${i + 1}/${agentFiles.length}]${RESET} Running ${colors.cyan}${agent.name}${RESET}...`);
+
+    try {
+      await executeWithProvider(provider, prompt, {
+        verbose: options.verbose,
+        foreground: true,
+        squadName: squad.name,
+        agentName: agent.name,
+        model: agentModel,
+      });
+      completed++;
+      writeLine(`  ${icons.success} ${colors.cyan}${agent.name}${RESET} complete`);
+    } catch (error) {
+      failed++;
+      const msg = error instanceof Error ? error.message : String(error);
+      writeLine(`  ${icons.error} ${colors.red}${agent.name} failed: ${msg}${RESET}`);
+    }
+    writeLine();
+  }
+
+  const elapsed = Math.round((Date.now() - startMs) / 1000);
+  writeLine(`  ${icons.success} Sequential run complete (${completed}/${agentFiles.length} agents, ${elapsed}s)`);
+  if (failed > 0) {
+    writeLine(`  ${colors.yellow}${failed} agent(s) failed${RESET}`);
+  }
+  writeLine();
 }
 
 async function runAgent(
@@ -2223,6 +2368,7 @@ TIME LIMIT: You have ${timeoutMins} minutes. Work efficiently:
             foreground: !isBackground,
             squadName,
             agentName,
+            model: options.model,
           });
         }
 
@@ -2796,6 +2942,7 @@ async function executeWithProvider(
     cwd?: string;
     squadName?: string;
     agentName?: string;
+    model?: string;
   }
 ): Promise<string> {
   const cliConfig = getCLIConfig(provider);
@@ -2852,7 +2999,7 @@ async function executeWithProvider(
     effectivePrompt = prompt.replaceAll(projectRoot, workDir);
   }
 
-  const args = cliConfig.buildArgs(effectivePrompt);
+  const args = cliConfig.buildArgs(effectivePrompt, { model: options.model });
 
   if (options.verbose) {
     writeLine(`  ${colors.dim}Provider: ${cliConfig.displayName}${RESET}`);
@@ -2866,11 +3013,19 @@ async function executeWithProvider(
   // Foreground mode: run directly in terminal
   if (options.foreground) {
     return new Promise((resolve, reject) => {
+      // For stdinPrompt providers (e.g. Ollama), pipe prompt via stdin
+      // to avoid shell arg length limits with multi-KB prompts
+      const useStdin = cliConfig.stdinPrompt === true;
       const proc = spawn(cliConfig.command, args, {
-        stdio: 'inherit',
+        stdio: useStdin ? ['pipe', 'inherit', 'inherit'] : 'inherit',
         cwd: workDir,
         env: providerEnv,
       });
+
+      if (useStdin && proc.stdin) {
+        proc.stdin.write(effectivePrompt);
+        proc.stdin.end();
+      }
 
       proc.on('close', (code) => {
         cleanupWorktree(workDir, projectRoot);
@@ -2898,11 +3053,13 @@ async function executeWithProvider(
   }
 
   const escapedPrompt = effectivePrompt.replace(/'/g, "'\\''");
-  const providerArgs = cliConfig.buildArgs(escapedPrompt).map(a => `'${a}'`).join(' ');
+  const providerArgs = cliConfig.buildArgs(escapedPrompt, { model: options.model }).map(a => `'${a}'`).join(' ');
+  // For stdinPrompt providers in background, pipe prompt via heredoc
+  const stdinRedirect = cliConfig.stdinPrompt ? ` <<'SQUADS_PROMPT_EOF'\n${effectivePrompt}\nSQUADS_PROMPT_EOF` : '';
   const cleanupCmd = workDir !== projectRoot
     ? `; git -C '${projectRoot}' worktree remove '${workDir}' --force 2>/dev/null; git -C '${projectRoot}' branch -D '${branchName}' 2>/dev/null`
     : '';
-  const shellScript = `cd '${workDir}' && ${cliConfig.command} ${providerArgs} > '${logFile}' 2>&1${cleanupCmd}`;
+  const shellScript = `cd '${workDir}' && ${cliConfig.command} ${providerArgs}${stdinRedirect} > '${logFile}' 2>&1${cleanupCmd}`;
   const wrapperScript = `echo $$ > '${pidFile}'; ${shellScript}`;
 
   const child = spawn('sh', ['-c', wrapperScript], {

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -24,6 +24,9 @@ export interface CLIConfig {
 
   /** Build non-interactive args for execution */
   buildArgs: (prompt: string, options?: RunOptions) => string[];
+
+  /** If true, pipe prompt via stdin instead of CLI arg (avoids shell arg length limits) */
+  stdinPrompt?: boolean;
 }
 
 export interface RunOptions {
@@ -107,7 +110,8 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     displayName: 'Ollama (Local)',
     command: 'ollama',
     install: 'brew install ollama',
-    buildArgs: (prompt, opts) => ['run', opts?.model || 'llama3.1', prompt],
+    buildArgs: (_prompt, opts) => ['run', opts?.model || 'llama3.1'],
+    stdinPrompt: true,
   },
 };
 

--- a/templates/seed/skills/squads-cli/SKILL.md
+++ b/templates/seed/skills/squads-cli/SKILL.md
@@ -1,84 +1,329 @@
-# squads-cli — Operations Manual
+---
+name: squads-cli
+description: Squads CLI reference for autonomous agents — run squads, manage memory, check status, set goals, and operate the AI workforce. TRIGGER when using squads commands, dispatching agents, reading/writing memory, checking squad status, or operating the autonomous loop.
+context: fork
+---
 
-You have access to the `squads` CLI for managing your AI workforce.
+# Squads CLI
 
-## Execute (Daily Operations)
+The `squads` CLI is the operating system for your AI workforce. Agents are the primary users — they call these commands during execution to understand context, persist learnings, and coordinate with other squads.
+
+## Core Concepts
+
+| Concept | Description |
+|---------|-------------|
+| **Squad** | A team of agents in `.agents/squads/{name}/` — defined by `SQUAD.md` |
+| **Agent** | A markdown file (`{agent}.md`) inside a squad directory |
+| **Memory** | Persistent state in `.agents/memory/{squad}/{agent}/` — survives across runs |
+| **Target** | `squad/agent` notation (e.g., `engineering/issue-solver`) |
+| **Context cascade** | Layered context injection: SYSTEM → SQUAD → priorities → directives → state |
+
+## File Structure
+
+```
+.agents/
+├── config/SYSTEM.md              # Immutable rules (all agents)
+├── squads/{squad}/
+│   ├── SQUAD.md                  # Squad identity, goals, KPIs
+│   └── {agent}.md                # Agent definition
+└── memory/
+    ├── {squad}/
+    │   ├── priorities.md          # Current operational focus
+    │   ├── feedback.md            # Last cycle evaluation
+    │   ├── active-work.md         # Open PRs/issues
+    │   └── {agent}/
+    │       ├── state.md           # Agent's persistent state
+    │       └── learnings.md       # Accumulated insights
+    ├── company/directives.md      # Strategic overlay
+    └── daily-briefing.md          # Cross-squad context
+```
+
+---
+
+## Running Agents
+
+### Single Agent
 
 ```bash
-squads run <squad>/<agent>        # Execute a specific agent
-squads run <squad> --lead         # Orchestrate full squad
-squads run <squad> --parallel     # Run all agents in parallel
-squads list                       # Discover squads and agents
-squads exec list                  # Recent execution history
-squads exec stats                 # Execution statistics
-squads orchestrate <squad>        # Multi-agent coordination
-squads env prompt <squad> -a <agent>  # Get agent prompt
+# Run specific agent (two equivalent notations)
+squads run engineering/issue-solver
+squads run engineering -a issue-solver
+
+# With founder directive (replaces lead briefing)
+squads run engineering/issue-solver --task "Fix CI pipeline for PR #593"
+
+# Dry run — preview without executing
+squads run engineering --dry-run
+
+# Background execution
+squads run engineering/scanner -b          # Detached
+squads run engineering/scanner -w          # Detached but tail logs
+
+# Use different LLM provider
+squads run research/analyst --provider=google
+squads run research/analyst --provider=google --model=gemini-2.5-flash
 ```
 
-## Understand (Situational Awareness)
+### Squad Conversation
+
+Run an entire squad as a coordinated team. Lead briefs → workers execute → lead reviews → iterate until convergence.
 
 ```bash
-squads dash --json                # Full dashboard (use --json for parsing)
-squads status [squad]             # Quick status snapshot
-squads context --json             # Business context feed
-squads cost                       # Cost tracking
-squads budget <squad>             # Budget check
-squads history                    # Execution history
+squads run research                        # Sequential conversation
+squads run research --parallel             # All agents in parallel (tmux)
+squads run research --lead                 # Single orchestrator with Task tool
+squads run research --max-turns 10         # Limit conversation turns
+squads run research --cost-ceiling 15      # Budget cap in USD
 ```
 
-## Track (Objectives + Metrics)
+### Autopilot (Autonomous Dispatch)
+
+No target = autopilot mode. CLI scores squads by priority, dispatches automatically.
 
 ```bash
-squads goal set <squad> "<goal>"  # Set a business objective
-squads goal list [squad]          # List goals
-squads goal complete <squad> <n>  # Mark goal done
-squads kpi list                   # List all KPIs
-squads kpi show <squad>           # Squad KPIs
-squads kpi trend <squad> <kpi>    # Show trend
-squads feedback add <squad> <1-5> "<feedback>"  # Rate output
-squads autonomy                   # Self-assessment
+squads run                                 # Start autopilot
+squads run --once                          # Single cycle then exit
+squads run --once --dry-run                # Preview what would dispatch
+squads run -i 15 --budget 50              # 15-min cycles, $50/day cap
+squads run --phased                        # Respect depends_on ordering
+squads run --max-parallel 3               # Up to 3 squads simultaneously
 ```
 
-## Learn (Memory + Knowledge)
+### Execution Options
+
+| Flag | Purpose |
+|------|---------|
+| `--verbose` | Detailed output with context sections logged |
+| `--timeout <min>` | Execution timeout (default: 30 min) |
+| `--effort <level>` | `high`, `medium`, `low` (default: from SQUAD.md or high) |
+| `--skills <ids>` | Load additional skills |
+| `--cloud` | Dispatch to cloud worker (requires `squads login`) |
+| `--no-verify` | Skip post-execution verification |
+| `--no-eval` | Skip post-run COO evaluation |
+| `--json` | Machine-readable output |
+
+---
+
+## Memory Operations
+
+Memory is how agents persist knowledge across runs. Files-first — everything is markdown on disk.
+
+### Read Memory
 
 ```bash
-squads memory read <squad>        # Load squad memory
-squads memory write <squad> "<insight>"  # Persist learning
-squads memory search "<query>"    # Search all memory
-squads memory list                # List all entries
-squads learn "<insight>"          # Capture learning
-squads learnings show <squad>     # View learnings
-squads sync --push                # Sync memory to git
+# View all memory for a squad
+squads memory read engineering
+
+# Search across ALL squad memory
+squads memory query "CI pipeline failures"
+squads memory query "agent performance"
 ```
 
-## Schedule (Automation)
+### Write Memory
 
 ```bash
-squads trigger list               # View triggers
-squads trigger fire <squad>       # Manual trigger
-squads autonomous start           # Start scheduler
-squads approval list              # Check pending approvals
+# Write insight to squad memory
+squads memory write research "MCP adoption rate at 15% — up from 8% last month"
+
+# Write to specific agent
+squads memory write engineering --agent issue-solver "PR #593 blocked by flaky test"
 ```
 
-## Decision Framework
+### Capture Learnings
 
-- **Read before act**: Always `squads context --json` or `squads memory read` first
-- **Track everything**: Use `goal progress`, `kpi record`, `feedback add`
-- **Persist learnings**: `squads memory write` after discoveries
-- **Use JSON**: Add `--json` when parsing output programmatically
-- **Escalate wisely**: High cost or unclear scope → ask the human
+```bash
+# Quick learning capture
+squads learn "Google blocks headless Chrome OAuth — use cookie injection" \
+  --squad engineering --category pattern --tags "auth,chrome,e2e"
 
-## JSON Output
-
-All key commands support `--json` for structured output:
-```json
-{
-  "ok": true,
-  "command": "status",
-  "data": { ... },
-  "error": null,
-  "meta": { "duration_ms": 1230, "connected": true }
-}
+# View learnings
+squads learnings
+squads learnings --squad engineering
 ```
 
-When piped (non-TTY), commands auto-output JSON.
+### Sync Memory
+
+```bash
+squads sync                    # Pull remote changes
+squads sync --push             # Pull + push local changes
+squads sync --postgres         # Also sync to Postgres
+```
+
+---
+
+## Status & Monitoring
+
+### Squad Status
+
+```bash
+squads status                  # All squads overview
+squads status engineering      # Specific squad details
+squads status -v               # Verbose with agent details
+squads status --json           # Machine-readable
+```
+
+### Dashboards
+
+```bash
+squads dash                    # Overview dashboard
+squads dash engineering        # Squad-specific dashboard
+squads dash --ceo              # Executive summary
+squads dash --full             # Include GitHub PR/issue stats (~30s)
+squads dash --list             # List available dashboards
+```
+
+### Execution History
+
+```bash
+squads exec list               # Recent executions
+squads exec list --squad eng   # Filter by squad
+squads exec show <id>          # Execution details
+squads exec stats              # Aggregate statistics
+```
+
+### Cost Tracking
+
+```bash
+squads cost                    # Today + this week
+squads cost --squad research   # Squad-specific costs
+squads cost --json             # Machine-readable
+```
+
+### Health & Readiness
+
+```bash
+squads doctor                  # Check tools, auth, project readiness
+squads doctor -v               # Verbose with install hints
+squads eval engineering/scanner  # Agent readiness score
+```
+
+---
+
+## Goals & Priorities
+
+Goals are aspirational (in SQUAD.md). Priorities are operational (in priorities.md).
+
+### Set Goals
+
+```bash
+squads goal set engineering "Zero CI failures on main branch"
+squads goal list                    # All squads
+squads goal list engineering        # Specific squad
+squads goal complete engineering 1  # Mark done
+squads goal progress engineering 1 "75%"
+```
+
+### Business Context
+
+```bash
+squads context                           # Full business context
+squads context --squad engineering       # Squad-focused context
+squads context --topic "pricing"         # Topic-focused search
+squads context --json                    # Agent-consumable format
+```
+
+---
+
+## Environment & Configuration
+
+### Execution Environment
+
+```bash
+squads env show engineering              # View MCP servers, skills, model, budget
+squads env show engineering --json       # Machine-readable
+squads env prompt engineering            # Ready-to-use prompt for Claude Code
+```
+
+### Provider Management
+
+```bash
+squads providers                         # List available LLM CLI providers
+```
+
+### Sessions
+
+```bash
+squads sessions                          # Active Claude Code sessions
+squads session start                     # Start new session
+squads session end                       # End current session
+```
+
+---
+
+## Autonomous Scheduling
+
+The daemon runs agents on configured schedules without human intervention.
+
+```bash
+squads auto start                  # Start scheduling daemon
+squads auto stop                   # Stop daemon
+squads auto status                 # Show daemon status + next runs
+squads auto pause "quota exhausted"  # Pause with reason
+squads auto resume                 # Resume after pause
+```
+
+---
+
+## Common Patterns
+
+### Agent Self-Context (during execution)
+
+Agents call these to understand their environment:
+
+```bash
+# What am I working with?
+squads env show ${SQUAD_NAME} --json
+
+# What do I know?
+squads memory read ${SQUAD_NAME}
+
+# What's happening across the org?
+squads status --json
+
+# What's the business context?
+squads context --squad ${SQUAD_NAME} --json
+```
+
+### Post-Execution Memory Update
+
+```bash
+# Persist what you learned
+squads memory write ${SQUAD_NAME} "Key finding from this run"
+squads learn "Pattern discovered: X causes Y" --squad ${SQUAD_NAME} --category pattern
+
+# Sync to remote
+squads sync --push
+```
+
+### Dispatch Another Agent
+
+```bash
+# From within an agent, trigger another
+squads run engineering/issue-solver --task "Fix the bug I found in #461" -b
+```
+
+### Check Before Creating
+
+Before creating issues/PRs, check what exists:
+
+```bash
+squads status engineering -v    # See active work
+squads memory read engineering  # See known issues
+squads context --squad engineering --json  # Full context
+```
+
+## Full Command Reference
+
+See `references/commands.md` for complete command listing with all flags.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `squads: command not found` | `npm install -g squads-cli` |
+| No squads found | Run `squads init` to create `.agents/` |
+| Agent not found | Check path: `.agents/squads/{squad}/{agent}.md` |
+| Memory not persisting | Check `.agents/memory/` exists, run `squads sync` |
+| Wrong provider | Set `--provider` flag or `provider:` in SQUAD.md frontmatter |
+| API quota exhausted | `squads auto pause "quota"`, switch provider, or wait |
+| Context too large | Use `--effort low` or reduce context layers |

--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -1,0 +1,181 @@
+# Squads CLI — Full Command Reference
+
+## All Commands
+
+| Command | Description |
+|---------|-------------|
+| `squads init` | Create `.agents/` directory with starter squads |
+| `squads add <name>` | Add a new squad with directory structure |
+| `squads run [target]` | Run squad, agent, or autopilot (no target = autopilot) |
+| `squads orchestrate <squad>` | Run squad with lead agent orchestration |
+| `squads status [squad]` | Show squad status and state |
+| `squads env show <squad>` | View execution environment (MCP, skills, model) |
+| `squads env prompt <squad>` | Output ready-to-use prompt for execution |
+| `squads context` | Get business context for alignment |
+| `squads dashboard [name]` | Show dashboards (`squads dash` alias) |
+| `squads exec list` | List recent executions |
+| `squads exec show <id>` | Show execution details |
+| `squads exec stats` | Show execution statistics |
+| `squads cost` | Show cost summary (today, week, by squad) |
+| `squads budget <squad>` | Check budget status for a squad |
+| `squads health` | Quick health check for infrastructure |
+| `squads doctor` | Check local tools, auth, project readiness |
+| `squads history` | Show recent agent execution history |
+| `squads results [squad]` | Show git activity + KPI goals vs actuals |
+| `squads goal set <squad> <desc>` | Set a goal for a squad |
+| `squads goal list [squad]` | List goals |
+| `squads goal complete <squad> <i>` | Mark goal completed |
+| `squads goal progress <squad> <i> <p>` | Update goal progress |
+| `squads kpi` | Track and analyze squad KPIs |
+| `squads progress` | Track active and completed agent tasks |
+| `squads feedback` | Record and view execution feedback |
+| `squads autonomy` | Show autonomy score and confidence metrics |
+| `squads stats [squad]` | Agent outcome scorecards: merge rate, waste |
+| `squads memory query <q>` | Search across all squad memory |
+| `squads memory read <squad>` | Show memory for a squad |
+| `squads memory write <squad> <content>` | Add to squad memory |
+| `squads memory list` | List all memory entries |
+| `squads memory sync` | Sync memory from git |
+| `squads memory search <q>` | Search stored conversations (requires login) |
+| `squads memory extract` | Extract memories from recent conversations |
+| `squads learn <insight>` | Capture a learning for future sessions |
+| `squads learnings` | View and search learnings |
+| `squads sync` | Git memory synchronization |
+| `squads trigger` | Manage smart triggers |
+| `squads approval` | Manage approval requests |
+| `squads auto start` | Start autonomous scheduling daemon |
+| `squads auto stop` | Stop scheduling daemon |
+| `squads auto status` | Show daemon status and next runs |
+| `squads auto pause [reason]` | Pause daemon |
+| `squads auto resume` | Resume paused daemon |
+| `squads sessions` | Show active Claude Code sessions |
+| `squads session` | Manage current session lifecycle |
+| `squads detect-squad` | Detect squad from cwd (for hooks) |
+| `squads login` | Log in to Squads platform |
+| `squads logout` | Log out |
+| `squads whoami` | Show current user |
+| `squads eval <target>` | Evaluate agent readiness |
+| `squads deploy` | Deploy agents to Squads platform |
+| `squads cognition` | Business cognition engine |
+| `squads providers` | Show available LLM CLI providers |
+| `squads update` | Check for and install updates |
+| `squads version` | Show version information |
+
+## `squads run` — Full Options
+
+```
+squads run [target] [options]
+
+Target formats:
+  (none)                    Autopilot mode
+  <squad>                   Squad conversation
+  <squad>/<agent>           Single agent
+  <squad> -a <agent>        Single agent (flag notation)
+
+Agent execution:
+  -v, --verbose             Detailed output
+  -d, --dry-run             Preview without executing
+  -t, --timeout <min>       Timeout in minutes (default: 30)
+  -b, --background          Run detached
+  -w, --watch               Run detached but tail logs
+  --task <directive>        Founder directive
+  --effort <level>          high | medium | low
+  --skills <ids...>         Additional skills to load
+  --provider <provider>     anthropic | google | openai | mistral | xai | aider | ollama
+  --model <model>           opus | sonnet | haiku | gemini-2.5-flash | gpt-4o | etc.
+  --cloud                   Dispatch to cloud worker
+  --no-verify               Skip post-execution verification
+  --no-eval                 Skip COO evaluation
+  --use-api                 Use API credits instead of subscription
+
+Squad conversation:
+  -p, --parallel            All agents in parallel (tmux)
+  -l, --lead                Single orchestrator with Task tool
+  --max-turns <n>           Max conversation turns (default: 20)
+  --cost-ceiling <usd>      Cost ceiling in USD (default: 25)
+
+Autopilot:
+  -i, --interval <min>      Minutes between cycles (default: 30)
+  --max-parallel <count>    Max parallel squad loops (default: 2)
+  --budget <usd>            Daily budget cap (default: 0 = unlimited)
+  --once                    Single cycle then exit
+  --phased                  Use depends_on phase ordering
+
+Output:
+  -j, --json                Machine-readable output
+```
+
+## `squads init` — Full Options
+
+```
+squads init [options]
+
+  -p, --provider <provider>  LLM provider (claude, gemini, openai, ollama, none)
+  --pack <packs...>          Additional squads: engineering, marketing, operations, all
+  --skip-infra               Skip infrastructure setup
+  --force                    Skip requirement checks
+  -y, --yes                  Accept defaults (non-interactive)
+  -q, --quick                Files only, skip prompts
+```
+
+## `squads memory` — Full Options
+
+```
+squads memory query <query>           Search all memory
+squads memory read <squad>            Show squad memory
+squads memory write <squad> <content> Write to memory
+  --agent <agent>                     Target specific agent
+squads memory list                    List all entries
+squads memory sync [options]          Sync from git
+  --push                              Also push changes
+squads memory search <query>          Search conversations (requires login)
+squads memory extract                 Extract from recent conversations
+```
+
+## `squads context` — Full Options
+
+```
+squads context [options]
+
+  -s, --squad <squad>     Focus on specific squad
+  -t, --topic <topic>     Search memory for topic
+  -a, --agent             JSON for agent consumption
+  -j, --json              JSON output
+  -v, --verbose           Additional details
+```
+
+## Global Patterns
+
+Every command supports:
+- `--json` or `-j` for machine-readable output
+- `--verbose` or `-v` for detailed output
+- `--help` or `-h` for usage information
+
+## SQUAD.md Frontmatter
+
+Squads are configured via YAML frontmatter in SQUAD.md:
+
+```yaml
+---
+name: engineering
+repo: agents-squads/engineering
+provider: anthropic
+model: opus
+effort: high
+depends_on: [data]
+kpis:
+  merge_rate:
+    target: ">80%"
+    unit: percentage
+---
+```
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Squad identifier |
+| `repo` | GitHub repo (org/repo format) |
+| `provider` | Default LLM provider |
+| `model` | Default model |
+| `effort` | Default effort level |
+| `depends_on` | Phase ordering dependencies |
+| `kpis` | KPI definitions for tracking |


### PR DESCRIPTION
## Summary

Fixes #602 — Local LLMs (Ollama) now work with `squads run <squad>`.

- **Sequential mode**: Non-tool-use providers (Ollama, Aider, xAI, etc.) run agents one-at-a-time instead of failing with "No lead agent found" or hallucinating tool calls
- **Lead mode blocked**: Clear error message with alternatives when using `--lead` with non-tool-use providers
- **Stdin prompt passing**: Ollama prompts piped via stdin instead of CLI args (fixes shell arg length limits on multi-KB agent prompts)
- **Per-agent model support**: `model` option now flows through `executeWithProvider` so users can set different Ollama models per agent
- **Zero behavior change** for Claude/Gemini users — conversation mode is unchanged

## Test plan

- [x] `npm run build` passes
- [x] All 1732 tests pass
- [ ] `squads run <squad> --provider ollama --dry-run` → shows "sequential mode"
- [ ] `squads run <squad> --lead --provider ollama` → shows clear error with alternatives
- [ ] `squads run <squad>/<agent> --provider ollama` → works as before (single agent)
- [ ] `squads run <squad>` without --provider → conversation mode unchanged (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)