### PR TITLE
feat(run): workflow rewrite — smart skip, org cycle, wave execution [v0.3.0 — 2/7]

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,5 @@
 import { join } from 'path';
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
-import { execSync } from 'child_process';
 import {
   findSquadsDir,
   loadSquad,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -234,12 +234,6 @@ export async function runCommand(
         }
       }
 
-      // Commit hq memory changes between waves so next wave sees fresh state
-      try {
-        execSync('git add -A .agents/memory/ && git diff --cached --quiet || git commit -m "memory: wave ' + waveNum + ' state updates"', {
-          cwd: process.cwd(), stdio: 'pipe', encoding: 'utf-8',
-        });
-      } catch { /* no changes to commit */ }
     }
 
     // Clear resume file if cycle completed without quota hit

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -76,21 +76,12 @@ export async function runCommand(
       return;
     }
 
-    // Step 3: EXECUTE — wave-based parallel execution
-    //
-    // Wave 1 (producers):  research, intelligence, data — create raw material
-    // Wave 2 (builders):   cli, website, finance, engineering — build on wave 1
-    // Wave 3 (amplifiers): marketing, growth, product, analytics, customer, economics — use wave 2
-    // Wave 4 (reviewers):  operations, company — evaluate everything
-    //
-    // Within each wave, squads run in parallel (different target repos).
-    // Between waves, we wait — so each wave sees the previous wave's output.
+    // Step 3: EXECUTE — all planned squads run in parallel
+    // Each squad targets its own repo, so no conflicts.
+    // Users can define custom wave ordering via SQUAD.md `wave:` field in the future.
 
     const waves: string[][] = [
-      ['research', 'intelligence', 'data'],
-      ['cli', 'website', 'finance', 'engineering'],
-      ['marketing', 'growth', 'product', 'analytics', 'customer', 'economics'],
-      ['operations', 'company'],
+      plan.map(s => s.squad),
     ];
 
     // Resume support: load quota-skipped squads from previous run
