### PR TITLE
feat: scoped permissions + daemon Tier 2 triggers (#625, #628)

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -661,7 +661,26 @@ export async function executeWithClaude(
     // Build claude args as array to avoid shell escaping issues with large prompts
     const claudeArgs: string[] = [];
     if (!process.stdin.isTTY) claudeArgs.push('--print');
-    claudeArgs.push('--dangerously-skip-permissions');
+
+    // Permission model: scoped allowed tools instead of blanket skip
+    // Agents can: read/write files, run git/gh/npm/bash, use tools
+    // Agents cannot: bypass to arbitrary system access
+    if (process.env.SQUADS_SKIP_PERMISSIONS === '1') {
+      // Explicit opt-in for sandboxed environments (Docker, CI)
+      claudeArgs.push('--dangerously-skip-permissions');
+    } else {
+      claudeArgs.push('--allowedTools',
+        'Read', 'Write', 'Edit', 'Glob', 'Grep',
+        'Bash(git:*)', 'Bash(gh:*)', 'Bash(npm:*)', 'Bash(npx:*)',
+        'Bash(node:*)', 'Bash(python3:*)', 'Bash(curl:*)',
+        'Bash(docker:*)', 'Bash(duckdb:*)',
+        'Bash(ls:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)',
+        'Bash(cat:*)', 'Bash(head:*)', 'Bash(tail:*)', 'Bash(wc:*)',
+        'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(date:*)',
+        'Bash(squads:*)',
+        'Agent', 'WebFetch', 'WebSearch',
+      );
+    }
     claudeArgs.push('--disable-slash-commands');
     if (mcpConfigPath) claudeArgs.push('--mcp-config', mcpConfigPath);
     if (claudeModelAlias) claudeArgs.push('--model', claudeModelAlias);

--- a/src/lib/squad-loop.ts
+++ b/src/lib/squad-loop.ts
@@ -757,3 +757,42 @@ export function scoreSquadsForPhase(
   const allSignals = scoreSquads(state, squadRepos, ghEnv);
   return allSignals.filter(s => phaseSquads.includes(s.squad));
 }
+
+/**
+ * Tier 2: fetch pending triggers from the API.
+ * Falls back to local scoring if API unavailable.
+ */
+export async function fetchTriggersFromApi(): Promise<SquadSignal[] | null> {
+  try {
+    const { isTier2, getTierSync } = await import('./tier-detect.js');
+    if (!isTier2()) return null;
+
+    const apiUrl = getTierSync().urls.api;
+    if (!apiUrl) return null;
+
+    const response = await fetch(`${apiUrl}/triggers/pending`, {
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) return null;
+
+    const triggers = await response.json() as Array<{
+      squad: string;
+      agent: string;
+      trigger_name: string;
+      priority: number;
+      context: Record<string, unknown>;
+    }>;
+
+    return triggers.map(t => ({
+      squad: t.squad,
+      score: t.priority * 10,
+      reason: `Trigger: ${t.trigger_name}`,
+      issues: [],
+      agent: t.agent,
+      context: t.context,
+    }));
+  } catch {
+    return null; // API unavailable — caller should fall back to local scoring
+  }
+}


### PR DESCRIPTION
Closes #625, #628. Scoped --allowedTools replaces --dangerously-skip-permissions. Daemon queries API triggers in Tier 2. 13/13 Docker tests pass.