### PR TITLE
feat: squads run --org — coordinated org cycle

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -308,6 +308,7 @@ program
   .option('--once', 'Autopilot: run one cycle then exit')
   .option('--phased', 'Autopilot: use dependency-based phase ordering (from SQUAD.md depends_on)')
   .option('--no-eval', 'Skip post-run COO evaluation')
+  .option('--org', 'Run all squads as a coordinated org cycle (scan → plan → execute → report)')
   .addHelpText('after', `
 Examples:
   $ squads run engineering              Run squad conversation (lead → scan → work → review)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -47,6 +47,70 @@ export async function runCommand(
     options.execute = true;
   }
 
+  // MODE 0: Org cycle — run all squads as a coordinated system
+  if (target === '--org' || options.org) {
+    const { scanOrg, planOrgCycle, displayOrgScan, displayPlan } = await import('../lib/org-cycle.js');
+
+    writeLine();
+    writeLine(`  ${gradient('squads')} ${colors.dim}org cycle${RESET}`);
+    writeLine();
+
+    // Step 1: SCAN
+    const scan = scanOrg();
+    displayOrgScan(scan);
+
+    // Step 2: PLAN
+    const plan = planOrgCycle(scan);
+    if (plan.length === 0) {
+      writeLine(`  ${colors.dim}No squads to run.${RESET}\n`);
+      return;
+    }
+    displayPlan(plan);
+
+    if (options.dryRun) {
+      writeLine(`  ${colors.dim}[dry-run] Would run ${plan.length} squad leads in order above.${RESET}\n`);
+      return;
+    }
+
+    // Step 3: EXECUTE — run each lead sequentially
+    const cycleStart = Date.now();
+    const results: Array<{ squad: string; agent: string; status: string; durationMs: number }> = [];
+
+    for (const s of plan) {
+      if (!s.lead) continue;
+      const leadPath = join(squadsDir, s.squad, `${s.lead}.md`);
+      if (!existsSync(leadPath)) continue;
+
+      writeLine(`  ${colors.cyan}Running ${s.squad}/${s.lead}...${RESET}`);
+      const runStart = Date.now();
+      try {
+        await runAgent(leadPath, s.lead, s.squad, { ...options, execute: true });
+        results.push({ squad: s.squad, agent: s.lead, status: 'completed', durationMs: Date.now() - runStart });
+      } catch (e) {
+        results.push({ squad: s.squad, agent: s.lead, status: 'failed', durationMs: Date.now() - runStart });
+        writeLine(`  ${colors.red}${s.squad}/${s.lead} failed: ${e instanceof Error ? e.message : String(e)}${RESET}`);
+      }
+    }
+
+    // Step 4: REPORT
+    const totalMs = Date.now() - cycleStart;
+    const completed = results.filter(r => r.status === 'completed').length;
+    const failed = results.filter(r => r.status === 'failed').length;
+
+    writeLine();
+    writeLine(`  ${bold}Org Cycle Complete${RESET}`);
+    writeLine(`  Duration: ${Math.round(totalMs / 60000)}m | Squads: ${completed} completed, ${failed} failed | Frozen: ${scan.filter(s => s.status === 'frozen').length} skipped`);
+    writeLine();
+
+    for (const r of results) {
+      const icon = r.status === 'completed' ? `${colors.green}pass${RESET}` : `${colors.red}fail${RESET}`;
+      writeLine(`  ${icon}  ${r.squad}/${r.agent}  ${colors.dim}${Math.round(r.durationMs / 1000)}s${RESET}`);
+    }
+    writeLine();
+
+    return;
+  }
+
   // MODE 1: Autopilot — no target means run all squads continuously
   if (!target) {
     await runAutopilot(squadsDir, options);

--- a/src/lib/org-cycle.ts
+++ b/src/lib/org-cycle.ts
@@ -1,0 +1,173 @@
+/**
+ * Org cycle — run the whole organization as a coordinated system.
+ *
+ * squads run --org [--dry-run]
+ *
+ * Steps:
+ * 1. SCAN:    Check all squads — priorities freshness, goal progress, scorecard grades
+ * 2. PLAN:    Decide what to run — skip frozen, prioritize by staleness + score
+ * 3. EXECUTE: Run leads in dependency order (phased)
+ * 4. EVALUATE: COO reviews all outputs
+ * 5. REPORT:  Org-level summary to observability
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { findSquadsDir, loadSquad } from './squad-parser.js';
+import { findMemoryDir } from './memory.js';
+import { colors, bold, RESET, writeLine } from './terminal.js';
+import { logObservability, type ObservabilityRecord } from './observability.js';
+
+export interface OrgScanResult {
+  squad: string;
+  status: 'active' | 'frozen' | 'stale' | 'healthy';
+  prioritiesAge: number; // days since last update
+  goalsActive: number;
+  lastExecution: string | null;
+  lead: string | null;
+  repo: string | null;
+  reason: string;
+}
+
+/**
+ * Scan all squads and return their health status.
+ */
+export function scanOrg(): OrgScanResult[] {
+  const squadsDir = findSquadsDir();
+  const memoryDir = findMemoryDir();
+  if (!squadsDir || !memoryDir) return [];
+
+  const results: OrgScanResult[] = [];
+  const now = Date.now();
+
+  for (const squadName of readdirSync(squadsDir).sort()) {
+    const squadPath = join(squadsDir, squadName);
+    if (!statSync(squadPath).isDirectory()) continue;
+    if (!existsSync(join(squadPath, 'SQUAD.md'))) continue;
+
+    const squad = loadSquad(squadName);
+    const result: OrgScanResult = {
+      squad: squadName,
+      status: 'healthy',
+      prioritiesAge: 999,
+      goalsActive: 0,
+      lastExecution: null,
+      lead: null,
+      repo: squad?.repo || null,
+      reason: '',
+    };
+
+    // Find lead agent
+    for (const file of readdirSync(squadPath)) {
+      if (file.endsWith('-lead.md') || file === 'coo.md' || file.startsWith('web-lead') || file.startsWith('intel-lead') || file.startsWith('eng-lead')) {
+        result.lead = file.replace('.md', '');
+        break;
+      }
+    }
+
+    // Check if frozen
+    const prioritiesPath = join(memoryDir, squadName, 'priorities.md');
+    if (existsSync(prioritiesPath)) {
+      const content = readFileSync(prioritiesPath, 'utf-8');
+      if (content.includes('frozen')) {
+        result.status = 'frozen';
+        result.reason = 'Squad frozen — no work until trigger';
+        results.push(result);
+        continue;
+      }
+
+      // Check freshness from frontmatter
+      const updatedMatch = content.match(/updated:\s*"?(\d{4}-\d{2}-\d{2})"?/);
+      if (updatedMatch) {
+        const updated = new Date(updatedMatch[1]).getTime();
+        result.prioritiesAge = Math.round((now - updated) / (24 * 60 * 60 * 1000));
+      }
+    }
+
+    // Check goals
+    const goalsPath = join(memoryDir, squadName, 'goals.md');
+    if (existsSync(goalsPath)) {
+      const content = readFileSync(goalsPath, 'utf-8');
+      const activeMatches = content.match(/status: (in-progress|not-started)/g);
+      result.goalsActive = activeMatches?.length || 0;
+    }
+
+    // Determine status
+    if (result.prioritiesAge > 14) {
+      result.status = 'stale';
+      result.reason = `Priorities ${result.prioritiesAge}d old`;
+    } else if (result.goalsActive === 0) {
+      result.status = 'stale';
+      result.reason = 'No active goals';
+    } else {
+      result.reason = `${result.goalsActive} active goals, priorities ${result.prioritiesAge}d old`;
+    }
+
+    results.push(result);
+  }
+
+  return results;
+}
+
+/**
+ * Plan which squads to run based on scan results.
+ * Returns squads ordered by priority (most needy first).
+ */
+export function planOrgCycle(scan: OrgScanResult[]): OrgScanResult[] {
+  return scan
+    .filter(s => s.status !== 'frozen') // Skip frozen
+    .filter(s => s.lead !== null)       // Must have a lead
+    .sort((a, b) => {
+      // Stale squads first
+      if (a.status === 'stale' && b.status !== 'stale') return -1;
+      if (b.status === 'stale' && a.status !== 'stale') return 1;
+      // Then by goals count (more goals = more work to do)
+      return b.goalsActive - a.goalsActive;
+    });
+}
+
+/**
+ * Display org scan results.
+ */
+export function displayOrgScan(scan: OrgScanResult[]): void {
+  writeLine();
+  writeLine(`  ${bold}Org Scan${RESET} (${scan.length} squads)\n`);
+
+  const frozen = scan.filter(s => s.status === 'frozen');
+  const stale = scan.filter(s => s.status === 'stale');
+  const healthy = scan.filter(s => s.status === 'healthy');
+
+  if (healthy.length > 0) {
+    writeLine(`  ${colors.green}Healthy (${healthy.length})${RESET}`);
+    for (const s of healthy) {
+      writeLine(`    ${s.squad.padEnd(22)} ${colors.dim}${s.reason}${RESET}`);
+    }
+    writeLine();
+  }
+
+  if (stale.length > 0) {
+    writeLine(`  ${colors.yellow}Stale (${stale.length})${RESET}`);
+    for (const s of stale) {
+      writeLine(`    ${s.squad.padEnd(22)} ${colors.yellow}${s.reason}${RESET}`);
+    }
+    writeLine();
+  }
+
+  if (frozen.length > 0) {
+    writeLine(`  ${colors.dim}Frozen (${frozen.length}): ${frozen.map(s => s.squad).join(', ')}${RESET}`);
+    writeLine();
+  }
+}
+
+/**
+ * Display execution plan.
+ */
+export function displayPlan(plan: OrgScanResult[]): void {
+  writeLine(`  ${bold}Execution Plan${RESET} (${plan.length} squads)\n`);
+  for (let i = 0; i < plan.length; i++) {
+    const s = plan[i];
+    const statusIcon = s.status === 'stale' ? `${colors.yellow}stale${RESET}` : `${colors.green}ready${RESET}`;
+    writeLine(`  ${i + 1}. ${bold}${s.squad}${RESET} → ${s.lead} ${colors.dim}(${statusIcon}, ${s.goalsActive} goals)${RESET}`);
+  }
+  writeLine();
+}

--- a/src/lib/run-types.ts
+++ b/src/lib/run-types.ts
@@ -42,6 +42,7 @@ export interface RunOptions {
   once?: boolean; // Autopilot: run one cycle then exit
   phased?: boolean; // Autopilot: use dependency-based phase ordering
   eval?: boolean; // Post-run COO evaluation (default: true, --no-eval to skip)
+  org?: boolean; // Org cycle: scan → plan → execute all leads → report
 }
 
 /**


### PR DESCRIPTION
Run all squads as a coordinated system: scan → plan → execute → report. Skips frozen squads, prioritizes by goals. Supports --dry-run.