### PR TITLE
fix(init): squads init works in clean environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.worktrees
+*.tgz

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -327,8 +327,11 @@ Examples:
     return runCommand(target || null, { ...options, timeout: parseInt(options.timeout, 10) });
   });
 
-// List command (removed — use status instead)
-program.command('list', { hidden: true }).description('[removed]').action(removedCommand('list', 'Use: squads status'));
+// List command — alias for status
+program.command('list').description('List squads (alias for: squads status)').action(async () => {
+  const { statusCommand } = await import('./commands/status.js');
+  return statusCommand();
+});
 
 // Orchestrate command - lead-coordinated squad execution
 registerOrchestrateCommand(program);

--- a/src/lib/setup-checks.ts
+++ b/src/lib/setup-checks.ts
@@ -260,12 +260,13 @@ export function checkProviderAuth(providerId: string): CheckResult {
     return { name: provider.name, status: 'ok' };
   }
 
-  // Check CLI if required
+  // Check CLI if required — missing CLI is a warning (not an error) during init
+  // Users can scaffold first and install the provider CLI later
   if (provider.cliCheck) {
     if (!commandExists(provider.cliCheck)) {
       return {
         name: provider.name,
-        status: 'missing',
+        status: 'warning',
         message: `CLI not installed`,
         hint: provider.installCmd ? `Install: ${provider.installCmd}` : undefined,
         fixCommand: provider.installCmd,

--- a/test/docker/Dockerfile.fresh-user
+++ b/test/docker/Dockerfile.fresh-user
@@ -1,12 +1,16 @@
 # Simulates a brand new user installing squads-cli for the first time.
 # No config, no .agents dir, no history — completely clean environment.
+# Builds from local source so tests exercise the current codebase.
 
 FROM node:22-slim
 
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
-# Install squads-cli globally (as root, like sudo npm install -g)
-RUN npm install -g squads-cli 2>&1 || echo "INSTALL FAILED"
+# Build squads-cli from local source and install globally
+WORKDIR /app
+COPY . .
+RUN npm ci && npm run build && npm pack
+RUN npm install -g squads-cli-*.tgz
 
 # Verify it's installed
 RUN which squads && squads --version || echo "squads not found after install"

--- a/test/setup-checks.test.ts
+++ b/test/setup-checks.test.ts
@@ -296,12 +296,12 @@ describe('setup-checks', () => {
       expect(result.message).toContain('Unknown provider');
     });
 
-    it('returns missing when provider CLI not installed', () => {
-      // commandExists('claude') -> false
+    it('returns warning when provider CLI not installed', () => {
+      // commandExists('claude') -> false — treated as warning, not error
       mockedExecSync.mockImplementationOnce(() => { throw new Error(); });
 
       const result = checkProviderAuth('claude');
-      expect(result.status).toBe('missing');
+      expect(result.status).toBe('warning');
       expect(result.fixCommand).toBeDefined();
     });
 
@@ -338,11 +338,11 @@ describe('setup-checks', () => {
       }
     });
 
-    it('returns missing when ollama CLI not installed', () => {
+    it('returns warning when ollama CLI not installed', () => {
       mockedExecSync.mockImplementationOnce(() => { throw new Error(); });
 
       const result = checkProviderAuth('ollama');
-      expect(result.status).toBe('missing');
+      expect(result.status).toBe('warning');
     });
   });
 


### PR DESCRIPTION
## Summary

Clean rebase of #611 onto develop (after #609 merged).

- Missing provider CLIs treated as warning, not error — users can scaffold first
- Restored `squads list` as alias for `squads status`
- Dockerfile builds from local source via `npm pack`
- Added `.dockerignore` for fast Docker builds

## Testing

All 9 fresh-user Docker test steps pass:
```
PASS  version, help, init, agents-dir, status, list, catalog-list, doctor, unknown-cmd
=== Results: 9 passed, 0 failed ===
```

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)