### PR TITLE
fix: add sequential mode for Ollama/local LLM providers (#602)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/squad-parser.js';
 import {
   type RunOptions,
+  TOOL_USE_PROVIDERS,
 } from '../lib/run-types.js';
 import {
   preflightExecutorCheck,
@@ -26,7 +27,7 @@ import { runCloudDispatch } from '../lib/cloud-dispatch.js';
 import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
 import { reportExecutionStart, reportConversationResult, pushCognitionSignal } from '../lib/api-client.js';
 import { runAgent } from '../lib/agent-runner.js';
-import { runPostEvaluation, runAutopilot, runLeadMode } from '../lib/run-modes.js';
+import { runPostEvaluation, runAutopilot, runLeadMode, runSequentialMode } from '../lib/run-modes.js';
 
 export async function runCommand(
   target: string | null,
@@ -231,9 +232,15 @@ async function runSquad(
         return;
       }
     } else {
-      // Default: Run squad as multi-agent conversation
-      // Lead briefs → scanners discover → workers execute → lead reviews → converge
-      if (options.execute) {
+      // Determine provider for mode selection
+      const squadProvider = options.provider || squad?.providers?.default || 'anthropic';
+
+      if (options.execute && !TOOL_USE_PROVIDERS.has(squadProvider)) {
+        // Sequential mode for providers without tool use (Ollama, Codex, etc.)
+        await runSequentialMode(squad, squadsDir, squadProvider, options);
+      } else if (options.execute) {
+        // Default: Run squad as multi-agent conversation
+        // Lead briefs → scanners discover → workers execute → lead reviews → converge
         writeLine(`  ${bold}Conversation mode${RESET} ${colors.dim}(lead → scan → work → review → verify)${RESET}`);
         writeLine();
 
@@ -290,13 +297,17 @@ async function runSquad(
         writeLine();
       } else {
         // Dry-run: show what would happen
-        writeLine(`  ${colors.dim}Default mode: conversation (lead → scan → work → review → verify)${RESET}`);
+        const squadProvider2 = options.provider || squad?.providers?.default || 'anthropic';
+        const modeLabel = TOOL_USE_PROVIDERS.has(squadProvider2)
+          ? 'conversation (lead → scan → work → review → verify)'
+          : `sequential (${squadProvider2} — agents run one at a time)`;
+        writeLine(`  ${colors.dim}Default mode: ${modeLabel}${RESET}`);
         writeLine();
         for (const agent of squad.agents) {
           writeLine(`  ${icons.empty} ${colors.cyan}${agent.name}${RESET} ${colors.dim}${agent.role}${RESET}`);
         }
         writeLine();
-        writeLine(`  ${colors.dim}Run conversation:${RESET}`);
+        writeLine(`  ${colors.dim}Run:${RESET}`);
         writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET}`);
         writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --task "review and merge open PRs"`);
         writeLine();

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -701,6 +701,7 @@ export async function executeWithProvider(
     cwd?: string;
     squadName?: string;
     agentName?: string;
+    model?: string;
   }
 ): Promise<string> {
   const cliConfig = getCLIConfig(provider);
@@ -757,7 +758,8 @@ export async function executeWithProvider(
     effectivePrompt = prompt.replaceAll(projectRoot, workDir);
   }
 
-  const args = cliConfig.buildArgs(effectivePrompt);
+  const buildOpts = options.model ? { model: options.model } : undefined;
+  const args = cliConfig.buildArgs(effectivePrompt, buildOpts);
 
   if (options.verbose) {
     writeLine(`  ${colors.dim}Provider: ${cliConfig.displayName}${RESET}`);
@@ -766,16 +768,25 @@ export async function executeWithProvider(
     if (workDir !== projectRoot) {
       writeLine(`  ${colors.dim}Worktree: ${branchName}${RESET}`);
     }
+    if (cliConfig.stdinPrompt) {
+      writeLine(`  ${colors.dim}Prompt delivery: stdin${RESET}`);
+    }
   }
 
   // Foreground mode: run directly in terminal
   if (options.foreground) {
     return new Promise((resolve, reject) => {
       const proc = spawn(cliConfig.command, args, {
-        stdio: 'inherit',
+        stdio: cliConfig.stdinPrompt ? ['pipe', 'inherit', 'inherit'] : 'inherit',
         cwd: workDir,
         env: providerEnv,
       });
+
+      // For stdinPrompt providers (e.g. Ollama), pipe the prompt via stdin
+      if (cliConfig.stdinPrompt && proc.stdin) {
+        proc.stdin.write(effectivePrompt);
+        proc.stdin.end();
+      }
 
       proc.on('close', (code) => {
         cleanupWorktree(workDir, projectRoot);

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -24,6 +24,9 @@ export interface CLIConfig {
 
   /** Build non-interactive args for execution */
   buildArgs: (prompt: string, options?: RunOptions) => string[];
+
+  /** If true, pipe prompt via stdin instead of CLI arg (avoids shell arg length limits) */
+  stdinPrompt?: boolean;
 }
 
 export interface RunOptions {
@@ -107,7 +110,8 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     displayName: 'Ollama (Local)',
     command: 'ollama',
     install: 'brew install ollama',
-    buildArgs: (prompt, opts) => ['run', opts?.model || 'llama3.1', prompt],
+    buildArgs: (_prompt, opts) => ['run', opts?.model || 'llama3.1'],
+    stdinPrompt: true,
   },
 };
 

--- a/src/lib/run-modes.ts
+++ b/src/lib/run-modes.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'fs';
 import {
   type RunOptions,
   DEFAULT_TIMEOUT_MINUTES,
+  TOOL_USE_PROVIDERS,
 } from './run-types.js';
 import {
   checkClaudeCliAvailable,
@@ -604,6 +605,21 @@ export async function runLeadMode(
     return;
   }
 
+  // Block lead mode for providers without tool use support
+  const squadProvider = options.provider || squad?.providers?.default || 'anthropic';
+  if (!TOOL_USE_PROVIDERS.has(squadProvider)) {
+    const cliConfig = getCLIConfig(squadProvider);
+    const providerName = cliConfig?.displayName || squadProvider;
+    writeLine(`  ${icons.warning} ${colors.yellow}Lead mode requires tool-use support (Claude, Gemini)${RESET}`);
+    writeLine(`  ${colors.dim}${providerName} cannot spawn sub-agents via Task tool.${RESET}`);
+    writeLine();
+    writeLine(`  ${colors.dim}Options:${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --provider ${squadProvider}  ${colors.dim}← sequential mode (recommended)${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}/${agentFiles[0]?.name || 'agent'}${RESET} --provider ${squadProvider}  ${colors.dim}← single agent${RESET}`);
+    writeLine();
+    return;
+  }
+
   writeLine(`  ${bold}Lead mode${RESET} ${colors.dim}orchestrating ${agentFiles.length} agents${RESET}`);
   writeLine();
 
@@ -761,4 +777,94 @@ Begin by assessing pending work, then delegate to agents via Task tool.`;
     writeLine(`  ${colors.dim}${msg}${RESET}`);
     writeLine(`  ${colors.dim}Run \`squads doctor\` to check your setup.${RESET}`);
   }
+}
+
+// ── Sequential mode ──────────────────────────────────────────────────
+// For providers without tool-use (Ollama, Codex, etc.): run each agent
+// one at a time. No output chaining — each agent reads its own context.
+
+/**
+ * Run all squad agents sequentially with a non-tool-use provider.
+ * Each agent runs in foreground, one at a time (Ollama saturates hardware).
+ */
+export async function runSequentialMode(
+  squad: NonNullable<ReturnType<typeof loadSquad>>,
+  squadsDir: string,
+  provider: string,
+  options: RunOptions,
+): Promise<void> {
+  const cliConfig = getCLIConfig(provider);
+  const providerName = cliConfig?.displayName || provider;
+
+  const agentFiles = squad.agents
+    .map(a => ({
+      name: a.name,
+      role: a.role || '',
+      path: join(squadsDir, squad.dir, `${a.name}.md`),
+    }))
+    .filter(a => existsSync(a.path));
+
+  if (agentFiles.length === 0) {
+    writeLine(`  ${icons.error} ${colors.red}No agent files found${RESET}`);
+    return;
+  }
+
+  writeLine(`  ${bold}Sequential mode${RESET} ${colors.dim}(${providerName} — agents run one at a time)${RESET}`);
+  writeLine();
+
+  for (const agent of agentFiles) {
+    writeLine(`  ${icons.empty} ${colors.cyan}${agent.name}${RESET} ${colors.dim}${agent.role}${RESET}`);
+  }
+  writeLine();
+
+  if (!options.execute) {
+    writeLine(`  ${colors.dim}Run sequentially:${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --provider ${provider}`);
+    writeLine();
+    return;
+  }
+
+  const startMs = Date.now();
+  let completed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < agentFiles.length; i++) {
+    const agent = agentFiles[i];
+    const label = `[${i + 1}/${agentFiles.length}]`;
+    writeLine(`  ${colors.dim}${label}${RESET} Running ${colors.cyan}${agent.name}${RESET}...`);
+
+    try {
+      // Read agent definition for the prompt
+      const definition = readFileSync(agent.path, 'utf-8');
+
+      // Build prompt: agent definition + squad context
+      const { gatherSquadContext } = await import('./run-context.js');
+      const context = gatherSquadContext(squad.dir, agent.name, {
+        verbose: options.verbose,
+        agentPath: agent.path,
+      });
+
+      const prompt = `${definition}\n${context}`;
+
+      await executeWithProvider(provider, prompt, {
+        verbose: options.verbose,
+        foreground: true,
+        squadName: squad.dir,
+        agentName: agent.name,
+        model: options.model,
+      });
+
+      completed++;
+      writeLine(`  ${icons.success} ${colors.dim}${label}${RESET} ${agent.name} ${colors.green}complete${RESET}`);
+    } catch (err) {
+      failed++;
+      writeLine(`  ${icons.error} ${colors.dim}${label}${RESET} ${agent.name} ${colors.red}failed: ${err instanceof Error ? err.message : String(err)}${RESET}`);
+    }
+
+    writeLine();
+  }
+
+  const elapsed = Math.round((Date.now() - startMs) / 1000);
+  writeLine(`  ${gradient('Sequential run complete')} ${colors.dim}(${completed} ok, ${failed} failed, ${elapsed}s)${RESET}`);
+  writeLine();
 }

--- a/src/lib/run-types.ts
+++ b/src/lib/run-types.ts
@@ -8,6 +8,9 @@ import type { EffortLevel } from './squad-parser.js';
 export const DEFAULT_TIMEOUT_MINUTES = 30;
 export const SOFT_DEADLINE_RATIO = 0.7;
 
+/** Providers that support tool use (sub-agent spawning, conversation orchestration) */
+export const TOOL_USE_PROVIDERS = new Set(['anthropic', 'google']);
+
 // ── Interfaces ───────────────────────────────────────────────────────
 
 export interface RunOptions {


### PR DESCRIPTION
## Summary
- Adds sequential execution mode for providers without tool-use support (Ollama, Codex, Mistral, xAI, Aider)
- Routes non-tool-use providers away from conversation/lead modes that require Task tool
- Fixes Ollama prompt delivery via stdin (avoids shell arg length limits)
- Passes `model` option through to `executeWithProvider` for per-agent model selection

Closes #602. Supersedes #604 (rebased cleanly after #606 extraction).

## Changes
| File | Change |
|------|--------|
| `src/lib/run-types.ts` | Add `TOOL_USE_PROVIDERS` constant |
| `src/lib/llm-clis.ts` | Add `stdinPrompt` to CLIConfig, set on Ollama |
| `src/lib/execution-engine.ts` | Handle `stdinPrompt` in foreground mode, add `model` option |
| `src/lib/run-modes.ts` | Add `runSequentialMode()`, block lead mode for non-tool-use |
| `src/commands/run.ts` | Route to sequential mode, update dry-run preview |

## Test plan
- [x] `npm run build` passes
- [x] All 1734 tests pass
- [ ] `squads run <squad> --provider ollama --dry-run` shows "sequential mode"
- [ ] `squads run <squad> --lead --provider ollama` shows clear error with alternatives
- [ ] `squads run <squad>/<agent> --provider ollama` works as before (single agent)
- [ ] `squads run <squad>` without --provider → conversation mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)