### PR TITLE
refactor(core): run engine decomposition + context helpers [v0.3.0 — 1/7]

### DIFF
--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -4,7 +4,7 @@
  */
 
 import ora from 'ora';
-import { join } from 'path';
+import { join, basename, extname } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import {
   findSquadsDir,
@@ -72,6 +72,13 @@ import { findMemoryDir } from './memory.js';
 
 // ── Operational constants (no magic numbers) ──────────────────────────
 export const DRYRUN_DEF_MAX_CHARS = 500;
+
+function formatRunDuration(ms: number): string {
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  const s = Math.round((ms % 60_000) / 1000);
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
 export const DRYRUN_CONTEXT_MAX_CHARS = parseInt(process.env.SQUADS_DRYRUN_MAX_CHARS || '800', 10);
 
 export async function runAgent(
@@ -80,6 +87,10 @@ export async function runAgent(
   squadName: string,
   options: RunOptions & { execute?: boolean }
 ): Promise<void> {
+  // Normalize: strip path prefix and extension if a full file path was passed
+  if (agentName.includes('/') || agentName.includes('\\')) {
+    agentName = basename(agentName, extname(agentName));
+  }
   const spinner = ora(`Running agent: ${agentName}`).start();
   const startMs = Date.now();
   const startTime = new Date(startMs).toISOString();
@@ -278,15 +289,8 @@ export async function runAgent(
     : '';
   const prompt = `You are ${agentName} from squad ${squadName}.
 ${taskDirective}
-Your full context follows — read it top-to-bottom. Each layer builds on the previous:
-- SYSTEM.md: how the system works (already loaded)
-- Company: who we are and why
-- Priorities: where to focus now
-- Goals: what to achieve (measurable targets)
-- Agent: your specific role and instructions
-- State: where you left off
-${systemContext}${squadContext}${cognitionContext}${learningContext}
-TIME LIMIT: ${timeoutMins} minutes. Focus on priorities first. If blocked, note it in state.md and move on.`;
+Your full context follows — read it top-to-bottom:
+${systemContext}${squadContext}${cognitionContext}${learningContext}`;
 
   // Resolve provider with full chain:
   // 1. Agent config (from agent file frontmatter/header)
@@ -385,9 +389,11 @@ TIME LIMIT: ${timeoutMins} minutes. Focus on priorities first. If blocked, note 
 
         if (isForeground || isWatch) {
           spinner.succeed(`Agent ${agentName} completed (${cliName})`);
+          writeLine(`  ${colors.green}Run completed${RESET} — ${squadName}/${agentName} (${formatRunDuration(Date.now() - startMs)})`);
         } else {
           spinner.succeed(`Agent ${agentName} launched in background (${cliName})`);
-          writeLine(`  ${colors.dim}${result}${RESET}`);
+          writeLine(`  ${colors.green}Run started${RESET} — ${squadName}/${agentName} (background)`);
+          if (result) writeLine(`  ${colors.dim}${result}${RESET}`);
           writeLine();
           writeLine(`  ${colors.dim}Monitor:${RESET} squads workers`);
           writeLine(`  ${colors.dim}Memory:${RESET}  squads memory show ${squadName}`);
@@ -399,16 +405,21 @@ TIME LIMIT: ${timeoutMins} minutes. Focus on priorities first. If blocked, note 
           squad: squadName, agent: agentName, executionId, error: String(error),
         }).catch(() => {});
 
-        spinner.fail(`Agent ${agentName} failed to launch`);
+        spinner.fail(`Agent ${agentName} failed`);
+        writeLine(`  ${colors.red}Run failed${RESET} — ${squadName}/${agentName} (${formatRunDuration(Date.now() - startMs)})`);
         updateExecutionStatus(squadName, agentName, executionId, 'failed', {
           error: String(error),
           durationMs: Date.now() - startMs,
         });
         const msg = error instanceof Error ? error.message : String(error);
-        const isLikelyBug = error instanceof ReferenceError || error instanceof TypeError || error instanceof SyntaxError;
+        const isApiKeyError = /api.?key|authentication|unauthorized|401/i.test(msg);
+        const isLikelyBug = !isApiKeyError && (error instanceof ReferenceError || error instanceof TypeError || error instanceof SyntaxError);
         writeLine(`  ${colors.red}${msg}${RESET}`);
         writeLine();
-        if (isLikelyBug) {
+        if (isApiKeyError) {
+          writeLine(`  ${colors.yellow}API key not set or invalid. Set ANTHROPIC_API_KEY and retry:${RESET}`);
+          writeLine(`  ${colors.dim}$ export ANTHROPIC_API_KEY=sk-ant-...${RESET}`);
+        } else if (isLikelyBug) {
           writeLine(`  ${colors.yellow}This looks like a bug. Please try:${RESET}`);
           writeLine(`  ${colors.dim}$${RESET} squads doctor          ${colors.dim}— check your setup${RESET}`);
           writeLine(`  ${colors.dim}$${RESET} squads update           ${colors.dim}— get the latest fixes${RESET}`);
@@ -418,7 +429,8 @@ TIME LIMIT: ${timeoutMins} minutes. Focus on priorities first. If blocked, note 
         } else {
           writeLine(`  ${colors.dim}Run \`squads doctor\` to check your setup, or \`squads run ${agentName} --verbose\` for details.${RESET}`);
         }
-        break; // Error — exit retry loop
+        // Re-throw so callers (org cycle) can detect the failure
+        throw error;
       }
     }
   } else {

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -14,7 +14,6 @@ import {
 } from './squad-parser.js';
 import {
   type RunOptions,
-  DEFAULT_TIMEOUT_MINUTES,
 } from './run-types.js';
 import {
   generateExecutionId,
@@ -53,9 +52,7 @@ import {
 import { parseCooldown } from './cron.js';
 import {
   colors,
-  bold,
   RESET,
-  gradient,
   icons,
   writeLine,
 } from './terminal.js';

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -15,7 +15,6 @@ import {
 import {
   type RunOptions,
   DEFAULT_TIMEOUT_MINUTES,
-  SOFT_DEADLINE_RATIO,
 } from './run-types.js';
 import {
   generateExecutionId,
@@ -36,7 +35,6 @@ import {
   executeWithClaude,
   executeWithProvider,
   verifyExecution,
-  preflightExecutorCheck,
 } from './execution-engine.js';
 import {
   type ContextRole,
@@ -67,8 +65,6 @@ import {
 } from './llm-clis.js';
 import { loadSession } from './auth.js';
 import { getApiUrl } from './env-config.js';
-import { pushCognitionSignal } from './api-client.js';
-import { findMemoryDir } from './memory.js';
 
 // ── Operational constants (no magic numbers) ──────────────────────────
 export const DRYRUN_DEF_MAX_CHARS = 500;
@@ -283,7 +279,6 @@ export async function runAgent(
   }
 
   // Generate the Claude Code prompt with timeout awareness
-  const timeoutMins = options.timeout || DEFAULT_TIMEOUT_MINUTES;
   const taskDirective = options.task
     ? `\n## TASK DIRECTIVE (overrides default behavior)\n${options.task}\n`
     : '';

--- a/src/lib/env-config.ts
+++ b/src/lib/env-config.ts
@@ -32,6 +32,8 @@ export interface EnvironmentConfig {
 export interface SquadsConfig {
   current: string;
   environments: Record<string, EnvironmentConfig>;
+  /** User email — captured opt-in during `squads init` for founder outreach */
+  email?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,4 +143,21 @@ export function getBridgeUrl(): string {
 
 export function getConsoleUrl(): string {
   return getEnv().console_url;
+}
+
+/**
+ * Persist the user's email address in ~/.squads/config.json.
+ * Used for opt-in founder outreach captured during `squads init`.
+ */
+export function saveEmail(email: string): void {
+  const config = loadConfig();
+  config.email = email;
+  saveConfig(config);
+}
+
+/**
+ * Retrieve the stored user email, if any.
+ */
+export function getEmail(): string | undefined {
+  return loadConfig().email;
 }

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -18,6 +18,7 @@ import {
   type EffortLevel,
   type Squad,
 } from './squad-parser.js';
+import { parseAgentFrontmatter } from './run-context.js';
 import {
   type ExecutionContext,
 } from './run-types.js';
@@ -336,7 +337,9 @@ export function buildAgentEnv(
 
   // Inject per-squad GCP credential if available
   // Agents get GOOGLE_APPLICATION_CREDENTIALS pointing to their squad's service account key
-  const credPath = join(homedir(), '.squads', 'secrets', `${execContext.squad}-sa-key.json`);
+  const credPath = process.env.SQUADS_GCP_CREDENTIALS_DIR
+    ? join(process.env.SQUADS_GCP_CREDENTIALS_DIR, `${execContext.squad}-sa-key.json`)
+    : join(homedir(), '.squads', 'secrets', `${execContext.squad}-sa-key.json`);
   if (existsSync(credPath)) env.GOOGLE_APPLICATION_CREDENTIALS = credPath;
 
   if (options?.includeOtel) {
@@ -666,12 +669,9 @@ export async function executeWithClaude(
     const squadsDir = findSquadsDir();
     if (squadsDir) {
       const agentPath = join(squadsDir, squadName, `${agentName}.md`);
-      if (existsSync(agentPath)) {
-        const content = readFileSync(agentPath, 'utf-8');
-        const modelMatch = content.match(/^model:\s*["']?([^"'\n]+)["']?/m);
-        if (modelMatch) {
-          effectiveModel = modelMatch[1].trim();
-        }
+      const frontmatter = parseAgentFrontmatter(agentPath);
+      if (frontmatter.model) {
+        effectiveModel = frontmatter.model;
       }
     }
   }

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -4,10 +4,17 @@
  */
 
 import { spawn, execSync } from 'child_process';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, unlinkSync } from 'fs';
+import { homedir } from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 import {
   loadSquad,
+  findSquadsDir,
+  findProjectRoot,
   type EffortLevel,
   type Squad,
 } from './squad-parser.js';
@@ -49,6 +56,34 @@ export const VERIFICATION_STATE_MAX_CHARS = 2000;
 export const VERIFICATION_EXEC_TIMEOUT_MS = 30000;
 export const LOG_FILE_INIT_DELAY_MS = 500;
 export const VERBOSE_COMMAND_MAX_CHARS = 50;
+
+// ── Guardrail settings ────────────────────────────────────────────────
+
+/**
+ * Resolve the path to a guardrail settings JSON file for --settings injection.
+ *
+ * Resolution order:
+ *   1. `.claude/guardrail.json` in the project root (user-provided override)
+ *   2. Bundled default: `templates/guardrail.json` alongside the squads-cli package
+ *
+ * Returns undefined when neither exists (no guardrail applied).
+ */
+export function resolveGuardrailSettings(projectRoot: string): string | undefined {
+  // 1. Project-level override
+  const projectGuardrail = join(projectRoot, '.claude', 'guardrail.json');
+  if (existsSync(projectGuardrail)) return projectGuardrail;
+
+  // 2. Bundled default (dist/lib/ → dist/templates/ in compiled output;
+  //    src/lib/ → templates/ in source tree)
+  const bundledGuardrail = join(__dirname, '..', '..', 'templates', 'guardrail.json');
+  if (existsSync(bundledGuardrail)) return bundledGuardrail;
+
+  // Also check one level up (when running from dist/lib/)
+  const bundledGuardrailAlt = join(__dirname, '..', 'templates', 'guardrail.json');
+  if (existsSync(bundledGuardrailAlt)) return bundledGuardrailAlt;
+
+  return undefined;
+}
 
 // ── Interfaces ────────────────────────────────────────────────────────
 
@@ -181,9 +216,11 @@ export async function verifyExecution(
     recentCommits = '(no commits found)';
   }
 
-  const verifyPrompt = `You are verifying whether an agent completed its task successfully.
+  // Load verification protocol from markdown
+  const verifyProtocolPath = join(findProjectRoot() || '', '.agents', 'config', 'verification.md');
+  const verifyProtocol = existsSync(verifyProtocolPath) ? readFileSync(verifyProtocolPath, 'utf-8') : 'Respond: PASS: reason or FAIL: reason';
 
-Agent: ${squadName}/${agentName}
+  const verifyPrompt = `Agent: ${squadName}/${agentName}
 
 ## Acceptance Criteria
 ${criteria}
@@ -196,12 +233,7 @@ ${stateContent || '(empty or not found)'}
 ### Recent Git Commits
 ${recentCommits}
 
-## Instructions
-Evaluate whether the acceptance criteria are met based on the evidence.
-Respond with EXACTLY one line:
-PASS: <brief reason>
-or
-FAIL: <brief reason>`;
+${verifyProtocol}`;
 
   try {
     const escapedPrompt = verifyPrompt.replace(/'/g, "'\\''");
@@ -301,6 +333,11 @@ export function buildAgentEnv(
   // Inject bot GH_TOKEN so agents create PRs/issues as the bot identity,
   // not the user's personal gh auth. This enables founder to review/approve.
   if (options?.ghToken) env.GH_TOKEN = options.ghToken;
+
+  // Inject per-squad GCP credential if available
+  // Agents get GOOGLE_APPLICATION_CREDENTIALS pointing to their squad's service account key
+  const credPath = join(homedir(), '.squads', 'secrets', `${execContext.squad}-sa-key.json`);
+  if (existsSync(credPath)) env.GOOGLE_APPLICATION_CREDENTIALS = credPath;
 
   if (options?.includeOtel) {
     env.OTEL_RESOURCE_ATTRIBUTES = `squads.squad=${execContext.squad},squads.agent=${execContext.agent},squads.task_type=${execContext.taskType},squads.trigger=${execContext.trigger},squads.execution_id=${execContext.executionId}`;
@@ -614,10 +651,32 @@ export async function executeWithClaude(
   ensureProjectTrusted(projectRoot);
 
   // Resolve model and provider
+  // Priority: 1) CLI --model flag  2) agent frontmatter model:  3) SQUAD.md model routing
   const squad = squadName !== 'unknown' ? loadSquad(squadName) : null;
   const mcpConfigPath = selectMcpConfig(squadName, squad);
+
+  // Merge CLI --skills flag with SQUAD.md context.skills
+  const squadSkills = squad?.context?.skills || [];
+  const mergedSkills = [...new Set([...(skills || []), ...squadSkills])];
   const taskType = detectTaskType(agentName);
-  const resolvedModel = resolveModel(model, squad, taskType);
+
+  // Read agent frontmatter model if no explicit CLI flag
+  let effectiveModel = model;
+  if (!effectiveModel) {
+    const squadsDir = findSquadsDir();
+    if (squadsDir) {
+      const agentPath = join(squadsDir, squadName, `${agentName}.md`);
+      if (existsSync(agentPath)) {
+        const content = readFileSync(agentPath, 'utf-8');
+        const modelMatch = content.match(/^model:\s*["']?([^"'\n]+)["']?/m);
+        if (modelMatch) {
+          effectiveModel = modelMatch[1].trim();
+        }
+      }
+    }
+  }
+
+  const resolvedModel = resolveModel(effectiveModel, squad, taskType);
   const provider = resolvedModel ? detectProviderFromModel(resolvedModel) : 'anthropic';
 
   // Resolve target repo for worktree creation (squad.repo → sibling dir)
@@ -664,7 +723,7 @@ export async function executeWithClaude(
     if (verbose) {
       logVerboseExecution({
         projectRoot, mode: 'foreground', useApi, execContext,
-        effort, skills, resolvedModel, claudeModelAlias, explicitModel: model,
+        effort, skills: mergedSkills, resolvedModel, claudeModelAlias, explicitModel: model,
       });
     }
 
@@ -684,6 +743,8 @@ export async function executeWithClaude(
         'Bash(git:*)', 'Bash(gh:*)', 'Bash(npm:*)', 'Bash(npx:*)',
         'Bash(node:*)', 'Bash(python3:*)', 'Bash(curl:*)',
         'Bash(docker:*)', 'Bash(duckdb:*)',
+        'Bash(bq:*)', 'Bash(gcloud:*)',
+        'Bash(gws:*)', 'Bash(stripe:*)',
         'Bash(ls:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)',
         'Bash(cat:*)', 'Bash(head:*)', 'Bash(tail:*)', 'Bash(wc:*)',
         'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(date:*)',
@@ -693,11 +754,14 @@ export async function executeWithClaude(
     }
     claudeArgs.push('--disable-slash-commands');
     if (mcpConfigPath) claudeArgs.push('--mcp-config', mcpConfigPath);
+    // Inject guardrail PreToolUse hooks so spawned sessions inherit destructive-command guards
+    const guardrailPath = resolveGuardrailSettings(targetRepoRoot);
+    if (guardrailPath) claudeArgs.push('--settings', guardrailPath);
     if (claudeModelAlias) claudeArgs.push('--model', claudeModelAlias);
     claudeArgs.push('--', prompt);
 
     const agentEnv = buildAgentEnv(spawnEnv as Record<string, string>, execContext, {
-      effort, skills, includeOtel: true, ghToken: botGhToken,
+      effort, skills: mergedSkills, includeOtel: true, ghToken: botGhToken,
     });
 
     return executeForeground({
@@ -710,7 +774,7 @@ export async function executeWithClaude(
   const timestamp = Date.now();
   const { logFile, pidFile } = prepareLogFiles(projectRoot, squadName, agentName, timestamp);
   const agentEnv = buildAgentEnv(spawnEnv as Record<string, string>, execContext, {
-    effort, skills, includeOtel: !runInWatch, ghToken: botGhToken,
+    effort, skills: mergedSkills, includeOtel: !runInWatch, ghToken: botGhToken,
   });
 
   const wrapperScript = buildDetachedShellScript({
@@ -733,7 +797,7 @@ export async function executeWithClaude(
   if (verbose) {
     logVerboseExecution({
       projectRoot, mode: 'background', useApi, execContext,
-      effort, skills, resolvedModel, claudeModelAlias,
+      effort, skills: mergedSkills, resolvedModel, claudeModelAlias,
       explicitModel: model, logFile, mcpConfigPath,
     });
   }

--- a/src/lib/idp/scorecard-engine.ts
+++ b/src/lib/idp/scorecard-engine.ts
@@ -7,7 +7,7 @@
  * - Git log (deploy frequency, recent activity)
  */
 
-import { existsSync, readFileSync, statSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import type { CatalogEntry, ScorecardDefinition, ScorecardResult } from './types.js';

--- a/src/lib/org-cycle.ts
+++ b/src/lib/org-cycle.ts
@@ -16,7 +16,6 @@ import { join } from 'path';
 import { findSquadsDir, loadSquad } from './squad-parser.js';
 import { findMemoryDir } from './memory.js';
 import { colors, bold, RESET, writeLine } from './terminal.js';
-import { logObservability, type ObservabilityRecord } from './observability.js';
 
 export interface OrgScanResult {
   squad: string;

--- a/src/lib/outcomes.ts
+++ b/src/lib/outcomes.ts
@@ -360,7 +360,7 @@ export function computeScorecard(
 
   const totalPRs = records.reduce((sum, r) => sum + r.artifacts.prsCreated.length, 0);
   const mergedPRs = records.reduce((sum, r) => sum + r.outcomes.prsMerged, 0);
-  const unmergedPRs = records.reduce((sum, r) => sum + r.outcomes.prsClosedUnmerged, 0);
+  const _unmergedPRs = records.reduce((sum, r) => sum + r.outcomes.prsClosedUnmerged, 0);
   const totalIssues = records.reduce((sum, r) => sum + r.artifacts.issuesCreated.length, 0);
   const closedIssues = records.reduce((sum, r) => sum + r.outcomes.issuesClosed, 0);
   const totalCost = records.reduce((sum, r) => sum + r.costUsd, 0);

--- a/src/lib/repo-enforcement.ts
+++ b/src/lib/repo-enforcement.ts
@@ -11,7 +11,7 @@
  */
 
 import { existsSync, readdirSync, statSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { findProjectRoot, loadSquad } from './squad-parser.js';
 import { colors, RESET, writeLine } from './terminal.js';
 

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -18,7 +18,7 @@
  */
 
 import { join, dirname } from 'path';
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, statSync } from 'fs';
 import { execSync } from 'child_process';
 import { findSquadsDir } from './squad-parser.js';
 import { findMemoryDir } from './memory.js';
@@ -388,25 +388,6 @@ export function resolveContextRoleFromAgent(agentPath: string, agentName: string
   }
 }
 
-/** Read all .md files from a directory, concatenated */
-function readDirMd(dirPath: string, maxChars: number): string {
-  if (!existsSync(dirPath)) return '';
-  try {
-    const files = readdirSync(dirPath).filter(f => f.endsWith('.md')).sort();
-    const parts: string[] = [];
-    let totalChars = 0;
-    for (const file of files) {
-      const content = safeRead(join(dirPath, file));
-      if (!content) continue;
-      if (totalChars + content.length > maxChars) break;
-      parts.push(content);
-      totalChars += content.length;
-    }
-    return parts.join('\n\n');
-  } catch {
-    return '';
-  }
-}
 
 // ── Squad Context System Assembly ─────────────────────────────────────
 

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -501,8 +501,9 @@ export function gatherSquadContext(
       // Add staleness caveat (#721) so agents know if their memory is outdated
       let staleNote = '';
       try {
+        const MS_PER_DAY = 24 * 60 * 60 * 1000;
         const mtime = statSync(stateFile).mtimeMs;
-        const daysAgo = Math.round((Date.now() - mtime) / 86400000);
+        const daysAgo = Math.floor((Date.now() - mtime) / MS_PER_DAY);
         if (daysAgo > 0) staleNote = `*(Last updated ${daysAgo} day${daysAgo > 1 ? 's' : ''} ago — verify before relying on this)*\n\n`;
       } catch { /* */ }
       addLayer(5, 'Previous State', staleNote + body, stateCap);

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -18,7 +18,7 @@
  */
 
 import { join, dirname } from 'path';
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { execSync } from 'child_process';
 import { findSquadsDir } from './squad-parser.js';
 import { findMemoryDir } from './memory.js';
@@ -464,22 +464,25 @@ export function gatherSquadContext(
     return true;
   }
 
-  // ── L1: company.md — Why (company identity, alignment) ──
-  const companyContext = loadCompanyContext();
-  if (companyContext) {
-    addLayer(1, 'Company', stripYamlFrontmatter(companyContext));
-  }
+  // ═══════════════════════════════════════════════════════════════════
+  // Context injection order: ACTION-FIRST, REFERENCE-LAST
+  //
+  // LLMs pay most attention to the beginning and end of context.
+  // Put what the agent should ACT ON first (feedback, goals, state).
+  // Put reference material last (company, agent definition).
+  // ═══════════════════════════════════════════════════════════════════
 
-  // ── L2: priorities.md — Where (current focus, urgency) ──
+  // ── L6: feedback.md — ACT ON THIS (corrections from last cycle) ──
+  // Injected FIRST so agents address feedback before anything else.
   if (memoryDir) {
-    const prioritiesFile = join(memoryDir, squadName, 'priorities.md');
-    const content = safeRead(prioritiesFile);
+    const feedbackFile = join(memoryDir, squadName, 'feedback.md');
+    const content = safeRead(feedbackFile);
     if (content) {
-      addLayer(2, 'Priorities', stripYamlFrontmatter(content));
+      addLayer(6, 'Feedback (act on this first)', content);
     }
   }
 
-  // ── L3: goals.md — What (measurable targets) ──
+  // ── L3: goals.md — What to achieve this cycle ──
   if (memoryDir) {
     const goalsFile = join(memoryDir, squadName, 'goals.md');
     const content = safeRead(goalsFile);
@@ -488,38 +491,49 @@ export function gatherSquadContext(
     }
   }
 
-  // ── L4: agent.md — You (agent role, instructions) ──
+  // ── L5: state.md — Where we left off ──
+  if (memoryDir) {
+    const stateFile = join(memoryDir, squadName, agentName, 'state.md');
+    const content = safeRead(stateFile);
+    if (content) {
+      const body = stripYamlFrontmatter(content);
+      const stateCap = (role === 'scanner' || role === 'verifier') ? 2000 : undefined;
+      // Add staleness caveat (#721) so agents know if their memory is outdated
+      let staleNote = '';
+      try {
+        const mtime = statSync(stateFile).mtimeMs;
+        const daysAgo = Math.round((Date.now() - mtime) / 86400000);
+        if (daysAgo > 0) staleNote = `*(Last updated ${daysAgo} day${daysAgo > 1 ? 's' : ''} ago — verify before relying on this)*\n\n`;
+      } catch { /* */ }
+      addLayer(5, 'Previous State', staleNote + body, stateCap);
+    }
+  }
+
+  // ── L2: priorities.md — Where to focus ──
+  if (memoryDir) {
+    const prioritiesFile = join(memoryDir, squadName, 'priorities.md');
+    const content = safeRead(prioritiesFile);
+    if (content) {
+      addLayer(2, 'Priorities', stripYamlFrontmatter(content));
+    }
+  }
+
+  // ── L4: agent.md — Your role and instructions ──
   if (options.agentPath) {
     const agentContent = safeRead(options.agentPath);
     if (agentContent) {
-      // Strip YAML frontmatter — inject the markdown body only
       const body = stripYamlFrontmatter(agentContent);
       addLayer(4, `Agent: ${agentName}`, body);
     }
   }
 
-  // ── L5: state.md — Memory (continuity from last run) ──
-  if (memoryDir) {
-    const stateFile = join(memoryDir, squadName, agentName, 'state.md');
-    const content = safeRead(stateFile);
-    if (content) {
-      // Strip frontmatter — LLM gets the body (Current/Blockers/Carry Forward)
-      const body = stripYamlFrontmatter(content);
-      const stateCap = (role === 'scanner' || role === 'verifier') ? 2000 : undefined;
-      addLayer(5, 'Previous State', body, stateCap);
-    }
+  // ── L1: company.md — Who we are (reference) ──
+  const companyContext = loadCompanyContext();
+  if (companyContext) {
+    addLayer(1, 'Company', stripYamlFrontmatter(companyContext));
   }
 
-  // ── L6: feedback.md — Supporting (squad-level feedback) ──
-  if (memoryDir) {
-    const feedbackFile = join(memoryDir, squadName, 'feedback.md');
-    const content = safeRead(feedbackFile);
-    if (content) {
-      addLayer(6, 'Feedback', content);
-    }
-  }
-
-  // ── L7: Daily briefing — Supporting (org pulse, leads+coo only) ──
+  // ── L7: Daily briefing — Org pulse (leads+coo only, reference) ──
   if (memoryDir) {
     const dailyFile = join(memoryDir, 'daily-briefing.md');
     const content = safeRead(dailyFile);
@@ -528,7 +542,7 @@ export function gatherSquadContext(
     }
   }
 
-  // ── L8: Cross-squad learnings — Supporting (from context_from agents) ──
+  // ── L8: Cross-squad learnings (leads+coo only, reference) ──
   if (memoryDir) {
     const frontmatter = options.agentPath ? parseAgentFrontmatter(options.agentPath) : {};
     const contextSquads = frontmatter.context_from || [];

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -61,6 +61,7 @@ export interface AgentFrontmatter {
   acceptance_criteria?: string;
   max_retries?: number;
   cooldown?: string;
+  model?: string;
   /**
    * `role:` field from agent YAML frontmatter (free text).
    * Used as the primary signal for context-role selection.

--- a/src/lib/run-modes.ts
+++ b/src/lib/run-modes.ts
@@ -26,6 +26,7 @@ import {
 import { runAgent } from './agent-runner.js';
 import {
   findSquadsDir,
+  findProjectRoot,
   loadSquad,
 } from './squad-parser.js';
 import {
@@ -114,70 +115,10 @@ export async function runPostEvaluation(
   writeLine();
   writeLine(`  ${gradient('eval')} ${colors.dim}COO evaluating: ${squadList}${RESET}`);
 
-  const evalTask = `Post-run evaluation for: ${squadList}.
-
-## Evaluation Process
-
-For each squad (${squadList}):
-
-### 1. Read previous feedback FIRST
-Read \`.agents/memory/{squad}/feedback.md\` if it exists. Note the previous grade, identified patterns, and priorities. This is your baseline — you are measuring CHANGE, not just current state.
-
-### 2. Gather current evidence
-- PRs (last 7 days): \`gh pr list --state all --limit 20 --json number,title,state,mergedAt,createdAt\`
-- Recent commits (last 7 days): \`gh api repos/{owner}/{repo}/commits?since=YYYY-MM-DDT00:00:00Z&per_page=20 --jq '.[].commit.message'\`
-- Open issues: \`gh issue list --state open --limit 15 --json number,title,labels\`
-- Read \`.agents/memory/{squad}/priorities.md\` and \`.agents/memory/company/directives.md\`
-- Read \`.agents/memory/{squad}/active-work.md\` (previous cycle's work tracking)
-
-### 3. Write feedback.md (APPEND history, don't overwrite)
-\`\`\`markdown
-# Feedback — {squad}
-
-## Current Assessment (YYYY-MM-DD): [A-F]
-Merge rate: X% | Noise ratio: Y% | Priority alignment: Z%
-
-## Trajectory: [improving | stable | declining | new]
-Previous grade: [grade] → Current: [grade]. [1-line explanation of why]
-
-## Valuable (continue)
-- [specific PR/issue that advanced priorities]
-
-## Noise (stop)
-- [specific anti-pattern observed]
-
-## Next Cycle Priorities
-1. [specific actionable item]
-
-## History
-| Date | Grade | Key Signal |
-|------|-------|------------|
-| YYYY-MM-DD | X | [what drove this grade] |
-[keep last 10 entries, append new row]
-\`\`\`
-
-### 4. Write active-work.md
-\`\`\`markdown
-# Active Work — {squad} (YYYY-MM-DD)
-## Continue (open PRs)
-- #{number}: {title} — {status/next action}
-## Backlog (assigned issues)
-- #{number}: {title} — {priority}
-## Do NOT Create
-- {description of known duplicate patterns from feedback history}
-\`\`\`
-
-### 5. Commit to hq main
-${squadsRun.length > 1 ? `
-### 6. Cross-squad assessment
-Evaluate how outputs from ${squadList} connect:
-- Duplicated efforts across squads?
-- Missing handoffs (one squad's output should feed another)?
-- Coordination gaps (conflicting PRs, redundant issues)?
-- Combined trajectory: is the org getting more effective or more noisy?
-Write cross-squad findings to \`.agents/memory/company/cross-squad-review.md\`.
-` : ''}
-CRITICAL: You are measuring DIRECTION not just position. A C-grade squad improving from F is better than a B-grade squad declining from A. The history table IS the feedback loop — agents read it next cycle.`;
+  // Load evaluation protocol from markdown (single source of truth)
+  const evalProtocolPath = join(findProjectRoot() || '', '.agents', 'config', 'coo-evaluation.md');
+  const evalProtocol = existsSync(evalProtocolPath) ? readFileSync(evalProtocolPath, 'utf-8') : '';
+  const evalTask = `Post-run evaluation for: ${squadList}.\n\n${evalProtocol}`;
 
   await runAgent('company-lead', cooPath, 'company', {
     ...options,
@@ -641,6 +582,10 @@ export async function runLeadMode(
   const agentList = agentFiles.map(a => `- ${a.name}: ${a.role}`).join('\n');
   const agentPaths = agentFiles.map(a => `- ${a.name}: ${a.path}`).join('\n');
 
+  // Load lead mode protocol from markdown
+  const leadProtocolPath = join(findProjectRoot() || '', '.agents', 'config', 'lead-mode.md');
+  const leadProtocol = existsSync(leadProtocolPath) ? readFileSync(leadProtocolPath, 'utf-8') : '';
+
   const prompt = `You are the Lead of the ${squad.name} squad.
 
 ## Mission
@@ -652,45 +597,7 @@ ${agentList}
 ## Agent Definition Files
 ${agentPaths}
 
-## Your Role as Lead
-
-1. **Assess the situation**: Check for pending work:
-   - Run \`gh issue list --repo {org}/hq --label squad:${squad.name}\` for assigned issues
-   - Check .agents/memory/${squad.dir}/ for squad state and pending tasks
-   - Review recent activity with \`git log --oneline -10\`
-
-2. **Delegate work using Task tool**: For each piece of work:
-   - Use the Task tool with subagent_type="general-purpose"
-   - Include the agent definition file path in the prompt
-   - Spawn multiple Task agents IN PARALLEL when work is independent
-   - Example: "Read ${agentFiles[0]?.path || 'agent.md'} and execute its instructions for [specific task]"
-
-3. **Coordinate parallel execution**:
-   - Independent tasks → spawn Task agents in parallel (single message, multiple tool calls)
-   - Dependent tasks → run sequentially
-   - Monitor progress and handle failures
-
-4. **Report and update memory**:
-   - Update .agents/memory/${squad.dir}/state.md with completed work
-   - Log learnings to learnings.md
-   - Create issues for follow-up work if needed
-
-## Time Budget
-You have ${timeoutMins} minutes. Prioritize high-impact work.
-
-## Critical Instructions
-- Use Task tool for delegation, NOT direct execution of agent work
-- Spawn parallel Task agents when work is independent
-- When done, type /exit to end the session
-- Do NOT wait for user input - work autonomously
-
-## Async Mode (CRITICAL)
-This is ASYNC execution - Task agents must be fully autonomous:
-- **Findings** → Create GitHub issues (gh issue create)
-- **Code changes** → Create PRs (gh pr create)
-- **Analysis results** → Write to .agents/outputs/ or memory files
-- **NEVER wait for human review** - complete the work and move on
-- **NEVER ask clarifying questions** - make reasonable decisions
+${leadProtocol}
 
 Instruct each Task agent: "Work autonomously. Output findings to GitHub issues. Output code changes as PRs. Do not wait for review."
 

--- a/src/lib/run-modes.ts
+++ b/src/lib/run-modes.ts
@@ -3,7 +3,6 @@
  * Extracted from commands/run.ts to reduce its size.
  */
 
-import { spawn } from 'child_process';
 import { join } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import {
@@ -13,16 +12,11 @@ import {
 } from './run-types.js';
 import {
   checkClaudeCliAvailable,
-  getProjectRoot,
 } from './run-utils.js';
 import {
   executeWithClaude,
   executeWithProvider,
 } from './execution-engine.js';
-import {
-  checkLocalCooldown,
-  DEFAULT_SCHEDULED_COOLDOWN_MS,
-} from './execution-log.js';
 import { runAgent } from './agent-runner.js';
 import {
   findSquadsDir,
@@ -50,12 +44,9 @@ import {
 } from './cognition.js';
 import {
   runConversation,
-  saveTranscript,
   type ConversationOptions,
 } from './workflow.js';
 import {
-  reportExecutionStart,
-  reportConversationResult,
   pushCognitionSignal,
 } from './api-client.js';
 import { getBotGhEnv } from './github.js';
@@ -71,9 +62,7 @@ import {
   getCLIConfig,
   isProviderCLIAvailable,
 } from './llm-clis.js';
-import { getBridgeUrl } from './env-config.js';
 import { classifyAgent } from './conversation.js';
-import ora from 'ora';
 
 // ── Post-run evaluation ─────────────────────────────────────────────
 // After any squad run, dispatch the COO (company-lead) to evaluate outputs.

--- a/src/lib/run-types.ts
+++ b/src/lib/run-types.ts
@@ -43,6 +43,9 @@ export interface RunOptions {
   phased?: boolean; // Autopilot: use dependency-based phase ordering
   eval?: boolean; // Post-run COO evaluation (default: true, --no-eval to skip)
   org?: boolean; // Org cycle: scan → plan → execute all leads → report
+  force?: boolean; // Force re-run squads that already completed today
+  resume?: boolean; // Resume org cycle from quota-skipped squads
+  focus?: string; // Cycle focus: create, resolve, review, ship, research, cost
 }
 
 /**

--- a/src/lib/run-utils.ts
+++ b/src/lib/run-utils.ts
@@ -7,7 +7,6 @@ import { join, dirname } from 'path';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { findSquadsDir, type Squad } from './squad-parser.js';
 import { resolveMcpConfigPath } from './mcp-config.js';
-import { findMemoryDir } from './memory.js';
 import { colors, RESET, writeLine } from './terminal.js';
 import type { ExecutionContext } from './run-types.js';
 

--- a/src/lib/squad-loop.ts
+++ b/src/lib/squad-loop.ts
@@ -15,7 +15,6 @@ import {
   findSquadsDir,
   listSquads,
   loadSquad,
-  type Squad,
 } from './squad-parser.js';
 import { findMemoryDir } from './memory.js';
 import { getOutcomeScoreModifier } from './outcomes.js';

--- a/src/lib/squad-parser.ts
+++ b/src/lib/squad-parser.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, readdirSync, writeFileSync } from 'fs';
 import { join, basename, dirname } from 'path';
+import { spawnSync } from 'child_process';
 import matter from 'gray-matter';
 import { resolveMcpConfig, type McpResolution } from './mcp-config.js';
 
@@ -64,6 +65,8 @@ export interface SquadFrontmatter {
   providers?: SquadProviders;
   /** Squad names this squad must wait for before executing (phase ordering) */
   depends_on?: string[];
+  /** Agents that participate in conversations. Others run on schedules. */
+  conversation_agents?: string[];
 }
 
 export interface Agent {
@@ -138,6 +141,8 @@ export interface Squad {
   context?: SquadContext;  // Frontmatter context block
   repo?: string;
   stack?: string;
+  /** Agents that participate in squad conversations. Others run on schedules. */
+  conversation_agents?: string[];
   /** Multi-LLM provider configuration */
   providers?: SquadProviders;
   /** Domain this squad operates in */
@@ -175,22 +180,76 @@ export interface ExecutionContext extends SquadContext {
 }
 
 /**
- * Find the .agents/squads directory by searching current directory and parents.
- * Searches up to 5 parent directories.
- * @returns Path to squads directory or null if not found
+ * Run `git rev-parse` with a given flag in a given directory.
+ * Returns stdout trimmed, or null on error.
  */
-export function findSquadsDir(): string | null {
-  // Look for .agents/squads in current directory or parent directories
-  let dir = process.cwd();
+function gitRevParse(flag: string, cwd: string): string | null {
+  const result = spawnSync('git', ['rev-parse', flag], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0 || !result.stdout) return null;
+  return result.stdout.trim();
+}
 
-  for (let i = 0; i < 5; i++) {
+/**
+ * Walk up from `startDir` (up to `maxLevels` times) looking for .agents/squads.
+ * Returns the squads path on first hit, or null.
+ */
+function walkUpForSquadsDir(startDir: string, maxLevels: number): string | null {
+  let dir = startDir;
+  for (let i = 0; i < maxLevels; i++) {
     const squadsPath = join(dir, '.agents', 'squads');
-    if (existsSync(squadsPath)) {
-      return squadsPath;
-    }
+    if (existsSync(squadsPath)) return squadsPath;
     const parent = join(dir, '..');
     if (parent === dir) break;
     dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Find the .agents/squads directory by searching current directory and parents.
+ *
+ * Search order:
+ * 1. Walk up to 5 levels from process.cwd() (handles normal project layouts).
+ * 2. If that fails and we are inside a git worktree or subdirectory, get the
+ *    git toplevel via `git rev-parse --show-toplevel` and walk up from there.
+ * 3. Also check the parent of the git toplevel so that sibling layouts like
+ *    `agents-squads/hq/` are found when CWD is `agents-squads/.worktrees/xxx/`.
+ *
+ * @returns Path to squads directory or null if not found
+ */
+export function findSquadsDir(): string | null {
+  const cwd = process.cwd();
+
+  // 1. Standard ancestor walk from CWD.
+  const fromCwd = walkUpForSquadsDir(cwd, 5);
+  if (fromCwd) return fromCwd;
+
+  // 2. Git-aware fallback: get the worktree's toplevel checkout directory.
+  const gitToplevel = gitRevParse('--show-toplevel', cwd);
+  if (gitToplevel && gitToplevel !== cwd) {
+    // Walk up from the git toplevel (handles CWD being deep inside a worktree).
+    const fromGitRoot = walkUpForSquadsDir(gitToplevel, 5);
+    if (fromGitRoot) return fromGitRoot;
+  }
+
+  // 3. For git worktrees the common .git dir lives in the main repo. Use
+  //    --git-common-dir to find the main repo root and look for siblings.
+  const gitCommonDir = gitRevParse('--git-common-dir', cwd);
+  if (gitCommonDir) {
+    // --git-common-dir returns the path to the common .git dir.
+    // Its parent is the main repo root; walk up from there.
+    const mainRepoRoot = join(gitCommonDir, '..');
+    const fromMainRoot = walkUpForSquadsDir(mainRepoRoot, 5);
+    if (fromMainRoot) return fromMainRoot;
+
+    // Also check siblings of the main repo root (e.g. hq/ lives next to squads-cli/).
+    const orgRoot = join(mainRepoRoot, '..');
+    const fromOrgRoot = walkUpForSquadsDir(orgRoot, 3);
+    if (fromOrgRoot) return fromOrgRoot;
   }
 
   return null;
@@ -354,6 +413,7 @@ export function parseSquadFile(filePath: string): Squad {
     context: fm.context,
     repo: fm.repo,
     stack: fm.stack,
+    conversation_agents: Array.isArray(fm.conversation_agents) ? fm.conversation_agents : undefined,
     providers: fm.providers,
     // Preserve raw frontmatter for KPIs and other custom fields
     frontmatter: frontmatter as Record<string, unknown>,


### PR DESCRIPTION
## Summary — PR 1 of 7 for v0.3.0 release
Core runtime refactoring. Foundation for all subsequent PRs.

## Changes (7 files)
- **run-context.ts**: expanded context helpers — goal injection, feedback, state loading
- **run-modes.ts**: simplified run modes, removed per-squad limits
- **run-types.ts**: added `conversation_agents` field type
- **execution-engine.ts**: phase-ordered execution, role-based context
- **agent-runner.ts**: bot identity injection, guardrail hooks, tool sets
- **squad-parser.ts**: `findProjectRoot`, skills loading, dynamic discovery
- **env-config.ts**: environment URL resolution additions

## Merge order
**Merge this first.** Subsequent PRs build on these changes:
1. **→ core-refactor** (this PR)
2. run-engine
3. conversation
4. new-commands
5. init-ux
6. security-guardrails
7. tests-docs

## Test plan
- [x] `npm run build` passes
- [ ] Review refactored modules for correctness

Reorganized from 219-commit develop branch for proper review.
Backup tag: `pre-v0.3.0-backup`