### PR TITLE
feat: squads goals dashboard + services tests

### DIFF
--- a/docs/tier2.md
+++ b/docs/tier2.md
@@ -1,0 +1,143 @@
+# Tier 2: Local Services
+
+squads-cli operates in one of two tiers:
+
+- **Tier 1** (default) — file-based only. All state lives in JSONL, markdown, and git. Zero external dependencies. Works everywhere.
+- **Tier 2** — local Docker services. Adds Postgres, Redis, a REST API, and a Bridge service for webhook-driven workflows and richer observability.
+
+Tier 2 is optional and fully local. Most users never need it.
+
+## What Tier 2 Adds
+
+| Service   | Port  | Purpose                                  |
+|-----------|-------|------------------------------------------|
+| API       | 8090  | REST API for agent executions and jobs   |
+| Bridge    | 8088  | GitHub webhook receiver                  |
+| Postgres  | 5432  | Persistent job queue (Procrastinate)     |
+| Redis     | 6379  | Pub/sub and caching                      |
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop) installed and running
+- The `agents-squads/engineering` repo cloned as a sibling to this repo:
+
+```
+~/agents-squads/
+  squads-cli/         ← this repo
+  engineering/
+    docker/
+      docker-compose.yml   ← Tier 2 services definition
+```
+
+squads-cli looks for the compose file at:
+
+1. `~/agents-squads/engineering/docker/docker-compose.yml`
+2. `~/agents-squads/engineering/docker/docker-compose.yaml`
+3. `../engineering/docker/docker-compose.yml` (relative to cwd)
+
+## Usage
+
+### Start services
+
+```bash
+squads services up
+```
+
+Expected output:
+
+```
+  Starting Tier 2 services...
+
+  docker compose up -d
+  [Docker output]
+
+  Services started. Waiting for health checks...
+  Tier 2 active. All services healthy.
+
+  API:      http://localhost:8090
+  Bridge:   http://localhost:8088
+  Postgres: localhost:5432
+  Redis:    localhost:6379
+```
+
+Optional profiles:
+
+```bash
+squads services up --webhooks    # also start ngrok tunnel for GitHub webhooks
+squads services up --telemetry   # also start OpenTelemetry collector
+```
+
+### Check status
+
+```bash
+squads services status
+```
+
+Expected output (when running):
+
+```
+  Services (Tier 2)
+
+  up  squads-postgres  0.0.0.0:5432->5432/tcp
+  up  squads-redis     0.0.0.0:6379->6379/tcp
+  up  squads-api       0.0.0.0:8090->8090/tcp
+  up  squads-bridge    0.0.0.0:8088->8088/tcp
+
+  Database
+    Procrastinate jobs: 12
+    Agent executions:  47
+```
+
+Expected output (when not running):
+
+```
+  Services (Tier 1)
+
+  No Docker containers running.
+```
+
+### Stop services
+
+```bash
+squads services down
+```
+
+Expected output:
+
+```
+  Stopping Tier 2 services...
+
+  [Docker output]
+
+  Services stopped. Falling back to Tier 1 (file-based).
+```
+
+If no compose file is found:
+
+```
+  No docker-compose.yml found. Nothing to stop.
+```
+
+## Fallback Behavior
+
+squads-cli always degrades gracefully to Tier 1 when Tier 2 services are unavailable:
+
+- Commands that read from Postgres fall back to JSONL files.
+- Commands that post to the API are silently skipped or use local state.
+- `squads services status` reports `Tier 1` and shows no containers.
+
+You can always run `squads services status` to confirm which tier is active.
+
+## Tier Detection
+
+At startup, squads-cli probes `http://localhost:8090/health` and `http://localhost:8088/health` with a 1.5 s timeout. If the API responds with HTTP 2xx, Tier 2 is active. The result is cached for the lifetime of the process.
+
+To check programmatically:
+
+```typescript
+import { detectTier } from 'squads-cli/lib/tier-detect';
+
+const info = await detectTier();
+console.log(info.tier);          // 1 or 2
+console.log(info.services.api);  // true | false
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ import { registerReleaseCommands } from './commands/release-check.js';
 import { registerObservabilityCommands } from './commands/observability.js';
 import { registerTierCommand } from './commands/tier.js';
 import { registerServicesCommands } from './commands/services.js';
+import { registerGoalsCommand } from './commands/goals.js';
 
 // All other command handlers are lazy-loaded via dynamic import() inside
 // action handlers. Only the invoked command's dependencies are loaded,
@@ -1059,6 +1060,7 @@ registerReleaseCommands(program);
 registerObservabilityCommands(program);
 registerTierCommand(program);
 registerServicesCommands(program);
+registerGoalsCommand(program);
 
 // Providers command - show LLM CLI availability for multi-LLM support
 program

--- a/src/commands/goals.ts
+++ b/src/commands/goals.ts
@@ -1,0 +1,141 @@
+/**
+ * squads goals — dashboard view of all squad goals.
+ */
+
+import { Command } from 'commander';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { findSquadsDir } from '../lib/squad-parser.js';
+import { findMemoryDir } from '../lib/memory.js';
+import { colors, bold, RESET, writeLine } from '../lib/terminal.js';
+
+interface GoalInfo {
+  name: string;
+  status: string;
+  section: 'active' | 'achieved' | 'abandoned' | 'proposed';
+}
+
+function parseGoals(filePath: string): GoalInfo[] {
+  if (!existsSync(filePath)) return [];
+  const content = readFileSync(filePath, 'utf-8');
+  const goals: GoalInfo[] = [];
+
+  let currentSection: GoalInfo['section'] = 'active';
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('## Active')) currentSection = 'active';
+    else if (line.startsWith('## Achieved')) currentSection = 'achieved';
+    else if (line.startsWith('## Abandoned')) currentSection = 'abandoned';
+    else if (line.startsWith('## Proposed')) currentSection = 'proposed';
+
+    const match = line.match(/\*\*([^*]+)\*\*.*status:\s*(\S+)/);
+    if (match) {
+      goals.push({ name: match[1].trim(), status: match[2].trim(), section: currentSection });
+    }
+
+    // Achieved goals don't have status field — detect by section
+    if (currentSection === 'achieved' && line.match(/\*\*([^*]+)\*\*.*achieved:/)) {
+      const nameMatch = line.match(/\*\*([^*]+)\*\*/);
+      if (nameMatch) {
+        goals.push({ name: nameMatch[1].trim(), status: 'achieved', section: 'achieved' });
+      }
+    }
+  }
+
+  return goals;
+}
+
+export function registerGoalsCommand(program: Command): void {
+  program
+    .command('goals')
+    .description('Dashboard of all squad goals — status at a glance')
+    .option('-s, --squad <squad>', 'Show goals for a specific squad')
+    .option('--json', 'Output as JSON')
+    .action((opts) => {
+      const squadsDir = findSquadsDir();
+      const memoryDir = findMemoryDir();
+      if (!squadsDir || !memoryDir) {
+        writeLine(`\n  ${colors.dim}No squads found. Run squads init.${RESET}\n`);
+        return;
+      }
+
+      const squadDirs = readdirSync(squadsDir).filter(d => {
+        return existsSync(join(squadsDir, d, 'SQUAD.md'));
+      }).sort();
+
+      const allData: Record<string, { goals: GoalInfo[]; active: number; achieved: number; blocked: number }> = {};
+
+      for (const squad of squadDirs) {
+        if (opts.squad && squad !== opts.squad) continue;
+        const goalsPath = join(memoryDir, squad, 'goals.md');
+        const goals = parseGoals(goalsPath);
+        const active = goals.filter(g => g.section === 'active').length;
+        const achieved = goals.filter(g => g.section === 'achieved').length;
+        const blocked = goals.filter(g => g.status === 'blocked' || g.status === 'AT-RISK').length;
+        allData[squad] = { goals, active, achieved, blocked };
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(allData, null, 2));
+        return;
+      }
+
+      // Summary view
+      const totalActive = Object.values(allData).reduce((s, d) => s + d.active, 0);
+      const totalAchieved = Object.values(allData).reduce((s, d) => s + d.achieved, 0);
+      const totalBlocked = Object.values(allData).reduce((s, d) => s + d.blocked, 0);
+
+      writeLine();
+      writeLine(`  ${bold}Goals Dashboard${RESET}  ${totalActive} active | ${colors.green}${totalAchieved} achieved${RESET} | ${totalBlocked > 0 ? colors.red : colors.dim}${totalBlocked} blocked${RESET}`);
+      writeLine();
+      writeLine(`  ${'Squad'} ${''.padEnd(10)} ${'Active'.padStart(6)} ${'Done'.padStart(6)} ${'Block'.padStart(6)}  Top Goal`);
+      writeLine(`  ${'-'.repeat(78)}`);
+
+      for (const [squad, data] of Object.entries(allData)) {
+        const frozen = data.active === 0 && data.achieved === 0;
+        if (frozen) continue; // Skip frozen squads in summary
+
+        const activeGoals = data.goals.filter(g => g.section === 'active');
+        const topGoal = activeGoals[0];
+        const topStr = topGoal
+          ? `${topGoal.name.slice(0, 30).padEnd(30)} ${statusIcon(topGoal.status)}`
+          : `${colors.dim}(no active goals)${RESET}`;
+
+        const blockedStr = data.blocked > 0 ? `${colors.red}${data.blocked}${RESET}` : `${colors.dim}0${RESET}`;
+        const achievedStr = data.achieved > 0 ? `${colors.green}${data.achieved}${RESET}` : `${colors.dim}0${RESET}`;
+
+        writeLine(`  ${squad.padEnd(15)} ${String(data.active).padStart(6)} ${String(data.achieved).padStart(6)} ${String(data.blocked).padStart(6)}  ${topStr}`);
+      }
+
+      // Detail view for specific squad
+      if (opts.squad && allData[opts.squad]) {
+        const data = allData[opts.squad];
+        writeLine();
+        writeLine(`  ${bold}${opts.squad} — Detail${RESET}`);
+
+        for (const section of ['active', 'achieved', 'abandoned', 'proposed'] as const) {
+          const sectionGoals = data.goals.filter(g => g.section === section);
+          if (sectionGoals.length === 0) continue;
+          writeLine(`\n  ${colors.cyan}${section.toUpperCase()}${RESET}`);
+          for (const g of sectionGoals) {
+            writeLine(`    ${statusIcon(g.status)}  ${g.name}`);
+          }
+        }
+      }
+
+      writeLine();
+    });
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'achieved':
+    case 'complete': return `${colors.green}done${RESET}`;
+    case 'in-progress':
+    case 'improving': return `${colors.cyan}prog${RESET}`;
+    case 'not-started': return `${colors.dim}todo${RESET}`;
+    case 'blocked':
+    case 'AT-RISK': return `${colors.red}block${RESET}`;
+    default: return `${colors.dim}${status.slice(0, 5)}${RESET}`;
+  }
+}

--- a/test/commands/services.test.ts
+++ b/test/commands/services.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+// All mocks must be hoisted before any imports from the modules under test.
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+  };
+});
+
+vi.mock('../../src/lib/tier-detect.js', () => ({
+  detectTier: vi.fn(),
+}));
+
+vi.mock('../../src/lib/terminal.js', () => ({
+  writeLine: vi.fn(),
+  colors: {
+    dim: '',
+    red: '',
+    green: '',
+    yellow: '',
+    cyan: '',
+    white: '',
+    purple: '',
+  },
+  bold: '',
+  RESET: '',
+  gradient: vi.fn((s: string) => s),
+  padEnd: vi.fn((s: string, n: number) => s.padEnd(n)),
+  icons: {
+    success: '✓',
+    error: '✗',
+    warning: '!',
+    progress: '›',
+    empty: '○',
+  },
+}));
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { detectTier } from '../../src/lib/tier-detect.js';
+import { writeLine } from '../../src/lib/terminal.js';
+import { registerServicesCommands } from '../../src/commands/services.js';
+
+const mockExecSync = vi.mocked(execSync);
+const mockExistsSync = vi.mocked(existsSync);
+const mockDetectTier = vi.mocked(detectTier);
+const mockWriteLine = vi.mocked(writeLine);
+
+const tier1Info = {
+  tier: 1 as const,
+  services: { api: false, bridge: false, postgres: false, redis: false },
+  urls: { api: null, bridge: null },
+};
+
+const tier2Info = {
+  tier: 2 as const,
+  services: { api: true, bridge: true, postgres: true, redis: true },
+  urls: { api: 'http://localhost:8090', bridge: 'http://localhost:8088' },
+};
+
+function buildProgram() {
+  const program = new Command();
+  program.exitOverride();
+  registerServicesCommands(program);
+  return program;
+}
+
+describe('services up', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: Docker unavailable, no compose file
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+    mockExistsSync.mockReturnValue(false);
+    mockDetectTier.mockResolvedValue(tier1Info);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows error and exits gracefully when Docker is unavailable', async () => {
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'up']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/Docker not found/i);
+    // Should NOT throw — graceful exit
+  });
+
+  it('shows Docker Desktop install hint when Docker is unavailable', async () => {
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'up']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/docker\.com/i);
+  });
+
+  it('shows error when Docker Compose is unavailable (Docker present)', async () => {
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes('docker --version')) return 'Docker version 24.0.0';
+      throw new Error('command not found');
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'up']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/Docker Compose not found/i);
+  });
+
+  it('shows error with expected path when compose file is missing', async () => {
+    // Docker and Compose available, but no compose file on disk
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes('docker --version') || c.includes('docker compose version')) {
+        return 'ok';
+      }
+      throw new Error('command not found');
+    });
+    mockExistsSync.mockReturnValue(false);
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'up']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/docker-compose\.yml not found/i);
+    expect(combined).toMatch(/engineering\/docker/i);
+  });
+
+  it('registers the services up subcommand', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    expect(serviceCmd).toBeDefined();
+    const upCmd = serviceCmd?.commands.find(c => c.name() === 'up');
+    expect(upCmd).toBeDefined();
+    expect(upCmd?.description()).toMatch(/start/i);
+  });
+});
+
+describe('services down', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+    mockExistsSync.mockReturnValue(false);
+    mockDetectTier.mockResolvedValue(tier1Info);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows "nothing to stop" message when compose file is missing', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'down']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/nothing to stop/i);
+  });
+
+  it('resolves gracefully when compose file is absent', async () => {
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(['node', 'squads', 'services', 'down'])
+    ).resolves.toBeDefined();
+  });
+
+  it('registers the services down subcommand', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    const downCmd = serviceCmd?.commands.find(c => c.name() === 'down');
+    expect(downCmd).toBeDefined();
+    expect(downCmd?.description()).toMatch(/stop/i);
+  });
+});
+
+describe('services status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // docker ps returns null (no running containers)
+    mockExecSync.mockReturnValue(null as unknown as ReturnType<typeof execSync>);
+    mockDetectTier.mockResolvedValue(tier1Info);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows "no containers running" when docker ps returns nothing', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'status']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/no docker containers running/i);
+  });
+
+  it('shows tier info from detectTier even when no containers', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found');
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'status']);
+
+    expect(mockDetectTier).toHaveBeenCalledOnce();
+  });
+
+  it('displays container names when docker ps returns results', async () => {
+    mockDetectTier.mockResolvedValue(tier2Info);
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes('docker ps')) {
+        return 'squads-postgres\tUp 5 minutes (healthy)\t0.0.0.0:5432->5432/tcp';
+      }
+      // psql queries return null (throw)
+      throw new Error('not found');
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'status']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toContain('squads-postgres');
+  });
+
+  it('shows Tier 2 when api is healthy', async () => {
+    mockDetectTier.mockResolvedValue(tier2Info);
+    mockExecSync.mockImplementation((cmd: unknown) => {
+      const c = String(cmd);
+      if (c.includes('docker ps')) {
+        return 'squads-api\tUp 2 minutes (healthy)\t0.0.0.0:8090->8090/tcp';
+      }
+      throw new Error('not found');
+    });
+
+    const program = buildProgram();
+    await program.parseAsync(['node', 'squads', 'services', 'status']);
+
+    const calls = mockWriteLine.mock.calls.map(c => String(c[0] ?? ''));
+    const combined = calls.join('\n');
+    expect(combined).toMatch(/tier 2/i);
+  });
+
+  it('registers the services status subcommand', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    const statusCmd = serviceCmd?.commands.find(c => c.name() === 'status');
+    expect(statusCmd).toBeDefined();
+    expect(statusCmd?.description()).toMatch(/health|show|running/i);
+  });
+});
+
+describe('services command structure', () => {
+  it('registers services command with correct description', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    expect(serviceCmd).toBeDefined();
+    expect(serviceCmd?.description()).toMatch(/tier 2|docker|services/i);
+  });
+
+  it('registers all three subcommands: up, down, status', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    const names = serviceCmd?.commands.map(c => c.name()) ?? [];
+    expect(names).toContain('up');
+    expect(names).toContain('down');
+    expect(names).toContain('status');
+  });
+
+  it('services up supports --webhooks flag', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    const upCmd = serviceCmd?.commands.find(c => c.name() === 'up');
+    const options = upCmd?.options.map(o => o.long) ?? [];
+    expect(options).toContain('--webhooks');
+  });
+
+  it('services up supports --telemetry flag', () => {
+    const program = buildProgram();
+    const serviceCmd = program.commands.find(c => c.name() === 'services');
+    const upCmd = serviceCmd?.commands.find(c => c.name() === 'up');
+    const options = upCmd?.options.map(o => o.long) ?? [];
+    expect(options).toContain('--telemetry');
+  });
+});


### PR DESCRIPTION
## Summary
- `squads goals` — dashboard showing active/achieved/blocked goals per squad with top goal status
- `squads goals --squad <name>` — detail view for a specific squad
- `squads goals --json` — JSON output
- Services command tests and Tier 2 documentation

Closes #667

## Test plan
- [ ] `squads goals` shows summary table
- [ ] `squads goals --squad intelligence` shows detail view
- [ ] `squads goals --json` outputs valid JSON
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)