@@ -197,9 +188,8 @@ export async function runCommand(
       if (waveSquads.length === 0) continue;
 
       const waveNum = waveIdx + 1;
-      const waveNames = ['Producers', 'Builders', 'Amplifiers', 'Reviewers'];
       writeLine();
-      writeLine(`  ${bold}Wave ${waveNum}: ${waveNames[waveIdx]}${RESET} ${colors.dim}(${waveSquads.join(', ')})${RESET}`);
+      writeLine(`  ${bold}Wave ${waveNum}${RESET} ${colors.dim}(${waveSquads.join(', ')})${RESET}`);
 
       // Run all squads in this wave in parallel
       const waveResults = await Promise.all(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { execSync } from 'child_process';
 import {
   findSquadsDir,
   loadSquad,
@@ -27,6 +28,8 @@ import { runCloudDispatch } from '../lib/cloud-dispatch.js';
 import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
 import { reportExecutionStart, reportConversationResult, pushCognitionSignal } from '../lib/api-client.js';
 import { runAgent } from '../lib/agent-runner.js';
+import { findMemoryDir } from '../lib/memory.js';
+import { statSync } from 'fs';
 import { runPostEvaluation, runAutopilot, runLeadMode, runSequentialMode } from '../lib/run-modes.js';
 
 export async function runCommand(
@@ -52,7 +55,8 @@ export async function runCommand(
     const { scanOrg, planOrgCycle, displayOrgScan, displayPlan } = await import('../lib/org-cycle.js');
 
     writeLine();
-    writeLine(`  ${gradient('squads')} ${colors.dim}org cycle${RESET}`);
+    const focusLabel = options.focus ? ` ${bold}[${options.focus}]${RESET}` : '';
+    writeLine(`  ${gradient('squads')} ${colors.dim}org cycle${RESET}${focusLabel}`);
     writeLine();
 
     // Step 1: SCAN
@@ -72,52 +76,186 @@ export async function runCommand(
       return;
     }
 
-    // Step 3: EXECUTE — run each lead sequentially
+    // Step 3: EXECUTE — wave-based parallel execution
+    //
+    // Wave 1 (producers):  research, intelligence, data — create raw material
+    // Wave 2 (builders):   cli, website, finance, engineering — build on wave 1
+    // Wave 3 (amplifiers): marketing, growth, product, analytics, customer, economics — use wave 2
+    // Wave 4 (reviewers):  operations, company — evaluate everything
+    //
+    // Within each wave, squads run in parallel (different target repos).
+    // Between waves, we wait — so each wave sees the previous wave's output.
+
+    const waves: string[][] = [
+      ['research', 'intelligence', 'data'],
+      ['cli', 'website', 'finance', 'engineering'],
+      ['marketing', 'growth', 'product', 'analytics', 'customer', 'economics'],
+      ['operations', 'company'],
+    ];
+
+    // Resume support: load quota-skipped squads from previous run
+    const resumeFile = join(process.cwd(), '.agents', 'observability', 'resume.json');
+    let resumeSquads: Set<string> | null = null;
+    if (options.resume && existsSync(resumeFile)) {
+      try {
+        const data = JSON.parse(readFileSync(resumeFile, 'utf-8'));
+        resumeSquads = new Set(data.squads as string[]);
+        writeLine(`  ${bold}Resuming${RESET} ${resumeSquads.size} squads from quota stop: ${[...resumeSquads].join(', ')}`);
+      } catch { /* invalid file, run full cycle */ }
+    }
+
     const cycleStart = Date.now();
-    const results: Array<{ squad: string; agent: string; status: string; durationMs: number }> = [];
+    const results: Array<{ squad: string; agent: string; status: string; durationMs: number; turnCount?: number; totalCost?: number; converged?: boolean }> = [];
 
     // Snapshot all goals before execution
-    const { snapshotGoals, diffGoals } = await import('../lib/observability.js');
+    const { snapshotGoals, diffGoals, queryExecutions } = await import('../lib/observability.js');
     const allGoalsBefore: Record<string, Record<string, string>> = {};
     for (const s of plan) {
       allGoalsBefore[s.squad] = snapshotGoals(s.squad);
     }
 
-    for (const s of plan) {
-      if (!s.lead) continue;
-      const leadPath = join(squadsDir, s.squad, `${s.lead}.md`);
-      if (!existsSync(leadPath)) continue;
+    // Build set of planned squads for filtering
+    const plannedSquads = new Set(plan.map(s => s.squad));
 
-      writeLine(`  ${colors.cyan}Running ${s.squad}/${s.lead}...${RESET}`);
+    // Check skip logic
+    const today = new Date().toISOString().slice(0, 10);
+    const todayExecs = queryExecutions({ since: `${today}T00:00:00Z`, limit: 500 });
+    const completedTodayMap = new Map<string, string>();
+    for (const e of todayExecs) {
+      if (e.status === 'completed' && e.agent?.includes('lead')) {
+        if (!completedTodayMap.has(e.squad) || e.ts > completedTodayMap.get(e.squad)!) {
+          completedTodayMap.set(e.squad, e.ts);
+        }
+      }
+    }
+
+    function shouldSkip(squadName: string): boolean {
+      if (options.force) return false;
+      const lastRun = completedTodayMap.get(squadName);
+      if (!lastRun) return false;
+      const memoryDir = findMemoryDir();
+      if (memoryDir) {
+        const goalsPath = join(memoryDir, squadName, 'goals.md');
+        const priPath = join(memoryDir, squadName, 'priorities.md');
+        try {
+          const lastRunMs = new Date(lastRun).getTime();
+          const goalsMtime = existsSync(goalsPath) ? statSync(goalsPath).mtimeMs : 0;
+          const priMtime = existsSync(priPath) ? statSync(priPath).mtimeMs : 0;
+          if (goalsMtime > lastRunMs || priMtime > lastRunMs) return false;
+        } catch { return false; }
+      }
+      return true;
+    }
+
+    async function runSquadConversation(squadName: string): Promise<typeof results[0]> {
+      const s = plan.find(p => p.squad === squadName);
+      if (!s || !s.lead) return { squad: squadName, agent: 'unknown', status: 'skipped', durationMs: 0 };
+
+      if (shouldSkip(squadName)) {
+        writeLine(`  ${colors.dim}skip  ${squadName} (completed today, goals unchanged)${RESET}`);
+        return { squad: squadName, agent: s.lead, status: 'skipped', durationMs: 0 };
+      }
+
+      const squad = loadSquad(squadName);
+      if (!squad) {
+        writeLine(`  ${colors.red}${squadName}: squad not found${RESET}`);
+        return { squad: squadName, agent: s.lead, status: 'failed', durationMs: 0 };
+      }
+
       const runStart = Date.now();
       try {
-        await runAgent(s.lead, leadPath, s.squad, { ...options, execute: true });
-        results.push({ squad: s.squad, agent: s.lead, status: 'completed', durationMs: Date.now() - runStart });
+        const convOptions: ConversationOptions = {
+          task: options.task,
+          maxTurns: options.maxTurns,
+          costCeiling: options.costCeiling,
+          verbose: options.verbose,
+          model: options.model,
+          focus: (options.focus as ConversationOptions['focus']) || undefined,
+        };
+
+        const result = await runConversation(squad, convOptions);
+        saveTranscript(result.transcript);
+
+        const status = result.converged ? 'converged' : 'completed';
+        writeLine(`  ${result.converged ? icons.success : icons.warning} ${squadName}: ${result.reason} ${colors.dim}(${result.turnCount}t, ~$${result.totalCost.toFixed(2)})${RESET}`);
+        return {
+          squad: squadName, agent: s.lead, status,
+          durationMs: Date.now() - runStart,
+          turnCount: result.turnCount, totalCost: result.totalCost, converged: result.converged,
+        };
       } catch (e) {
         const errMsg = e instanceof Error ? e.message : String(e);
-        results.push({ squad: s.squad, agent: s.lead, status: 'failed', durationMs: Date.now() - runStart });
-
-        // Detect quota limit — if agent fails in <10s, likely quota/rate limit
-        const failDuration = Date.now() - runStart;
-        const isQuotaLikely = failDuration < 10000 && errMsg.includes('code 1');
-        const isExplicitQuota = errMsg.includes('hit your limit') || errMsg.includes('rate limit') || errMsg.includes('quota');
-
-        if (isExplicitQuota || isQuotaLikely) {
-          // Check if previous squad also failed fast — confirms it's quota, not a bug
-          const prevFailed = results.length >= 2 &&
-            results[results.length - 2]?.status === 'failed' &&
-            (results[results.length - 2]?.durationMs || 0) < 10000;
-
-          if (isExplicitQuota || prevFailed) {
-            writeLine(`  ${colors.red}Quota limit reached — stopping org cycle.${RESET}`);
-            writeLine(`  ${colors.dim}Completed ${results.filter(r => r.status === 'completed').length} squads before hitting limit.${RESET}`);
-            writeLine(`  ${colors.dim}Resume with 'squads run --org' when quota resets.${RESET}`);
-            break;
-          }
-        }
-
-        writeLine(`  ${colors.red}${s.squad}/${s.lead} failed: ${errMsg}${RESET}`);
+        writeLine(`  ${colors.red}${squadName} failed: ${errMsg.slice(0, 80)}${RESET}`);
+        return { squad: squadName, agent: s.lead, status: 'failed', durationMs: Date.now() - runStart };
       }
+    }
+
+    for (let waveIdx = 0; waveIdx < waves.length; waveIdx++) {
+      const wave = waves[waveIdx];
+      // If resuming, only run squads that were skipped last time
+      const waveSquads = wave.filter(s => plannedSquads.has(s) && (!resumeSquads || resumeSquads.has(s)));
+      if (waveSquads.length === 0) continue;
+
+      const waveNum = waveIdx + 1;
+      const waveNames = ['Producers', 'Builders', 'Amplifiers', 'Reviewers'];
+      writeLine();
+      writeLine(`  ${bold}Wave ${waveNum}: ${waveNames[waveIdx]}${RESET} ${colors.dim}(${waveSquads.join(', ')})${RESET}`);
+
+      // Run all squads in this wave in parallel
+      const waveResults = await Promise.all(
+        waveSquads.map(s => runSquadConversation(s))
+      );
+      results.push(...waveResults);
+
+      // Quota detection: if any squad in this wave got "hit your limit" responses,
+      // stop the cycle — remaining waves will produce empty results.
+      const quotaHit = waveResults.some(r => {
+        // Check transcripts for quota messages
+        const convDir = join(process.cwd(), '.agents', 'conversations', r.squad);
+        try {
+          const files = readdirSync(convDir).sort().reverse();
+          if (files.length > 0) {
+            const latest = readFileSync(join(convDir, files[0]), 'utf-8');
+            return latest.includes('hit your limit') || latest.includes('rate limit') || latest.includes('[QUOTA]') || latest.includes('Quota limit reached');
+          }
+        } catch { /* no transcript */ }
+        return false;
+      });
+
+      if (quotaHit) {
+        const remainingWaves = waves.slice(waveIdx + 1).flat().filter(s => plannedSquads.has(s) && (!resumeSquads || resumeSquads.has(s)));
+        if (remainingWaves.length > 0) {
+          writeLine(`\n  ${colors.red}Quota limit reached.${RESET} Skipping ${remainingWaves.length} remaining squads.`);
+          writeLine(`  ${colors.dim}Resume later: squads run --org --resume${RESET}`);
+          for (const s of remainingWaves) {
+            results.push({ squad: s, agent: 'unknown', status: 'quota-skipped', durationMs: 0 });
+          }
+          // Save skipped squads for resume
+          try {
+            const obsDir = join(process.cwd(), '.agents', 'observability');
+            if (!existsSync(obsDir)) mkdirSync(obsDir, { recursive: true });
+            writeFileSync(resumeFile, JSON.stringify({
+              squads: remainingWaves,
+              stoppedAt: new Date().toISOString(),
+              waveIdx: waveIdx + 1,
+            }));
+          } catch { /* best effort */ }
+          break; // Exit wave loop
+        }
+      }
+
+      // Commit hq memory changes between waves so next wave sees fresh state
+      try {
+        execSync('git add -A .agents/memory/ && git diff --cached --quiet || git commit -m "memory: wave ' + waveNum + ' state updates"', {
+          cwd: process.cwd(), stdio: 'pipe', encoding: 'utf-8',
+        });
+      } catch { /* no changes to commit */ }
+    }
+
+    // Clear resume file if cycle completed without quota hit
+    const quotaSkipped = results.filter(r => r.status === 'quota-skipped').length;
+    if (quotaSkipped === 0 && existsSync(resumeFile)) {
+      try { unlinkSync(resumeFile); } catch { /* best effort */ }
     }
 
     // Step 4: REPORT — compare goals before and after
@@ -125,14 +263,21 @@ export async function runCommand(
     const completed = results.filter(r => r.status === 'completed').length;
     const failed = results.filter(r => r.status === 'failed').length;
 
+    const totalCostAll = results.reduce((s, r) => s + (r.totalCost || 0), 0);
+    const totalTurns = results.reduce((s, r) => s + (r.turnCount || 0), 0);
+
     writeLine();
     writeLine(`  ${bold}Org Cycle Complete${RESET}`);
-    writeLine(`  Duration: ${Math.round(totalMs / 60000)}m | Squads: ${completed} completed, ${failed} failed | Frozen: ${scan.filter(s => s.status === 'frozen').length} skipped`);
+    writeLine(`  Duration: ${Math.round(totalMs / 60000)}m | Squads: ${completed} done, ${failed} failed | ~$${totalCostAll.toFixed(0)} | ${totalTurns} turns`);
     writeLine();
 
     for (const r of results) {
-      const icon = r.status === 'completed' ? `${colors.green}pass${RESET}` : `${colors.red}fail${RESET}`;
-      writeLine(`  ${icon}  ${r.squad}/${r.agent}  ${colors.dim}${Math.round(r.durationMs / 1000)}s${RESET}`);
+      const icon = r.status === 'converged' ? `${colors.green}conv${RESET}`
+        : r.status === 'completed' ? `${colors.green}done${RESET}`
+        : r.status === 'skipped' ? `${colors.dim}skip${RESET}`
+        : `${colors.red}fail${RESET}`;
+      const meta = r.turnCount ? `${r.turnCount}t ~$${(r.totalCost || 0).toFixed(2)}` : '';
+      writeLine(`  ${icon}  ${r.squad.padEnd(18)} ${colors.dim}${Math.round(r.durationMs / 1000)}s  ${meta}${RESET}`);
     }
 
     // Goal changes summary
@@ -213,9 +358,23 @@ export async function runCommand(
   if (squad) {
     await track(Events.CLI_RUN, { type: 'squad', target: squad.name });
     await flushEvents(); // Ensure telemetry is sent before potential exit
-    await runSquad(squad, squadsDir, options);
-    // Post-run COO evaluation (default on, --no-eval to skip)
-    await runPostEvaluation([squad.name], options);
+    const runStartMs = Date.now();
+    let hadError = false;
+    try {
+      await runSquad(squad, squadsDir, options);
+      // Post-run COO evaluation (default on, --no-eval to skip)
+      await runPostEvaluation([squad.name], options);
+    } catch (err) {
+      hadError = true;
+      throw err;
+    } finally {
+      await track(Events.CLI_RUN_COMPLETE, {
+        exit_code: hadError ? 1 : 0,
+        duration_ms: Date.now() - runStartMs,
+        agent_count: squad.agents?.length ?? 1,
+        had_error: hadError,
+      });
+    }
   } else {
     // Try to find as an agent
     const agents = listAgents(squadsDir);
@@ -226,9 +385,23 @@ export async function runCommand(
       const pathParts = agent.filePath.split('/');
       const squadIdx = pathParts.indexOf('squads');
       const resolvedSquadName = squadIdx >= 0 ? pathParts[squadIdx + 1] : 'unknown';
-      await runAgent(agent.name, agent.filePath, resolvedSquadName, options);
-      // Post-run COO evaluation for the squad this agent belongs to
-      await runPostEvaluation([resolvedSquadName], options);
+      const runStartMs = Date.now();
+      let hadError = false;
+      try {
+        await runAgent(agent.name, agent.filePath, resolvedSquadName, options);
+        // Post-run COO evaluation for the squad this agent belongs to
+        await runPostEvaluation([resolvedSquadName], options);
+      } catch (err) {
+        hadError = true;
+        throw err;
+      } finally {
+        await track(Events.CLI_RUN_COMPLETE, {
+          exit_code: hadError ? 1 : 0,
+          duration_ms: Date.now() - runStartMs,
+          agent_count: 1,
+          had_error: hadError,
+        });
+      }
     } else {
       writeLine(`  ${colors.red}Squad or agent "${target}" not found${RESET}`);
       const similar = findSimilarSquads(target, listSquads(squadsDir));

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -310,6 +310,7 @@ export const Events = {
 
   // Commands
   CLI_RUN: 'cli.run',
+  CLI_RUN_COMPLETE: 'cli.run.complete',
   CLI_STATUS: 'cli.status',
   CLI_DASHBOARD: 'cli.dashboard',
   CLI_WORKERS: 'cli.workers',

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -11,9 +11,13 @@
  * Token budget replaces turn limits. Lead plans within the budget.
  */
 
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { fileURLToPath } from 'url';
 import { spawn } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 import {
   type AgentRole,
@@ -312,35 +316,22 @@ export async function runConversation(
 
   // Load plan prompt template from .agents/config/conversation-roles.md (Lead first turn)
   // Focus instructions override the default planning behavior
-  const planPrompt = `You are ${lead.name} (lead) in squad ${squad.name}.
-
-Read your full agent definition at ${lead.path} and follow its instructions.
-
-## Cycle Focus: ${focus.toUpperCase()}
-
-${focusInstructions}
-
-## Budget
-
-${Math.round(tokenBudget / 1000)}K output tokens for the whole squad.
-Each worker task uses ~5-10K tokens. Max ${Math.floor(tokenBudget / 10000)} tasks.
-
-Available workers: ${workerNames}
-Available scanners: ${scannerNames || '(none)'}
-
-## Output Format
-
-\`\`\`plan
-GOAL: [which goal this cycle advances]
-TASKS:
-- worker: [worker-name] | task: [specific instruction with issue number or PR number]
-- worker: [worker-name] | task: [specific instruction]
-\`\`\`
-
-Then end with:
-## STATUS: CONTINUE
-
-${squadContext}`;
+  // Load plan prompt from template (no prompts in TypeScript — CLAUDE.md rule)
+  const planTemplatePath = join(__dirname, '..', 'templates', 'prompts', 'plan.md');
+  const planTemplate = existsSync(planTemplatePath)
+    ? readFileSync(planTemplatePath, 'utf-8')
+    : 'You are {{LEAD_NAME}} (lead) in squad {{SQUAD_NAME}}. Plan the work.';
+  const planPrompt = planTemplate
+    .replace('{{LEAD_NAME}}', lead.name)
+    .replace('{{SQUAD_NAME}}', squad.name)
+    .replace('{{LEAD_PATH}}', lead.path)
+    .replace('{{FOCUS}}', focus.toUpperCase())
+    .replace('{{FOCUS_INSTRUCTIONS}}', focusInstructions)
+    .replace('{{BUDGET_K}}', String(Math.round(tokenBudget / 1000)))
+    .replace('{{MAX_TASKS}}', String(Math.floor(tokenBudget / 10000)))
+    .replace('{{WORKERS}}', workerNames)
+    .replace('{{SCANNERS}}', scannerNames || '(none)')
+    .replace('{{SQUAD_CONTEXT}}', squadContext);
 
   const planOutput = await runIndependentAgent({
     agentName: lead.name, agentPath: lead.path, role: 'lead',

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -1,15 +1,19 @@
 /**
- * Squad Conversation Workflow — Orchestrates multi-agent conversations.
+ * Squad Workflow — Plan → Execute → Review → Verify
  *
- * Lead briefs → scanners discover → workers execute → lead reviews →
- * loop until convergence or budget exhausted.
+ * Architecture:
+ * 1. PLAN: Lead sees goals + feedback + budget → produces task assignments
+ * 2. EXECUTE: Workers run independently in parallel, each with their task
+ * 3. REVIEW: Lead evaluates worker output, merges PRs, updates goals
+ * 4. VERIFY: Verifier checks deliverables against quality gate
  *
- * CLI manages turns (deterministic), lead manages content (creative).
+ * Workers don't share a conversation — they get their task + squad context.
+ * Token budget replaces turn limits. Lead plans within the budget.
  */
 
 import { join } from 'path';
-import { existsSync, writeFileSync, mkdirSync } from 'fs';;
-import { execSync, exec } from 'child_process';;
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { spawn } from 'child_process';
 
 import {
   type AgentRole,
@@ -30,200 +34,179 @@ import {
   type ContextRole,
   gatherSquadContext,
 } from './run-context.js';
+import {
+  buildAgentEnv,
+  resolveGuardrailSettings,
+} from './execution-engine.js';
+import { type ExecutionContext } from './run-types.js';
+import { getBotGhEnv } from './github.js';
+import { generateExecutionId, getClaudeModelAlias } from './run-utils.js';
+import { colors, RESET, writeLine } from './terminal.js';
+import {
+  logObservability,
+  snapshotGoals,
+  diffGoals,
+  type ObservabilityRecord,
+} from './observability.js';
 
 // =============================================================================
 // Configuration
 // =============================================================================
 
+export type CycleFocus = 'create' | 'resolve' | 'review' | 'ship' | 'research' | 'cost';
+
 export interface ConversationOptions {
-  /** Override lead's briefing with a founder directive */
   task?: string;
-  /** Maximum turns before stopping (default: 20) */
   maxTurns?: number;
-  /** Cost ceiling in USD (default: 25) */
   costCeiling?: number;
-  /** Verbose logging */
   verbose?: boolean;
-  /** Model override for all agents */
   model?: string;
+  /** Token budget for the squad (output tokens). Default: 50K */
+  tokenBudget?: number;
+  /** Cycle focus — changes the lead's planning behavior */
+  focus?: CycleFocus;
 }
 
-const DEFAULT_MAX_TURNS = 20;
+/** Load focus instructions from .agents/config/cycle-focus.md */
+function loadFocusPrompt(focus: CycleFocus): string {
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return '';
+  const focusPath = join(squadsDir, '..', 'config', 'cycle-focus.md');
+  if (!existsSync(focusPath)) return '';
+  const content = readFileSync(focusPath, 'utf-8');
+  if (!content) return '';
+  const match = content.match(new RegExp(`## ${focus}\\n([\\s\\S]*?)(?=\\n## |$)`));
+  return match ? match[1].trim() : '';
+}
+
+/** Default output token budget per squad. Lead should plan within this. */
+const DEFAULT_TOKEN_BUDGET = 50000;
 const DEFAULT_COST_CEILING = 25;
 
 // =============================================================================
-// Agent Turn Execution
+// Agent Execution (independent, tool-capable)
 // =============================================================================
 
-interface AgentTurnConfig {
+interface AgentRunConfig {
   agentName: string;
   agentPath: string;
   role: AgentRole;
   squadName: string;
   model: string;
-  transcript: Transcript;
-  task?: string;
-  /** Working directory for the agent process (defaults to process.cwd()) */
-  cwd?: string;
+  /** The specific task for this agent (from lead's plan) */
+  task: string;
+  /** Full squad context (goals, feedback, priorities, etc.) */
+  squadContext: string;
+  cwd: string;
 }
 
 /**
- * Execute a single agent turn via `claude --print`.
- * Returns the agent's text output.
+ * Run a single agent independently via `claude --print --allowedTools`.
+ * Agent gets: their task + squad context. No shared transcript.
  */
-function executeAgentTurn(config: AgentTurnConfig): string {
-  const { agentName, agentPath, role, squadName, model: _model, transcript, task } = config;
-
-  // Build the prompt: agent definition + squad context + transcript context + role instructions
-  const transcriptContext = serializeTranscript(transcript);
-
-  // Inject role-based squad context (priorities, feedback, active work, etc.)
-  const contextRole: ContextRole = agentName.includes('company-lead') ? 'coo' : (role as ContextRole);
-  const squadContext = gatherSquadContext(squadName, agentName, {
-    agentPath, role: contextRole
-  });
-
-  let roleInstructions: string;
-  switch (role) {
-    case 'lead':
-      if (transcript.turns.length === 0 && task) {
-        // First turn with founder directive — replaces lead briefing
-        roleInstructions = `## Founder Directive\n\n${task}\n\nBrief the team on this directive. Set priorities and assign work.`;
-      } else if (transcript.turns.length === 0) {
-        roleInstructions = `## Your Role: Lead\n\nYou are starting a new squad session. Brief the team:\n1. Review open issues and PRs\n2. Set priorities for this session\n3. Assign work to workers\n4. Be specific about what each worker should do`;
-      } else {
-        roleInstructions = `## Your Role: Lead (Review)\n\nReview the work done so far. Either:\n- Request specific changes from workers\n- Approve and signal completion if quality is sufficient\n- Merge PRs using \`gh pr merge --squash --delete-branch --auto\` (waits for required checks)`;
-      }
-      break;
-    case 'scanner':
-      roleInstructions = `## Your Role: Scanner\n\nScan for issues, gaps, and opportunities. Report findings concisely. Do NOT fix anything — just discover and report.`;
-      break;
-    case 'worker':
-      roleInstructions = `## Your Role: Worker\n\nExecute the work assigned by the lead. Create branches, write code, open PRs to develop. Be focused and efficient.`;
-      break;
-    case 'verifier':
-      roleInstructions = `## Your Role: Verifier\n\nVerify that work meets quality standards. Check PRs, run tests, validate output. Report pass/fail with specifics.`;
-      break;
-  }
+async function runIndependentAgent(config: AgentRunConfig): Promise<string> {
+  const { agentName, agentPath, role, squadName, task, squadContext } = config;
 
   const prompt = `You are ${agentName} (${role}) in squad ${squadName}.
 
 Read your full agent definition at ${agentPath} and follow its instructions.
 
-${roleInstructions}
+## Your Task
+
+${task}
+
 ${squadContext}
-${transcriptContext}
 
-IMPORTANT:
-- Be concise. Your output becomes part of a shared transcript.
-- Reference specific issue numbers, PR numbers, and file paths.
-- If you create a PR, include the PR number in your output.
-- If there's nothing to do, say "Nothing to do" clearly.
-- When done, summarize what you did in 2-3 sentences.`;
+## Output Requirements
 
-  // Resolve model: CLI override > role default
+- Commit your work (git add, commit, push)
+- Open PRs targeting develop (product repos) or push to main (domain repos)
+- Run the build before pushing — fix if it fails
+- Report: branch name, PR number, build status, what you changed
+- End with: ## STATUS: DONE or ## STATUS: BLOCKED [reason]`;
+
   const resolvedModel = config.model || modelForRole(role);
+  const claudeModel = getClaudeModelAlias(resolvedModel) || resolvedModel;
 
-  // Execute via claude --print (captures output)
-  // Strip CLAUDECODE and ANTHROPIC_API_KEY so child process uses Max subscription
   const { CLAUDECODE: _cc, ANTHROPIC_API_KEY: _ak, ...cleanEnv } = process.env;
-  const escapedPrompt = prompt.replace(/'/g, "'\\''");
 
+  let botGhToken: string | undefined;
   try {
-    const output = execSync(
-      `claude --print --dangerously-skip-permissions --model ${resolvedModel} -- '${escapedPrompt}'`,
-      {
-        cwd: config.cwd || process.cwd(),
-        timeout: 15 * 60 * 1000, // 15 min per turn
-        maxBuffer: 10 * 1024 * 1024, // 10MB
-        encoding: 'utf-8',
-        env: cleanEnv,
-      }
-    );
-    return output.trim();
-  } catch (err: unknown) {
-    const error = err as { stdout?: string; stderr?: string; message?: string };
-    // If the command produced output before failing, use it
-    if (error.stdout && error.stdout.trim().length > 0) {
-      return error.stdout.trim();
-    }
-    return `[ERROR] Agent ${agentName} failed: ${error.message || 'unknown error'}`;
+    const ghEnv = await getBotGhEnv();
+    botGhToken = ghEnv.GH_TOKEN;
+  } catch { /* falls back to user auth */ }
+
+  const execContext: ExecutionContext = {
+    squad: squadName, agent: agentName,
+    taskType: role === 'lead' ? 'lead' : role === 'scanner' ? 'research' : role === 'verifier' ? 'evaluation' : 'execution',
+    trigger: 'scheduled', executionId: generateExecutionId(),
+  };
+
+  // Effort level per role (#702): scanners low, workers high, verifiers medium
+  const effortByRole: Record<string, string> = { lead: 'high', scanner: 'low', worker: 'high', verifier: 'medium' };
+  const agentEnv = buildAgentEnv(cleanEnv as Record<string, string>, execContext, { ghToken: botGhToken, effort: effortByRole[role] as 'high' | 'medium' | 'low' });
+
+  // Role-based tool sets (#701): scanners get read-only, workers get full, verifiers get read+build
+  const readTools = ['Read', 'Glob', 'Grep', 'Bash(git:*)', 'Bash(gh:*)', 'Bash(ls:*)', 'Bash(cat:*)', 'Bash(head:*)', 'Bash(tail:*)', 'Bash(wc:*)', 'Bash(date:*)', 'Bash(curl:*)', 'WebFetch', 'WebSearch'];
+  const writeTools = ['Write', 'Edit', 'Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)', 'Bash(python3:*)', 'Bash(docker:*)', 'Bash(duckdb:*)', 'Bash(bq:*)', 'Bash(gcloud:*)', 'Bash(gws:*)', 'Bash(stripe:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)', 'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(squads:*)', 'Agent'];
+  const buildTools = ['Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)'];
+
+  const toolsByRole: Record<string, string[]> = {
+    lead: [...readTools, ...writeTools],
+    scanner: readTools,
+    worker: [...readTools, ...writeTools],
+    verifier: [...readTools, ...buildTools],
+  };
+
+  const claudeArgs: string[] = ['--print'];
+  if (process.env.SQUADS_SKIP_PERMISSIONS === '1') {
+    claudeArgs.push('--dangerously-skip-permissions');
+  } else {
+    const tools = toolsByRole[role] || [...readTools, ...writeTools];
+    claudeArgs.push('--allowedTools', ...tools);
   }
-}
+  claudeArgs.push('--disable-slash-commands');
+  const guardrailPath = resolveGuardrailSettings(config.cwd);
+  if (guardrailPath) claudeArgs.push('--settings', guardrailPath);
+  if (claudeModel) claudeArgs.push('--model', claudeModel);
 
-/**
- * Async version of executeAgentTurn for parallel execution.
- * Same logic, but returns a Promise instead of blocking.
- */
-function executeAgentTurnAsync(config: AgentTurnConfig): Promise<string> {
-  const { agentName, agentPath, role, squadName, model: _model, transcript, task } = config;
+  return new Promise<string>((resolve) => {
+    const chunks: Buffer[] = [];
+    const child = spawn('claude', claudeArgs, {
+      cwd: config.cwd, env: agentEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
-  let roleInstructions = '';
-  switch (role) {
-    case 'lead':
-      roleInstructions = task
-        ? `FOUNDER DIRECTIVE: ${task}\n\nBrief the team on this directive. Assign specific tasks to scanners and workers.`
-        : 'Review the conversation so far. Assess worker output. Direct next actions or declare convergence.';
-      break;
-    case 'scanner':
-      roleInstructions = 'Scan for issues, data, or signals relevant to the lead\'s brief. Report findings concisely.';
-      break;
-    case 'worker':
-      roleInstructions = 'Execute the specific task assigned by the lead. Produce concrete output (PRs, issues, content, analysis).';
-      break;
-    case 'verifier':
-      roleInstructions = 'Verify the worker\'s output meets quality standards. Check for errors, omissions, and alignment with goals.';
-      break;
-  }
+    child.stdin.write(prompt);
+    child.stdin.end();
 
-  const transcriptContext = transcript.turns.length > 0
-    ? `\n== CONVERSATION SO FAR ==\n${serializeTranscript(transcript)}\n== END CONVERSATION ==`
-    : '';
+    child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+    const stderrChunks: Buffer[] = [];
+    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
 
-  const resolvedModel = config.model || modelForRole(role);
-  const prompt = `You are ${agentName} (${role}) in squad ${squadName}.
-
-Read your full agent definition at ${agentPath} and follow its instructions.
-
-${roleInstructions}
-
-${transcriptContext}
-
-IMPORTANT:
-- Be concise. Your output becomes part of a shared transcript.
-- Reference specific issue numbers, PR numbers, and file paths.
-- If you create a PR, include the PR number in your output.
-- If there's nothing to do, say "Nothing to do" clearly.
-- When done, summarize what you did in 2-3 sentences.`;
-
-  const escapedPrompt = prompt.replace(/'/g, "'\\''");
-  const { CLAUDECODE: _cc2, ANTHROPIC_API_KEY: _ak2, ...cleanEnvAsync } = process.env;
-
-  return new Promise((resolve) => {
-    exec(
-      `claude --print --dangerously-skip-permissions --model ${resolvedModel} -- '${escapedPrompt}'`,
-      {
-        cwd: config.cwd || process.cwd(),
-        timeout: 15 * 60 * 1000,
-        maxBuffer: 10 * 1024 * 1024,
-        encoding: 'utf-8',
-        env: cleanEnvAsync,
-      },
-      (error: Error | null, stdout: string, _stderr: string) => {
-        if (stdout && stdout.trim().length > 0) {
-          resolve(stdout.trim());
-        } else if (error) {
-          resolve(`[ERROR] Agent ${agentName} failed: ${error.message || 'unknown error'}`);
-        } else {
-          resolve('[No output]');
-        }
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      const output = Buffer.concat(chunks).toString('utf-8').trim();
+      const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim();
+      // Detect quota hit — Claude returns this when rate limited
+      if (output.includes('hit your limit') || output.includes('rate limit')) {
+        resolve(`[QUOTA] ${agentName}: API limit reached`);
+      } else if (output.length > 0) {
+        resolve(output);
+      } else if (code !== 0) {
+        resolve(`[ERROR] ${agentName} exited with code ${code}${stderr ? ': ' + stderr.slice(0, 200) : ''}`);
+      } else {
+        resolve(`[${agentName} completed with no output]`);
       }
-    );
+    });
+
+    child.on('error', (err) => { clearTimeout(timeout); resolve(`[ERROR] ${agentName} failed to spawn: ${err.message}`); });
+    const timeout = setTimeout(() => { child.kill('SIGTERM'); resolve(`[ERROR] ${agentName} timed out after 8 minutes`); }, 8 * 60 * 1000);
   });
 }
 
 // =============================================================================
-// Conversation Orchestrator
+// Squad Workflow: Plan → Execute → Review → Verify
 // =============================================================================
 
 interface ClassifiedAgent {
@@ -232,23 +215,20 @@ interface ClassifiedAgent {
   path: string;
 }
 
-/**
- * Build the turn order for a squad conversation.
- * Returns agents grouped by role in execution order.
- */
-function buildTurnPlan(squad: Squad, squadsDir: string): ClassifiedAgent[] {
+function buildAgentRoster(squad: Squad, squadsDir: string): ClassifiedAgent[] {
+  // If squad defines conversation_agents, only include those in the conversation.
+  // Other agents run on their own schedules, not in the squad conversation.
+  const conversationFilter = squad.conversation_agents;
+
   const agents: ClassifiedAgent[] = [];
-
   for (const agent of squad.agents) {
+    if (conversationFilter && !conversationFilter.includes(agent.name)) continue;
     const role = classifyAgent(agent.name, agent.role);
-    if (!role) continue; // Unclassified agents are excluded
-
+    if (!role) continue;
     const agentPath = join(squadsDir, squad.dir, `${agent.name}.md`);
     if (!existsSync(agentPath)) continue;
-
     agents.push({ name: agent.name, role, path: agentPath });
   }
-
   return agents;
 }
 
@@ -261,15 +241,10 @@ export interface ConversationResult {
 }
 
 /**
- * Run a full squad conversation.
+ * Run a squad workflow: Plan → Execute → Review → Verify.
  *
- * Turn order per cycle:
- * 1. Lead briefs (or founder directive on first turn)
- * 2. Scanners discover (parallel-safe but run sequentially for simplicity)
- * 3. Workers execute
- * 4. Lead reviews
- * 5. Verifiers check (if workers produced output)
- * 6. Check convergence → loop or exit
+ * Lead plans within token budget, workers execute independently in parallel,
+ * lead reviews, verifier checks quality.
  */
 export async function runConversation(
   squad: Squad,
@@ -277,252 +252,365 @@ export async function runConversation(
 ): Promise<ConversationResult> {
   const squadsDir = findSquadsDir();
   if (!squadsDir) {
-    return {
-      transcript: createTranscript(squad.name),
-      turnCount: 0,
-      totalCost: 0,
-      converged: true,
-      reason: 'No squads directory found',
-    };
+    return { transcript: createTranscript(squad.name), turnCount: 0, totalCost: 0, converged: true, reason: 'No squads directory found' };
   }
 
-  const maxTurns = options.maxTurns || DEFAULT_MAX_TURNS;
+  const tokenBudget = options.tokenBudget || DEFAULT_TOKEN_BUDGET;
   const costCeiling = options.costCeiling || DEFAULT_COST_CEILING;
+  const maxTurns = options.maxTurns || 100;
   const transcript = createTranscript(squad.name);
 
-  // Resolve squad's working directory from repo field (e.g. "org/squads-cli" → sibling repo dir)
-  // squadsDir = /path/to/hq/.agents/squads → go up 3 levels to get parent of project root
+  // Resolve squad's working directory
   let squadCwd = process.cwd();
   if (squad.repo) {
     const repoName = squad.repo.split('/').pop();
     if (repoName) {
       const reposRoot = join(squadsDir, '..', '..', '..');
       const candidatePath = join(reposRoot, repoName);
-      if (existsSync(candidatePath)) {
-        squadCwd = candidatePath;
-      }
+      if (existsSync(candidatePath)) squadCwd = candidatePath;
     }
   }
 
-  // Classify all agents
-  const allAgents = buildTurnPlan(squad, squadsDir);
+  const allAgents = buildAgentRoster(squad, squadsDir);
   const leads = allAgents.filter(a => a.role === 'lead');
   const scanners = allAgents.filter(a => a.role === 'scanner');
   const workers = allAgents.filter(a => a.role === 'worker');
   const verifiers = allAgents.filter(a => a.role === 'verifier');
 
   if (leads.length === 0) {
-    return {
-      transcript,
-      turnCount: 0,
-      totalCost: 0,
-      converged: true,
-      reason: 'No lead agent found — cannot orchestrate conversation',
-    };
+    return { transcript, turnCount: 0, totalCost: 0, converged: true, reason: 'No lead agent found' };
   }
 
-  const lead = leads[0]; // Primary lead
-  const log = (msg: string) => {
-    if (options.verbose) {
-      const ts = new Date().toISOString().slice(11, 19);
-      process.stderr.write(`  [${ts}] ${msg}\n`);
-    }
-  };
+  const lead = leads[0];
+  const log = (msg: string) => writeLine(`  ${colors.dim}${msg}${RESET}`);
 
-  log(`Conversation: ${squad.name} | ${allAgents.length} agents | max ${maxTurns} turns | $${costCeiling} ceiling`);
-  log(`  Lead: ${lead.name} | Scanners: ${scanners.map(s => s.name).join(', ') || 'none'} | Workers: ${workers.map(w => w.name).join(', ') || 'none'} | Verifiers: ${verifiers.map(v => v.name).join(', ') || 'none'}`);
+  // Track timing and goals before cycle begins
+  const cycleStartMs = Date.now();
+  const executionId = generateExecutionId();
+  const goalsBefore = snapshotGoals(squad.name);
 
-  // === CYCLE LOOP ===
-  let cycleCount = 0;
-  const MAX_CYCLES = 5; // Safety: max 5 full cycles (lead→scan→work→review→verify)
+  log(`${squad.name}: ${allAgents.length} agents (${leads.length}L ${scanners.length}S ${workers.length}W ${verifiers.length}V) budget: ${Math.round(tokenBudget / 1000)}K tokens`);
 
-  while (cycleCount < MAX_CYCLES) {
-    cycleCount++;
-    log(`\n--- Cycle ${cycleCount} ---`);
+  // Build squad context once (shared by all agents)
+  const contextRole: ContextRole = lead.name.includes('company-lead') ? 'coo' : 'lead';
+  const squadContext = gatherSquadContext(squad.name, lead.name, {
+    agentPath: lead.path, role: contextRole,
+  });
 
-    // Step 1: Lead briefs
-    log(`Turn ${transcript.turns.length + 1}: ${lead.name} (lead)`);
-    const leadOutput = executeAgentTurn({
-      agentName: lead.name,
-      agentPath: lead.path,
-      role: 'lead',
-      squadName: squad.name,
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 1: PLAN — Lead scopes work within budget
+  // ═══════════════════════════════════════════════════════════════════
+
+  log(`  plan: ${lead.name}...`);
+
+  const workerNames = workers.map(w => w.name).join(', ') || '(no workers — do the work yourself)';
+  const scannerNames = scanners.map(s => s.name).join(', ');
+
+  // Load focus-specific instructions from .agents/config/cycle-focus.md
+  const focus = options.focus || 'create';
+  const focusInstructions = loadFocusPrompt(focus);
+
+  // Load plan prompt template from .agents/config/conversation-roles.md (Lead first turn)
+  // Focus instructions override the default planning behavior
+  const planPrompt = `You are ${lead.name} (lead) in squad ${squad.name}.
+
+Read your full agent definition at ${lead.path} and follow its instructions.
+
+## Cycle Focus: ${focus.toUpperCase()}
+
+${focusInstructions}
+
+## Budget
+
+${Math.round(tokenBudget / 1000)}K output tokens for the whole squad.
+Each worker task uses ~5-10K tokens. Max ${Math.floor(tokenBudget / 10000)} tasks.
+
+Available workers: ${workerNames}
+Available scanners: ${scannerNames || '(none)'}
+
+## Output Format
+
+\`\`\`plan
+GOAL: [which goal this cycle advances]
+TASKS:
+- worker: [worker-name] | task: [specific instruction with issue number or PR number]
+- worker: [worker-name] | task: [specific instruction]
+\`\`\`
+
+Then end with:
+## STATUS: CONTINUE
+
+${squadContext}`;
+
+  const planOutput = await runIndependentAgent({
+    agentName: lead.name, agentPath: lead.path, role: 'lead',
+    squadName: squad.name, model: options.model || modelForRole('lead'),
+    task: options.task ? `${options.task}\n\n${planPrompt}` : planPrompt, squadContext: '', cwd: squadCwd,
+  });
+  addTurn(transcript, lead.name, 'lead', planOutput, estimateTurnCost(options.model || 'sonnet'));
+
+  // Quota detection — if plan hit the API limit, stop immediately
+  if (planOutput.includes('[QUOTA]') || planOutput.includes('hit your limit')) {
+    logObservability({
+      ts: new Date().toISOString(),
+      id: executionId,
+      squad: squad.name,
+      agent: lead.name,
+      provider: 'anthropic',
       model: options.model || modelForRole('lead'),
-      transcript,
-      task: cycleCount === 1 ? options.task : undefined,
-      cwd: squadCwd,
+      trigger: 'scheduled',
+      status: 'failed',
+      duration_ms: Date.now() - cycleStartMs,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      cost_usd: transcript.totalCost,
+      context_tokens: 0,
+      error: 'Quota limit reached',
+      task: options.task,
     });
-    addTurn(transcript, lead.name, 'lead', leadOutput, estimateTurnCost(options.model || 'sonnet'));
+    return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: false, reason: 'Quota limit reached' };
+  }
 
-    // Check convergence after lead
-    let conv = detectConvergence(transcript, maxTurns, costCeiling);
-    if (conv.converged) {
-      log(`Converged after lead: ${conv.reason}`);
-      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
-    }
+  // Check if lead declared done immediately (nothing to do)
+  const conv = detectConvergence(transcript, maxTurns, costCeiling);
+  if (conv.converged) {
+    const goalsAfterEarly = snapshotGoals(squad.name);
+    const goalsChangedEarly = diffGoals(goalsBefore, goalsAfterEarly);
+    logObservability({
+      ts: new Date().toISOString(),
+      id: executionId,
+      squad: squad.name,
+      agent: lead.name,
+      provider: 'anthropic',
+      model: options.model || modelForRole('lead'),
+      trigger: 'scheduled',
+      status: 'completed',
+      duration_ms: Date.now() - cycleStartMs,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      cost_usd: transcript.totalCost,
+      context_tokens: 0,
+      task: options.task,
+      goals_before: Object.keys(goalsBefore).length > 0 ? goalsBefore : undefined,
+      goals_after: Object.keys(goalsAfterEarly).length > 0 ? goalsAfterEarly : undefined,
+      goals_changed: goalsChangedEarly.length > 0 ? goalsChangedEarly : undefined,
+    });
+    return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
+  }
 
-    // Step 2: Scanners (only on first cycle) — run in parallel
-    if (cycleCount === 1 && scanners.length > 0) {
-      if (scanners.length === 1) {
-        log(`Turn ${transcript.turns.length + 1}: ${scanners[0].name} (scanner)`);
-        const output = executeAgentTurn({
-          agentName: scanners[0].name,
-          agentPath: scanners[0].path,
-          role: 'scanner',
-          squadName: squad.name,
-          model: options.model || modelForRole('scanner'),
-          transcript,
-          cwd: squadCwd,
-        });
-        addTurn(transcript, scanners[0].name, 'scanner', output, estimateTurnCost(options.model || 'haiku'));
-      } else {
-        log(`Turns ${transcript.turns.length + 1}-${transcript.turns.length + scanners.length}: ${scanners.map(s => s.name).join(', ')} (scanners, parallel)`);
-        const scannerPromises = scanners.map(scanner =>
-          executeAgentTurnAsync({
-            agentName: scanner.name,
-            agentPath: scanner.path,
-            role: 'scanner',
-            squadName: squad.name,
-            model: options.model || modelForRole('scanner'),
-            transcript, // snapshot — all scanners see same context
-            cwd: squadCwd,
-          }).then(output => ({ agent: scanner, output }))
-        );
-        const scannerResults = await Promise.all(scannerPromises);
-        for (const { agent, output } of scannerResults) {
-          addTurn(transcript, agent.name, 'scanner', output, estimateTurnCost(options.model || 'haiku'));
-        }
-      }
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 2: EXECUTE — Workers run independently in parallel
+  // ═══════════════════════════════════════════════════════════════════
 
-      conv = detectConvergence(transcript, maxTurns, costCeiling);
-      if (conv.converged) {
-        return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
-      }
-    }
+  // Parse task assignments from lead's plan
+  const taskAssignments = parseTaskAssignments(planOutput, [...workers, ...scanners]);
 
-    // Step 3: Workers execute — run in parallel if multiple
-    if (workers.length === 1) {
-      log(`Turn ${transcript.turns.length + 1}: ${workers[0].name} (worker)`);
-      const output = executeAgentTurn({
-        agentName: workers[0].name,
-        agentPath: workers[0].path,
-        role: 'worker',
-        squadName: squad.name,
-        model: options.model || modelForRole('worker'),
-        transcript,
-        cwd: squadCwd,
-      });
+  if (taskAssignments.length === 0) {
+    // No tasks parsed — lead does the work directly
+    log(`  execute: no task assignments found, lead works directly`);
+    addTurn(transcript, lead.name, 'lead', '[Lead produced plan but no parseable task assignments. Lead should do the work directly in the review phase.]', estimateTurnCost('sonnet'));
+  } else {
+    log(`  execute: ${taskAssignments.length} tasks in parallel...`);
+
+    // Run all assigned workers in parallel
+    const workerPromises = taskAssignments.map(({ agent, task }) => {
+      log(`    ${agent.name}: ${task.slice(0, 60)}...`);
+      return runIndependentAgent({
+        agentName: agent.name, agentPath: agent.path, role: agent.role,
+        squadName: squad.name, model: options.model || modelForRole(agent.role),
+        task, squadContext, cwd: squadCwd,
+      }).then(output => ({ agent, output }));
+    });
+
+    const workerResults = await Promise.all(workerPromises);
+
+    for (const { agent, output } of workerResults) {
       if (output.startsWith('[ERROR]')) {
-        process.stderr.write(`  [WARN] Worker ${workers[0].name} errored: ${output}\n`);
+        writeLine(`  ${colors.yellow}[WARN] ${agent.name}: ${output.slice(0, 80)}${RESET}`);
       }
-      addTurn(transcript, workers[0].name, 'worker', output, estimateTurnCost(options.model || 'sonnet'));
-    } else if (workers.length > 1) {
-      log(`Turns ${transcript.turns.length + 1}-${transcript.turns.length + workers.length}: ${workers.map(w => w.name).join(', ')} (workers, parallel)`);
-      const workerPromises = workers.map(worker =>
-        executeAgentTurnAsync({
-          agentName: worker.name,
-          agentPath: worker.path,
-          role: 'worker',
-          squadName: squad.name,
-          model: options.model || modelForRole('worker'),
-          transcript, // snapshot — all workers see same context
-          cwd: squadCwd,
-        }).then(output => ({ agent: worker, output }))
-      );
-      const workerResults = await Promise.all(workerPromises);
-      for (const { agent, output } of workerResults) {
-        if (output.startsWith('[ERROR]')) {
-          process.stderr.write(`  [WARN] Worker ${agent.name} errored: ${output}\n`);
-        }
-        addTurn(transcript, agent.name, 'worker', output, estimateTurnCost(options.model || 'sonnet'));
-      }
-    }
-
-    conv = detectConvergence(transcript, maxTurns, costCeiling);
-    if (conv.converged) {
-      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
-    }
-
-    // Step 4: Lead reviews worker output
-    log(`Turn ${transcript.turns.length + 1}: ${lead.name} (lead review)`);
-    const reviewOutput = executeAgentTurn({
-      agentName: lead.name,
-      agentPath: lead.path,
-      role: 'lead',
-      squadName: squad.name,
-      model: options.model || modelForRole('lead'),
-      transcript,
-      cwd: squadCwd,
-    });
-    addTurn(transcript, lead.name, 'lead', reviewOutput, estimateTurnCost(options.model || 'sonnet'));
-
-    conv = detectConvergence(transcript, maxTurns, costCeiling);
-    if (conv.converged) {
-      return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
-    }
-
-    // Step 5: Verifiers — run in parallel if multiple
-    if (verifiers.length === 1) {
-      log(`Turn ${transcript.turns.length + 1}: ${verifiers[0].name} (verifier)`);
-      const output = executeAgentTurn({
-        agentName: verifiers[0].name,
-        agentPath: verifiers[0].path,
-        role: 'verifier',
-        squadName: squad.name,
-        model: options.model || modelForRole('verifier'),
-        transcript,
-        cwd: squadCwd,
-      });
-      addTurn(transcript, verifiers[0].name, 'verifier', output, estimateTurnCost(options.model || 'haiku'));
-    } else if (verifiers.length > 1) {
-      log(`Turns ${transcript.turns.length + 1}-${transcript.turns.length + verifiers.length}: ${verifiers.map(v => v.name).join(', ')} (verifiers, parallel)`);
-      const verifierPromises = verifiers.map(verifier =>
-        executeAgentTurnAsync({
-          agentName: verifier.name,
-          agentPath: verifier.path,
-          role: 'verifier',
-          squadName: squad.name,
-          model: options.model || modelForRole('verifier'),
-          transcript,
-          cwd: squadCwd,
-        }).then(output => ({ agent: verifier, output }))
-      );
-      const verifierResults = await Promise.all(verifierPromises);
-      for (const { agent, output } of verifierResults) {
-        addTurn(transcript, agent.name, 'verifier', output, estimateTurnCost(options.model || 'haiku'));
-      }
-    }
-
-    if (verifiers.length > 0) {
-      conv = detectConvergence(transcript, maxTurns, costCeiling);
-      if (conv.converged) {
-        return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: true, reason: conv.reason };
-      }
+      addTurn(transcript, agent.name, agent.role, output, estimateTurnCost(options.model || 'sonnet'));
     }
   }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 3: REVIEW — Lead evaluates worker output
+  // ═══════════════════════════════════════════════════════════════════
+
+  log(`  review: ${lead.name}...`);
+
+  const reviewPrompt = `Review the work done by your team. The conversation transcript shows what each worker produced.
+
+1. Check if workers actually committed code (PR numbers, commit SHAs)
+2. Merge PRs that are ready: \`gh pr merge --squash --delete-branch --auto\`
+3. Update goals.md if a goal was achieved
+4. Update state.md with what was accomplished
+
+End with:
+## STATUS: DONE
+Summary: [what was achieved]`;
+
+  const reviewOutput = await runIndependentAgent({
+    agentName: lead.name, agentPath: lead.path, role: 'lead',
+    squadName: squad.name, model: options.model || modelForRole('lead'),
+    task: reviewPrompt, squadContext: `${squadContext}\n\n${serializeTranscript(transcript)}`,
+    cwd: squadCwd,
+  });
+  addTurn(transcript, lead.name, 'lead', reviewOutput, estimateTurnCost(options.model || 'sonnet'));
+
+  // Goals.md staleness check — warn if goals were not updated during review
+  const goalsAfterReview = snapshotGoals(squad.name);
+  const goalsChangedInReview = diffGoals(goalsBefore, goalsAfterReview);
+  if (goalsChangedInReview.length === 0 && Object.keys(goalsBefore).length > 0) {
+    writeLine(`  ${colors.yellow}[WARN] ${squad.name}: goals.md not updated after review — lead should update goals when work is completed${RESET}`);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // PHASE 4: VERIFY — Quality gate
+  // ═══════════════════════════════════════════════════════════════════
+
+  if (verifiers.length > 0) {
+    const verifier = verifiers[0];
+    log(`  verify: ${verifier.name}...`);
+
+    const verifyPrompt = `Verify the work from this cycle. The transcript shows the plan and worker outputs.
+
+Check every PR and deliverable:
+1. Build: does it pass?
+2. Conflicts: is the PR mergeable?
+3. Review comments: are ALL automated review comments addressed?
+4. Correctness: does it match what the lead asked for?
+
+End with:
+## VERDICT: APPROVED (all checks pass)
+or
+## VERDICT: REJECTED (which check failed and why)`;
+
+    const verifyOutput = await runIndependentAgent({
+      agentName: verifier.name, agentPath: verifier.path, role: 'verifier',
+      squadName: squad.name, model: options.model || modelForRole('verifier'),
+      task: verifyPrompt, squadContext: `${squadContext}\n\n${serializeTranscript(transcript)}`,
+      cwd: squadCwd,
+    });
+    addTurn(transcript, verifier.name, 'verifier', verifyOutput, estimateTurnCost(options.model || 'haiku'));
+  }
+
+  // Determine final convergence
+  const finalConv = detectConvergence(transcript, maxTurns, costCeiling);
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Observability — log conversation cycle as a single record
+  // ═══════════════════════════════════════════════════════════════════
+
+  const cycleDurationMs = Date.now() - cycleStartMs;
+  const goalsAfterFinal = snapshotGoals(squad.name);
+  const goalsChanged = diffGoals(goalsBefore, goalsAfterFinal);
+
+  const obsRecord: ObservabilityRecord = {
+    ts: new Date().toISOString(),
+    id: executionId,
+    squad: squad.name,
+    agent: lead.name,
+    provider: 'anthropic',
+    model: options.model || modelForRole('lead'),
+    trigger: 'scheduled',
+    status: 'completed',
+    duration_ms: cycleDurationMs,
+    input_tokens: 0,   // token-level data not available from spawned agents
+    output_tokens: transcript.turns.length > 0 ? transcript.turns.reduce((acc, t) => acc + t.content.length, 0) : 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    cost_usd: transcript.totalCost,
+    context_tokens: 0,
+    task: options.task,
+    goals_before: Object.keys(goalsBefore).length > 0 ? goalsBefore : undefined,
+    goals_after: Object.keys(goalsAfterFinal).length > 0 ? goalsAfterFinal : undefined,
+    goals_changed: goalsChanged.length > 0 ? goalsChanged : undefined,
+  };
+  logObservability(obsRecord);
 
   return {
     transcript,
     turnCount: transcript.turns.length,
     totalCost: transcript.totalCost,
-    converged: false,
-    reason: `Max cycles reached (${MAX_CYCLES})`,
+    converged: finalConv.converged, // reflect actual convergence status
+    reason: finalConv.reason || 'Cycle complete (plan → execute → review → verify)',
   };
+}
+
+// =============================================================================
+// Task Assignment Parser
+// =============================================================================
+
+interface TaskAssignment {
+  agent: ClassifiedAgent;
+  task: string;
+}
+
+/**
+ * Parse task assignments from lead's plan output.
+ * Looks for patterns like:
+ *   - worker: worker-name | task: do something
+ *   - scanner: scanner-name | task: scan something
+ *   - Assigned: worker-name → do something
+ */
+function parseTaskAssignments(planOutput: string, availableAgents: ClassifiedAgent[]): TaskAssignment[] {
+  const assignments: TaskAssignment[] = [];
+  const lines = planOutput.split('\n');
+
+  for (const line of lines) {
+    // Pattern: "- worker: name | task: description"
+    const pipeMatch = line.match(/(?:worker|scanner|agent):\s*(\S+)\s*\|\s*task:\s*(.+)/i);
+    if (pipeMatch) {
+      const agentName = pipeMatch[1].trim();
+      const task = pipeMatch[2].trim();
+      const agent = availableAgents.find(a => a.name === agentName || a.name.includes(agentName) || agentName.includes(a.name));
+      if (agent && task) {
+        assignments.push({ agent, task });
+        continue;
+      }
+    }
+
+    // Pattern: "Assigned: name → description" or "- name: description"
+    const arrowMatch = line.match(/(?:assigned|assign):\s*(\S+)\s*[→→-]\s*(.+)/i);
+    if (arrowMatch) {
+      const agentName = arrowMatch[1].trim();
+      const task = arrowMatch[2].trim();
+      const agent = availableAgents.find(a => a.name === agentName || a.name.includes(agentName) || agentName.includes(a.name));
+      if (agent && task) {
+        assignments.push({ agent, task });
+        continue;
+      }
+    }
+  }
+
+  // If no assignments parsed but workers exist, assign all workers the lead's full plan
+  if (assignments.length === 0 && availableAgents.length > 0) {
+    const workers = availableAgents.filter(a => a.role === 'worker');
+    for (const worker of workers) {
+      assignments.push({
+        agent: worker,
+        task: `The lead produced this plan. Execute the most important task:\n\n${planOutput.slice(0, 3000)}`,
+      });
+    }
+  }
+
+  return assignments;
 }
 
 // =============================================================================
 // Transcript Persistence
 // =============================================================================
 
-/** Save conversation transcript to .agents/conversations/{squad}/ */
 export function saveTranscript(transcript: Transcript): string | null {
   const squadsDir = findSquadsDir();
   if (!squadsDir) return null;
 
   const convDir = join(squadsDir, '..', 'conversations', transcript.squad);
-  if (!existsSync(convDir)) {
-    mkdirSync(convDir, { recursive: true });
-  }
+  if (!existsSync(convDir)) mkdirSync(convDir, { recursive: true });
 
   const id = Date.now().toString(36);
   const filePath = join(convDir, `${id}.md`);
@@ -532,9 +620,7 @@ export function saveTranscript(transcript: Transcript): string | null {
     `Started: ${transcript.startedAt}`,
     `Turns: ${transcript.turns.length}`,
     `Estimated cost: $${transcript.totalCost.toFixed(2)}`,
-    '',
-    '---',
-    '',
+    '', '---', '',
   ];
 
   for (const turn of transcript.turns) {

--- a/templates/prompts/plan.md
+++ b/templates/prompts/plan.md
@@ -1,0 +1,29 @@
+You are {{LEAD_NAME}} (lead) in squad {{SQUAD_NAME}}.
+
+Read your full agent definition at {{LEAD_PATH}} and follow its instructions.
+
+## Cycle Focus: {{FOCUS}}
+
+{{FOCUS_INSTRUCTIONS}}
+
+## Budget
+
+{{BUDGET_K}}K output tokens for the whole squad.
+Each worker task uses ~5-10K tokens. Max {{MAX_TASKS}} tasks.
+
+Available workers: {{WORKERS}}
+Available scanners: {{SCANNERS}}
+
+## Output Format
+
+```plan
+GOAL: [which goal this cycle advances]
+TASKS:
+- worker: [worker-name] | task: [specific instruction with issue number or PR number]
+- worker: [worker-name] | task: [specific instruction]
+```
+
+Then end with:
+## STATUS: CONTINUE
+
+{{SQUAD_CONTEXT}}

--- a/test/lib/workflow.test.ts
+++ b/test/lib/workflow.test.ts
@@ -24,6 +24,7 @@ vi.mock('child_process', () => ({
 // Mock squad-parser
 vi.mock('../../src/lib/squad-parser.js', () => ({
   findSquadsDir: vi.fn(),
+  findProjectRoot: vi.fn().mockResolvedValue('/mock/root'),
 }));
 
 // Mock run-context to avoid file system reads in unit tests

--- a/test/lib/workflow.test.ts
+++ b/test/lib/workflow.test.ts
@@ -24,7 +24,7 @@ vi.mock('child_process', () => ({
 // Mock squad-parser
 vi.mock('../../src/lib/squad-parser.js', () => ({
   findSquadsDir: vi.fn(),
-  findProjectRoot: vi.fn().mockResolvedValue('/mock/root'),
+  findProjectRoot: vi.fn().mockReturnValue('/mock/root'),
 }));
 
 // Mock run-context to avoid file system reads in unit tests

--- a/test/lib/workflow.test.ts
+++ b/test/lib/workflow.test.ts
@@ -6,25 +6,50 @@
  * - saveTranscript: creates file, returns path, handles no squads dir
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// Helper: create a mock child process that emits output then closes
+function createMockChild(output: string, code = 0) {
+  const child = new EventEmitter() as any;
+  child.stdin = { write: vi.fn(), end: vi.fn() };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  // Emit output async so listeners are attached first
+  process.nextTick(() => {
+    if (output) child.stdout.emit('data', Buffer.from(output));
+    child.emit('close', code);
+  });
+  return child;
+}
 
 // Mock fs before import
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
-  readFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue(''),
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
+  appendFileSync: vi.fn(),
 }));
 
-// Mock child_process before import
+// Mock child_process before import — workflow.ts uses spawn for agent execution
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
   exec: vi.fn(),
+  spawn: vi.fn(),
 }));
 
 // Mock squad-parser
 vi.mock('../../src/lib/squad-parser.js', () => ({
   findSquadsDir: vi.fn(),
   findProjectRoot: vi.fn().mockReturnValue('/mock/root'),
+}));
+
+// Mock observability to avoid file system reads
+vi.mock('../../src/lib/observability.js', () => ({
+  logObservability: vi.fn(),
+  snapshotGoals: vi.fn().mockReturnValue({}),
+  diffGoals: vi.fn().mockReturnValue([]),
 }));
 
 // Mock run-context to avoid file system reads in unit tests
@@ -42,7 +67,7 @@ vi.mock('../../src/lib/conversation.js', async () => {
 });
 
 import { existsSync, writeFileSync, mkdirSync } from 'fs';
-import { execSync } from 'child_process';
+import { spawn } from 'child_process';
 import { findSquadsDir } from '../../src/lib/squad-parser.js';
 import { runConversation, saveTranscript } from '../../src/lib/workflow.js';
 import { createTranscript, addTurn } from '../../src/lib/conversation.js';
@@ -51,7 +76,7 @@ import type { Squad } from '../../src/lib/squad-parser.js';
 const mockExistsSync = vi.mocked(existsSync);
 const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockMkdirSync = vi.mocked(mkdirSync);
-const mockExecSync = vi.mocked(execSync);
+const mockSpawn = vi.mocked(spawn);
 const mockFindSquadsDir = vi.mocked(findSquadsDir);
 
 // Minimal squad fixture
@@ -106,7 +131,7 @@ describe('runConversation', () => {
     mockExistsSync.mockReturnValue(true); // agent file exists
 
     // Lead outputs a convergence phrase immediately
-    mockExecSync.mockReturnValue('Session complete. All PRs merged.' as never);
+    mockSpawn.mockImplementation(() => createMockChild('Session complete. All PRs merged.') as any);
 
     const squad = makeSquad({
       agents: [{ name: 'squad-lead', role: 'orchestrates the team', model: undefined }],
@@ -122,7 +147,7 @@ describe('runConversation', () => {
     mockExistsSync.mockReturnValue(true);
 
     // Each lead turn produces non-convergent output but we set very low cost ceiling
-    mockExecSync.mockReturnValue('Still working on it.' as never);
+    mockSpawn.mockImplementation(() => createMockChild('Still working on it.') as any);
 
     const squad = makeSquad({
       agents: [{ name: 'squad-lead', role: 'orchestrates the team', model: undefined }],
@@ -143,7 +168,7 @@ describe('runConversation', () => {
     mockExistsSync.mockReturnValue(true);
 
     // Each turn produces non-convergent output with no cost (free)
-    mockExecSync.mockImplementation(() => 'Still working on it.' as never);
+    mockSpawn.mockImplementation(() => createMockChild('Still working on it.') as any);
 
     const squad = makeSquad({
       agents: [{ name: 'squad-lead', role: 'orchestrates the team', model: undefined }],
@@ -164,9 +189,10 @@ describe('runConversation', () => {
     mockExistsSync.mockReturnValue(true);
 
     const capturedPrompts: string[] = [];
-    mockExecSync.mockImplementation((cmd: string) => {
-      capturedPrompts.push(cmd);
-      return 'Session complete.' as never;
+    mockSpawn.mockImplementation(() => {
+      const child = createMockChild('Session complete.');
+      child.stdin.write = vi.fn((data: string) => { capturedPrompts.push(data); return true; });
+      return child as any;
     });
 
     const squad = makeSquad({
@@ -191,7 +217,7 @@ describe('runConversation', () => {
       return false;
     });
 
-    mockExecSync.mockReturnValue('Session complete.' as never);
+    mockSpawn.mockImplementation(() => createMockChild('Session complete.') as any);
 
     const squad = makeSquad({
       repo: 'agents-squads/squads-cli',
@@ -207,7 +233,7 @@ describe('runConversation', () => {
     mockFindSquadsDir.mockReturnValue('/fake/.agents/squads');
     mockExistsSync.mockReturnValue(true);
 
-    mockExecSync.mockReturnValue('Session complete.' as never);
+    mockSpawn.mockImplementation(() => createMockChild('Session complete.') as any);
 
     const squad = makeSquad({
       agents: [


### PR DESCRIPTION
## Summary — PR 2 of 7 for v0.3.0 release
Run engine and workflow rewrite. The core execution pipeline.

## Changes (2 files, major)
- **run.ts** (+255 lines): `--force`, `--focus`, `--resume` flags. Org cycle coordination. Wave-based parallel execution. Quota detection. Worker timeout. Goal/directive injection.
- **workflow.ts** (rewritten): Plan/execute/review/verify phases with token budget. Auto-compact transcript. Convergence detection (STATUS/VERDICT). Cap transcript turns at 8K chars. Role-based tool sets. SYSTEM.md as immutable Layer 1.

## Merge order
Depends on PR #731 (core-refactor). Merge second:
1. ✅ core-refactor (#731)
2. **→ run-engine** (this PR)
3. conversation
4. new-commands
5. init-ux
6. security-guardrails
7. tests-docs

## Test plan
- [x] `npm run build` passes
- [ ] Review workflow state machine for correctness
- [ ] Review quota detection logic

Reorganized from 219-commit develop branch for proper review.