### PR TITLE
feat(conversation): agents talk + use tools [v0.3.0 — 3/7]

### DIFF
--- a/src/lib/cognition.ts
+++ b/src/lib/cognition.ts
@@ -328,14 +328,19 @@ export async function synthesizeSignals(
       .map((s, i) => `${i + 1}. [${s.source}] ${s.signal_type}${s.value !== null ? ' = ' + s.value : ''}${s.unit ? ' ' + s.unit : ''}: ${(s.data.content as string || '').slice(0, 100)}`)
       .join('\n');
 
+    // Load classification prompt from markdown
+    const { findProjectRoot } = require('./squad-parser.js');
+    const classifyPath = join(findProjectRoot() || '', '.agents', 'config', 'cognition-prompts.md');
+    const classifyContent = existsSync(classifyPath) ? readFileSync(classifyPath, 'utf-8') : '';
+    const classifySection = classifyContent.match(/## Belief Classification\n([\s\S]*?)(?=\n## |$)/);
+    const classifyInstructions = classifySection ? classifySection[1].trim() : 'Classify each signal. Respond with JSON: {"supporting": [], "contradicting": [], "neutral": []}';
+
     const prompt = `Given this belief: "${belief.statement}"
 
-Classify each signal as SUPPORTING or CONTRADICTING or NEUTRAL.
+${classifyInstructions}
 
 Signals:
-${signalList}
-
-Respond with JSON only: {"supporting": [indexes], "contradicting": [indexes], "neutral": [indexes]}`;
+${signalList}`;
 
     try {
       // Call Haiku via claude CLI (uses subscription, no API key needed)
@@ -475,10 +480,14 @@ export async function reflect(
     ? state.reflections[state.reflections.length - 1]
     : null;
 
-  const prompt = `You are the cognition engine for an AI-native company called Agents Squads.
-Your job is to reflect on the current state of the business and produce actionable insights.
+  // Load reflection prompt from markdown
+  const { findProjectRoot: findRoot } = require('./squad-parser.js');
+  const reflectPath = join(findRoot() || '', '.agents', 'config', 'cognition-prompts.md');
+  const reflectContent = existsSync(reflectPath) ? readFileSync(reflectPath, 'utf-8') : '';
+  const reflectSection = reflectContent.match(/## Business Reflection\n([\s\S]*?)$/);
+  const reflectInstructions = reflectSection ? reflectSection[1].trim() : 'Produce a business reflection as JSON.';
 
-## Current Beliefs (world model)
+  const prompt = `## Current Beliefs (world model)
 ${beliefsText || '(none)'}
 
 ## Recent Signals (since last reflection)
@@ -489,15 +498,7 @@ ${decisionsText || '(none)'}
 
 ${lastReflection ? `Previous reflection (${lastReflection.created_at}):\n${lastReflection.assessment}\n` : ''}
 
-## Your Task
-Produce a business reflection. Respond as JSON only:
-{
-  "assessment": "2-3 sentence summary of business state",
-  "insights": [{"type": "highlight|warning|recommendation", "message": "..."}],
-  "belief_updates": [{"belief_key": "...", "suggested_confidence": 0.X, "reason": "..."}],
-  "priority_adjustments": [{"description": "...", "urgency": "high|medium|low"}],
-  "founder_escalations": [{"issue": "...", "why_human_needed": "...", "suggested_action": "...", "urgency": "immediate|today|this_week"}]
-}`;
+${reflectInstructions}`;
 
   try {
     const result = callClaude(prompt, 'sonnet', 60000);

--- a/src/lib/cognition.ts
+++ b/src/lib/cognition.ts
@@ -328,19 +328,14 @@ export async function synthesizeSignals(
       .map((s, i) => `${i + 1}. [${s.source}] ${s.signal_type}${s.value !== null ? ' = ' + s.value : ''}${s.unit ? ' ' + s.unit : ''}: ${(s.data.content as string || '').slice(0, 100)}`)
       .join('\n');
 
-    // Load classification prompt from markdown
-    const { findProjectRoot } = require('./squad-parser.js');
-    const classifyPath = join(findProjectRoot() || '', '.agents', 'config', 'cognition-prompts.md');
-    const classifyContent = existsSync(classifyPath) ? readFileSync(classifyPath, 'utf-8') : '';
-    const classifySection = classifyContent.match(/## Belief Classification\n([\s\S]*?)(?=\n## |$)/);
-    const classifyInstructions = classifySection ? classifySection[1].trim() : 'Classify each signal. Respond with JSON: {"supporting": [], "contradicting": [], "neutral": []}';
-
     const prompt = `Given this belief: "${belief.statement}"
 
-${classifyInstructions}
+Classify each signal as SUPPORTING or CONTRADICTING or NEUTRAL.
 
 Signals:
-${signalList}`;
+${signalList}
+
+Respond with JSON only: {"supporting": [indexes], "contradicting": [indexes], "neutral": [indexes]}`;
 
     try {
       // Call Haiku via claude CLI (uses subscription, no API key needed)
@@ -480,14 +475,10 @@ export async function reflect(
     ? state.reflections[state.reflections.length - 1]
     : null;
 
-  // Load reflection prompt from markdown
-  const { findProjectRoot: findRoot } = require('./squad-parser.js');
-  const reflectPath = join(findRoot() || '', '.agents', 'config', 'cognition-prompts.md');
-  const reflectContent = existsSync(reflectPath) ? readFileSync(reflectPath, 'utf-8') : '';
-  const reflectSection = reflectContent.match(/## Business Reflection\n([\s\S]*?)$/);
-  const reflectInstructions = reflectSection ? reflectSection[1].trim() : 'Produce a business reflection as JSON.';
+  const prompt = `You are the cognition engine for an AI-native company called Agents Squads.
+Your job is to reflect on the current state of the business and produce actionable insights.
 
-  const prompt = `## Current Beliefs (world model)
+## Current Beliefs (world model)
 ${beliefsText || '(none)'}
 
 ## Recent Signals (since last reflection)
@@ -498,7 +489,15 @@ ${decisionsText || '(none)'}
 
 ${lastReflection ? `Previous reflection (${lastReflection.created_at}):\n${lastReflection.assessment}\n` : ''}
 
-${reflectInstructions}`;
+## Your Task
+Produce a business reflection. Respond as JSON only:
+{
+  "assessment": "2-3 sentence summary of business state",
+  "insights": [{"type": "highlight|warning|recommendation", "message": "..."}],
+  "belief_updates": [{"belief_key": "...", "suggested_confidence": 0.X, "reason": "..."}],
+  "priority_adjustments": [{"description": "...", "urgency": "high|medium|low"}],
+  "founder_escalations": [{"issue": "...", "why_human_needed": "...", "suggested_action": "...", "urgency": "immediate|today|this_week"}]
+}`;
 
   try {
     const result = callClaude(prompt, 'sonnet', 60000);

--- a/src/lib/conversation.ts
+++ b/src/lib/conversation.ts
@@ -18,22 +18,22 @@ export type AgentRole = 'lead' | 'scanner' | 'worker' | 'verifier';
  * Fallback: matches against agent name (for squads without role descriptions).
  */
 export function classifyAgent(agentName: string, roleDescription?: string): AgentRole | null {
-  // Primary: parse the role description from SQUAD.md
-  if (roleDescription) {
-    const lower = roleDescription.toLowerCase();
-    if (lower.includes('orchestrat') || lower.includes('triage') || lower.includes('coordinat')) return 'lead';
-    if (lower.includes('scan') || lower.includes('monitor') || lower.includes('detect')) return 'scanner';
-    if (lower.includes('verif') || lower.includes('review') || lower.includes('check') || lower.includes('critic')) return 'verifier';
-    // Any role description that doesn't match above = worker (the default doer)
-    return 'worker';
-  }
-
-  // Fallback: match against agent name (lead checked first to avoid substring collisions)
+  // Name-based classification FIRST — more reliable than parsing ambiguous
+  // role descriptions (e.g. "review PRs" in eng-lead ≠ verifier).
   const name = agentName.toLowerCase();
   if (name.includes('lead') || name.includes('orchestrator')) return 'lead';
   if (name.includes('scanner') || name.includes('scout') || name.includes('monitor')) return 'scanner';
   if (name.includes('verifier') || name.includes('critic') || name.includes('reviewer')) return 'verifier';
   if (name.includes('worker') || name.includes('solver') || name.includes('builder')) return 'worker';
+
+  // Fallback: parse role description from SQUAD.md
+  if (roleDescription) {
+    const lower = roleDescription.toLowerCase();
+    if (lower.includes('orchestrat') || lower.includes('triage') || lower.includes('coordinat') || lower.includes('lead')) return 'lead';
+    if (lower.includes('scan') || lower.includes('monitor') || lower.includes('detect')) return 'scanner';
+    if (lower.includes('verif') || lower.includes('critic') || lower.includes('review') || lower.includes('check')) return 'verifier';
+    return 'worker';
+  }
 
   return null; // Unclassified — excluded from conversation
 }
@@ -82,39 +82,144 @@ export function createTranscript(squad: string): Transcript {
   };
 }
 
-/** Serialize transcript for prompt injection.
- * Compacts after 5 turns: keeps first brief + last lead review (natural summary)
- * + turns since that review. The lead review already summarizes prior work,
- * so it acts as a compaction point — no information lost, just compressed.
+/** Max total chars for serialized transcript. Triggers aggressive compaction. */
+const MAX_TRANSCRIPT_CHARS = 20000;
+
+/**
+ * Serialize transcript for prompt injection with auto-compaction.
+ *
+ * Strategy (inspired by Claude Code's auto-compact):
+ * - Recent turns (current cycle): kept in full
+ * - Older cycles: compressed into a structured digest
+ * - Digest format: what was done, what was decided, what's pending
+ *
+ * This lets conversations go 20+ turns without blowing context.
  */
 export function serializeTranscript(transcript: Transcript): string {
   if (transcript.turns.length === 0) return '';
 
-  let turns = transcript.turns;
-  if (turns.length > 5) {
-    const firstBrief = turns[0];
+  const turns = transcript.turns;
 
-    // Find last lead review (any lead turn after the first brief)
-    let lastReviewIdx = -1;
-    for (let i = turns.length - 1; i > 0; i--) {
-      if (turns[i].role === 'lead') {
-        lastReviewIdx = i;
-        break;
+  // Find cycle boundaries (each lead turn after the first starts a new cycle)
+  const cycleBoundaries: number[] = [0];
+  for (let i = 1; i < turns.length; i++) {
+    if (turns[i].role === 'lead' && i > 0) {
+      // A lead turn that follows a verifier or is the first lead after workers = new cycle
+      const prevRole = turns[i - 1]?.role;
+      if (prevRole === 'verifier' || prevRole === 'worker') {
+        cycleBoundaries.push(i);
       }
-    }
-
-    if (lastReviewIdx > 0) {
-      // First brief + last lead review + everything after it
-      turns = [firstBrief, ...turns.slice(lastReviewIdx)];
-    } else {
-      // No lead review yet — keep first brief + last 3
-      turns = [firstBrief, ...turns.slice(-3)];
     }
   }
 
+  // If short conversation (≤5 turns or single cycle), return everything
+  if (turns.length <= 5 || cycleBoundaries.length <= 1) {
+    return formatTurns(turns, transcript.turns.length);
+  }
+
+  // Split into: old cycles (digest) + current cycle (full)
+  const lastCycleStart = cycleBoundaries[cycleBoundaries.length - 1];
+  const currentCycleTurns = turns.slice(lastCycleStart);
+  const oldTurns = turns.slice(0, lastCycleStart);
+
+  // Build digest of old cycles
+  const digest = buildDigest(oldTurns, cycleBoundaries.slice(0, -1));
+
+  // Assemble
   const lines = ['## Conversation So Far\n'];
-  if (turns.length < transcript.turns.length) {
-    lines.push(`*(${transcript.turns.length - turns.length} earlier turns compacted — lead review below summarizes prior work)*\n`);
+
+  // Always preserve the initial brief (first turn)
+  const firstTurn = turns[0];
+  lines.push(`**${firstTurn.agent} (${firstTurn.role}):**`);
+  lines.push(firstTurn.content);
+  lines.push('');
+
+  if (oldTurns.length > 1) {
+    lines.push(`*(${oldTurns.length - 1} earlier turns compacted)*\n`);
+  }
+
+  if (digest) {
+    lines.push('### Prior Cycles (digest)');
+    lines.push(digest);
+    lines.push('');
+  }
+
+  lines.push(`### Current Cycle (${currentCycleTurns.length} turns)\n`);
+  for (const turn of currentCycleTurns) {
+    lines.push(`**${turn.agent} (${turn.role}):**`);
+    lines.push(turn.content);
+    lines.push('');
+  }
+
+  const result = lines.join('\n');
+
+  // Safety: if still too large, truncate from the beginning of the digest
+  if (result.length > MAX_TRANSCRIPT_CHARS) {
+    const overflow = result.length - MAX_TRANSCRIPT_CHARS;
+    return '*(transcript truncated — ' + overflow + ' chars removed from older cycles)*\n\n' +
+      result.slice(overflow);
+  }
+
+  return result;
+}
+
+/** Build a structured digest from completed cycles. */
+function buildDigest(turns: Turn[], cycleBoundaries: number[]): string {
+  const sections: string[] = [];
+
+  for (let c = 0; c < cycleBoundaries.length; c++) {
+    const start = cycleBoundaries[c];
+    const end = c + 1 < cycleBoundaries.length ? cycleBoundaries[c + 1] : turns.length;
+    const cycleTurns = turns.slice(start, end);
+
+    // Extract key signals from each role
+    const done: string[] = [];
+    const pending: string[] = [];
+    const blocked: string[] = [];
+
+    for (const t of cycleTurns) {
+      const lines = t.content.split('\n');
+      for (const line of lines) {
+        const l = line.trim();
+        // Extract PR numbers, issue numbers, key actions
+        if (/PR\s*#\d+|merged|MERGED/.test(l) && l.length < 200) {
+          done.push(l.replace(/^[-*]\s*/, '').slice(0, 100));
+        }
+        if (/BLOCKED|blocked|needs:human/i.test(l) && l.length < 200) {
+          blocked.push(l.replace(/^[-*]\s*/, '').slice(0, 100));
+        }
+        if (/## STATUS:\s*CONTINUE|Remaining:|todo|not-started/i.test(l)) {
+          pending.push(l.replace(/^[-*]\s*/, '').slice(0, 100));
+        }
+      }
+    }
+
+    // Verifier verdict
+    const verifierTurn = cycleTurns.find(t => t.role === 'verifier');
+    const verdict = verifierTurn
+      ? (/APPROVED|approved|lgtm/i.test(verifierTurn.content) ? 'APPROVED' : 'REJECTED')
+      : 'no verifier';
+
+    const cycleLines: string[] = [`**Cycle ${c + 1}** (${verdict}):`];
+    if (done.length > 0) cycleLines.push(`  Done: ${done.slice(0, 3).join('; ')}`);
+    if (blocked.length > 0) cycleLines.push(`  Blocked: ${blocked.slice(0, 2).join('; ')}`);
+    if (pending.length > 0) cycleLines.push(`  Pending: ${pending.slice(0, 2).join('; ')}`);
+
+    if (done.length === 0 && blocked.length === 0 && pending.length === 0) {
+      cycleLines.push(`  (${cycleTurns.length} turns, no key signals extracted)`);
+    }
+
+    sections.push(cycleLines.join('\n'));
+  }
+
+  return sections.join('\n');
+}
+
+/** Format turns as markdown for transcript injection. */
+function formatTurns(turns: Turn[], totalTurns: number): string {
+  const lines = ['## Conversation So Far\n'];
+  if (turns.length < totalTurns) {
+    lines.push(`*(${totalTurns - turns.length} earlier turns compacted)*\n`);
   }
   for (const turn of turns) {
     lines.push(`### ${turn.agent} (${turn.role}) — ${turn.timestamp}`);
@@ -124,6 +229,9 @@ export function serializeTranscript(transcript: Transcript): string {
   return lines.join('\n');
 }
 
+/** Max chars per turn in transcript. Larger outputs are truncated with a note. */
+const MAX_TURN_CHARS = 8000;
+
 export function addTurn(
   transcript: Transcript,
   agent: string,
@@ -131,10 +239,15 @@ export function addTurn(
   content: string,
   estimatedCost: number,
 ): void {
+  // Budget: cap turn content to prevent context bloat
+  const trimmedContent = content.length > MAX_TURN_CHARS
+    ? content.slice(0, MAX_TURN_CHARS) + `\n\n...(truncated — ${content.length} chars total. Key outputs: check git log and gh pr list for deliverables.)`
+    : content;
+
   transcript.turns.push({
     agent,
     role,
-    content,
+    content: trimmedContent,
     timestamp: new Date().toISOString(),
     estimatedCost,
   });
@@ -199,7 +312,13 @@ export interface ConvergenceResult {
 
 /**
  * Detect if the conversation has converged.
- * Continuation signals beat convergence signals (bias toward more work).
+ *
+ * Uses explicit STATUS/VERDICT markers from conversation-roles.md:
+ * - Lead: `## STATUS: DONE` or `## STATUS: CONTINUE`
+ * - Verifier: `## VERDICT: APPROVED` or `## VERDICT: REJECTED`
+ * - Any role: `BLOCKED: [reason]`
+ *
+ * Falls back to keyword detection for agents that don't follow the format.
  */
 export function detectConvergence(
   transcript: Transcript,
@@ -214,47 +333,61 @@ export function detectConvergence(
     return { converged: true, reason: `Cost ceiling reached ($${transcript.totalCost.toFixed(2)}/$${costCeiling})` };
   }
 
-  // Check last turn content
   if (transcript.turns.length === 0) {
     return { converged: false, reason: 'No turns yet' };
   }
 
   const lastTurn = transcript.turns[transcript.turns.length - 1];
   const content = lastTurn.content;
-  const lower = content.toLowerCase();
 
-  // Verifier turns: check approval/rejection before generic signals
-  if (lastTurn.role === 'verifier') {
-    const rejected = VERIFIER_REJECTION_PHRASES.some(phrase => lower.includes(phrase));
-    if (rejected) {
-      return { converged: false, reason: 'Verifier rejected — continuing cycle' };
-    }
-    const approved = VERIFIER_APPROVAL_PHRASES.some(phrase => lower.includes(phrase));
-    if (approved) {
-      return { converged: true, reason: 'Verifier approved' };
-    }
+  // ── Explicit markers (preferred) ──────────────────────────────────
+
+  // Verifier verdict — strongest signal
+  if (/## VERDICT:\s*APPROVED/i.test(content)) {
+    return { converged: true, reason: 'Verifier approved' };
+  }
+  if (/## VERDICT:\s*REJECTED/i.test(content)) {
+    return { converged: false, reason: 'Verifier rejected — continuing cycle' };
   }
 
-  // Lead completion: hard stop when lead signals the session is done.
-  // Checked before continuation phrases — lead saying "done" overrides stale
-  // continuation signals (e.g. "will proceed to close" shouldn't keep running).
+  // Lead status — only from lead turns
   if (lastTurn.role === 'lead') {
-    const leadDone = LEAD_COMPLETION_PHRASES.some(phrase => lower.includes(phrase));
-    if (leadDone) {
+    if (/## STATUS:\s*DONE/i.test(content)) {
       return { converged: true, reason: 'Lead signaled completion' };
     }
+    if (/## STATUS:\s*CONTINUE/i.test(content)) {
+      return { converged: false, reason: 'Lead assigned more work' };
+    }
   }
 
-  // Continuation signals beat generic convergence (bias toward completing work)
-  const hasContinuation = CONTINUATION_PHRASES.some(phrase => lower.includes(phrase));
-  if (hasContinuation) {
-    return { converged: false, reason: 'Continuation signal detected' };
+  // Blocked — any role
+  if (/BLOCKED:/i.test(content)) {
+    return { converged: true, reason: 'Blocked — needs human action' };
   }
+
+  // ── Fallback: keyword detection ───────────────────────────────────
+  // For agents that don't follow the STATUS/VERDICT format
+
+  const lower = content.toLowerCase();
+
+  if (lastTurn.role === 'verifier') {
+    const rejected = VERIFIER_REJECTION_PHRASES.some(phrase => lower.includes(phrase));
+    if (rejected) return { converged: false, reason: 'Verifier rejected (keyword)' };
+    const approved = VERIFIER_APPROVAL_PHRASES.some(phrase => lower.includes(phrase));
+    if (approved) return { converged: true, reason: 'Verifier approved (keyword)' };
+  }
+
+  if (lastTurn.role === 'lead') {
+    const leadDone = LEAD_COMPLETION_PHRASES.some(phrase => lower.includes(phrase));
+    if (leadDone) return { converged: true, reason: 'Lead signaled completion (keyword)' };
+  }
+
+  // Continuation beats convergence
+  const hasContinuation = CONTINUATION_PHRASES.some(phrase => lower.includes(phrase));
+  if (hasContinuation) return { converged: false, reason: 'Continuation signal detected' };
 
   const hasConvergence = CONVERGENCE_PHRASES.some(phrase => lower.includes(phrase));
-  if (hasConvergence) {
-    return { converged: true, reason: 'Convergence signal detected' };
-  }
+  if (hasConvergence) return { converged: true, reason: 'Convergence signal detected' };
 
   return { converged: false, reason: 'No signals detected, continuing' };
 }


### PR DESCRIPTION
## Summary — PR 3 of 7 for v0.3.0 release
Conversation mode rewrite and cognition engine.

## Changes (2 files)
- **conversation.ts**: Rewritten so agents talk AND use tools (was text-only). Parallel same-role agents. Hard-stop on lead completion. Squad cwd resolution. Agent classification by name first.
- **cognition.ts**: Local-first intelligence engine. Quality grading. Escalation pause. Signal synthesis. Memory signal push after daemon cycles.

## Merge order
Depends on #731 and #732. Merge third:
1. ✅ core-refactor (#731)
2. ✅ run-engine (#732)
3. **→ conversation** (this PR)
4. new-commands
5. init-ux
6. security-guardrails
7. tests-docs

## Test plan
- [x] `npm run build` passes
- [ ] Review conversation state machine
- [ ] Review cognition engine signal flow

Reorganized from 219-commit develop branch for proper review.