### PR TITLE
feat(commands): review, credentials, goals, log + minor fixes [v0.3.0 — 4/7]

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,9 @@ import { registerReleaseCommands } from './commands/release-check.js';
 import { registerObservabilityCommands } from './commands/observability.js';
 import { registerTierCommand } from './commands/tier.js';
 import { registerServicesCommands } from './commands/services.js';
+import { registerGoalsCommand } from './commands/goals.js';
+import { registerCredentialsCommand } from './commands/credentials.js';
+import { registerReviewCommand } from './commands/review.js';
 
 // All other command handlers are lazy-loaded via dynamic import() inside
 // action handlers. Only the invoked command's dependencies are loaded,
@@ -309,6 +312,9 @@ program
   .option('--phased', 'Autopilot: use dependency-based phase ordering (from SQUAD.md depends_on)')
   .option('--no-eval', 'Skip post-run COO evaluation')
   .option('--org', 'Run all squads as a coordinated org cycle (scan → plan → execute → report)')
+  .option('--force', 'Force re-run squads that already completed today')
+  .option('--resume', 'Resume org cycle from where quota stopped it')
+  .option('--focus <mode>', 'Cycle focus: create, resolve, review, ship, research, cost (default: create)')
   .addHelpText('after', `
 Examples:
   $ squads run engineering              Run squad conversation (lead → scan → work → review)
@@ -407,6 +413,28 @@ exec.action(async (options) => {
   const { execListCommand } = await import('./commands/exec.js');
   return execListCommand(options);
 });
+
+// Log command - run history from observability JSONL
+program
+  .command('log')
+  .description('Show run history with timestamps, duration, and status')
+  .option('-s, --squad <squad>', 'Filter by squad')
+  .option('-a, --agent <agent>', 'Filter by agent')
+  .option('-n, --limit <n>', 'Number of runs to show (default: 20)', '20')
+  .option('--since <date>', 'Show runs since date (e.g. 7d, 2026-04-01)')
+  .option('-j, --json', 'Output as JSON')
+  .addHelpText('after', `
+Examples:
+  $ squads log                     Show last 20 runs
+  $ squads log --squad product     Filter by squad
+  $ squads log --limit 50          Show last 50 runs
+  $ squads log --since 7d          Runs in last 7 days
+  $ squads log --json              Machine-readable output
+`)
+  .action(async (options) => {
+    const { logCommand } = await import('./commands/log.js');
+    return logCommand({ ...options, limit: parseInt(options.limit, 10) });
+  });
 
 // ─── Understand (situational awareness) ──────────────────────────────────────
 
@@ -1058,6 +1086,9 @@ registerReleaseCommands(program);
 registerObservabilityCommands(program);
 registerTierCommand(program);
 registerServicesCommands(program);
+registerGoalsCommand(program);
+registerCredentialsCommand(program);
+registerReviewCommand(program);
 
 // Providers command - show LLM CLI availability for multi-LLM support
 program

--- a/src/commands/catalog.ts
+++ b/src/commands/catalog.ts
@@ -25,7 +25,8 @@ function noIdp(): boolean {
 export function registerCatalogCommands(program: Command): void {
   const catalog = program
     .command('catalog')
-    .description('Service catalog — browse, inspect, and validate services');
+    .description('Service catalog — browse, inspect, and validate services')
+    .action(() => { catalog.outputHelp(); });
 
   // ── catalog list ──
   catalog

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -386,20 +386,9 @@ export async function contextPromptCommand(
 
   const agentPath = `.agents/squads/${squadName}/${options.agent}.md`;
 
-  // Build the prompt for Claude
-  const prompt = `Execute the ${options.agent} agent from squad ${squadName}.
-
-Read the agent definition at ${agentPath} and follow its instructions exactly.
-
-CRITICAL INSTRUCTIONS:
-- Work autonomously - do NOT ask clarifying questions
-- Use Task tool to spawn sub-agents when needed
-- Output findings to GitHub issues (gh issue create)
-- Output code changes as PRs (gh pr create)
-- Update memory files in .agents/memory/${squadName}/${options.agent}/
-- Type /exit when done
-
-Begin now.`;
+  // Prompt: identity + agent path only. All instructions in SYSTEM.md and agent.md.
+  const prompt = `You are ${options.agent} from squad ${squadName}.
+Read your agent definition at ${agentPath} and your context layers. Execute your goals.`;
 
   if (options.json) {
     console.log(JSON.stringify({

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -1,0 +1,373 @@
+/**
+ * squads credentials — manage per-squad GCP service accounts and credentials.
+ *
+ * Creates, rotates, lists, and revokes service accounts so agents
+ * can access the APIs they need without founder intervention.
+ */
+
+import { Command } from 'commander';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync } from 'fs';
+import { join, basename } from 'path';
+import { findSquadsDir } from '../lib/squad-parser.js';
+import { colors, bold, RESET, writeLine, icons } from '../lib/terminal.js';
+import { homedir } from 'os';
+
+// ── Permission mapping per squad ────────────────────────────────────────
+// Each squad gets ONLY the GCP roles it needs. Principle of least privilege.
+
+interface SquadPermissions {
+  roles: string[];
+  apis: string[];       // APIs to enable on the project
+  description: string;
+}
+
+const SQUAD_PERMISSIONS: Record<string, SquadPermissions> = {
+  analytics: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com'],
+    description: 'BQ telemetry read access',
+  },
+  data: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser', 'roles/cloudsql.client'],
+    apis: ['bigquery.googleapis.com', 'sqladmin.googleapis.com'],
+    description: 'BQ read + Cloud SQL client',
+  },
+  finance: {
+    roles: ['roles/drive.file', 'roles/sheets.editor'],
+    apis: ['sheets.googleapis.com', 'drive.googleapis.com'],
+    description: 'Google Sheets + Drive for financial models',
+  },
+  marketing: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com', 'searchconsole.googleapis.com'],
+    description: 'BQ read + Search Console',
+  },
+  engineering: {
+    roles: ['roles/cloudsql.admin', 'roles/run.developer', 'roles/secretmanager.secretAccessor'],
+    apis: ['sqladmin.googleapis.com', 'run.googleapis.com', 'secretmanager.googleapis.com'],
+    description: 'Cloud SQL admin + Cloud Run deploy + secrets',
+  },
+  customer: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com'],
+    description: 'BQ telemetry for user analysis',
+  },
+  intelligence: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com'],
+    description: 'BQ read for intelligence queries',
+  },
+  product: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com'],
+    description: 'BQ telemetry for product analytics',
+  },
+  growth: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
+    apis: ['bigquery.googleapis.com'],
+    description: 'BQ telemetry for growth metrics',
+  },
+  operations: {
+    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser', 'roles/monitoring.viewer'],
+    apis: ['bigquery.googleapis.com', 'monitoring.googleapis.com'],
+    description: 'BQ read + monitoring for ops health',
+  },
+};
+
+const SECRETS_DIR = join(homedir(), '.squads', 'secrets');
+const SA_SUFFIX = '-agent';
+
+function getProject(): string {
+  try {
+    return execSync('gcloud config get-value project 2>/dev/null', { encoding: 'utf-8' }).trim();
+  } catch {
+    throw new Error('No GCP project configured. Run: gcloud config set project <project-id>');
+  }
+}
+
+function saEmail(squad: string, project: string): string {
+  return `${squad}${SA_SUFFIX}@${project}.iam.gserviceaccount.com`;
+}
+
+function keyPath(squad: string): string {
+  return join(SECRETS_DIR, `${squad}-sa-key.json`);
+}
+
+function ensureSecretsDir(): void {
+  if (!existsSync(SECRETS_DIR)) {
+    mkdirSync(SECRETS_DIR, { recursive: true });
+  }
+}
+
+function gcloudExec(cmd: string, silent = false): string {
+  try {
+    const result = execSync(cmd, { encoding: 'utf-8', stdio: silent ? 'pipe' : ['pipe', 'inherit', 'inherit'] });
+    return (result || '').trim();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('Reauthentication')) {
+      throw new Error('gcloud auth expired. Run: gcloud auth login');
+    }
+    throw e;
+  }
+}
+
+// ── Commands ────────────────────────────────────────────────────────────
+
+async function createCredential(squad: string, opts: { force?: boolean }): Promise<void> {
+  const project = getProject();
+  const email = saEmail(squad, project);
+  const key = keyPath(squad);
+  const perms = SQUAD_PERMISSIONS[squad];
+
+  if (!perms) {
+    writeLine(`  ${icons.error} ${colors.red}No permission mapping for squad "${squad}"${RESET}`);
+    writeLine(`  ${colors.dim}Known squads: ${Object.keys(SQUAD_PERMISSIONS).join(', ')}${RESET}`);
+    return;
+  }
+
+  if (existsSync(key) && !opts.force) {
+    writeLine(`  ${icons.warning} ${colors.yellow}Credential already exists: ${key}${RESET}`);
+    writeLine(`  ${colors.dim}Use --force to recreate${RESET}`);
+    return;
+  }
+
+  ensureSecretsDir();
+
+  writeLine(`  ${bold}Creating service account for ${squad}${RESET}`);
+  writeLine(`  ${colors.dim}${perms.description}${RESET}`);
+  writeLine();
+
+  // 1. Enable required APIs
+  for (const api of perms.apis) {
+    writeLine(`  ${colors.dim}Enabling ${api}...${RESET}`);
+    try {
+      gcloudExec(`gcloud services enable ${api} --project ${project} 2>/dev/null`, true);
+    } catch { /* already enabled or no permission — continue */ }
+  }
+
+  // 2. Create service account (or skip if exists)
+  try {
+    gcloudExec(`gcloud iam service-accounts describe ${email} --project ${project} 2>/dev/null`, true);
+    writeLine(`  ${colors.dim}Service account exists: ${email}${RESET}`);
+  } catch {
+    writeLine(`  Creating ${email}...`);
+    gcloudExec(`gcloud iam service-accounts create ${squad}${SA_SUFFIX} --display-name "Squads ${squad} agent" --project ${project}`);
+  }
+
+  // 3. Grant IAM roles
+  for (const role of perms.roles) {
+    writeLine(`  ${colors.dim}Granting ${role}...${RESET}`);
+    try {
+      gcloudExec(
+        `gcloud projects add-iam-policy-binding ${project} --member="serviceAccount:${email}" --role="${role}" --condition=None --quiet 2>/dev/null`,
+        true,
+      );
+    } catch { /* role may already be bound */ }
+  }
+
+  // 4. Create and download key
+  if (existsSync(key) && opts.force) {
+    unlinkSync(key);
+  }
+  writeLine(`  ${colors.dim}Creating key...${RESET}`);
+  gcloudExec(`gcloud iam service-accounts keys create ${key} --iam-account=${email} --project ${project}`);
+
+  writeLine();
+  writeLine(`  ${icons.success} ${colors.green}${squad}${RESET} credential ready`);
+  writeLine(`  ${colors.dim}Key: ${key}${RESET}`);
+  writeLine(`  ${colors.dim}Roles: ${perms.roles.join(', ')}${RESET}`);
+  writeLine();
+}
+
+async function rotateCredential(squad: string): Promise<void> {
+  const project = getProject();
+  const email = saEmail(squad, project);
+  const key = keyPath(squad);
+
+  if (!existsSync(key)) {
+    writeLine(`  ${icons.error} ${colors.red}No credential found for ${squad}. Run: squads credentials create ${squad}${RESET}`);
+    return;
+  }
+
+  // Read old key to get key ID for deletion
+  const oldKeyData = JSON.parse(readFileSync(key, 'utf-8'));
+  const oldKeyId = oldKeyData.private_key_id;
+
+  writeLine(`  ${bold}Rotating ${squad} credential${RESET}`);
+
+  // Create new key first
+  const tmpKey = key + '.new';
+  gcloudExec(`gcloud iam service-accounts keys create ${tmpKey} --iam-account=${email} --project ${project}`);
+
+  // Replace old key file
+  unlinkSync(key);
+  const { renameSync } = await import('fs');
+  renameSync(tmpKey, key);
+
+  // Delete old key from GCP
+  if (oldKeyId) {
+    try {
+      gcloudExec(
+        `gcloud iam service-accounts keys delete ${oldKeyId} --iam-account=${email} --project ${project} --quiet`,
+        true,
+      );
+    } catch { /* old key may already be expired */ }
+  }
+
+  writeLine(`  ${icons.success} ${colors.green}${squad}${RESET} credential rotated`);
+  writeLine(`  ${colors.dim}New key: ${key}${RESET}`);
+  writeLine();
+}
+
+async function listCredentials(): Promise<void> {
+  ensureSecretsDir();
+  const squadsDir = findSquadsDir();
+  const allSquads = Object.keys(SQUAD_PERMISSIONS).sort();
+
+  writeLine();
+  writeLine(`  ${bold}Squad Credentials${RESET}`);
+  writeLine();
+  writeLine(`  ${'Squad'.padEnd(16)} ${'Status'.padEnd(10)} ${'Roles'.padEnd(40)} Key`);
+  writeLine(`  ${'-'.repeat(90)}`);
+
+  for (const squad of allSquads) {
+    const key = keyPath(squad);
+    const perms = SQUAD_PERMISSIONS[squad];
+    const hasKey = existsSync(key);
+    const status = hasKey ? `${colors.green}active${RESET}` : `${colors.dim}none${RESET}  `;
+    const roles = perms.roles.map(r => r.split('/')[1]).join(', ');
+
+    writeLine(`  ${squad.padEnd(16)} ${status} ${colors.dim}${roles.slice(0, 38).padEnd(40)}${RESET} ${hasKey ? '~/.squads/secrets/' + basename(key) : ''}`);
+  }
+
+  // Show squads without permission mapping
+  if (squadsDir) {
+    const dirs = readdirSync(squadsDir).filter(d =>
+      existsSync(join(squadsDir, d, 'SQUAD.md')) && !SQUAD_PERMISSIONS[d]
+    );
+    if (dirs.length > 0) {
+      writeLine();
+      writeLine(`  ${colors.dim}Squads without permission mapping: ${dirs.join(', ')}${RESET}`);
+      writeLine(`  ${colors.dim}Add to SQUAD_PERMISSIONS in credentials.ts if they need GCP access.${RESET}`);
+    }
+  }
+
+  writeLine();
+}
+
+async function revokeCredential(squad: string): Promise<void> {
+  const project = getProject();
+  const email = saEmail(squad, project);
+  const key = keyPath(squad);
+
+  writeLine(`  ${bold}Revoking ${squad} credential${RESET}`);
+
+  // Delete local key
+  if (existsSync(key)) {
+    unlinkSync(key);
+    writeLine(`  ${colors.dim}Deleted local key${RESET}`);
+  }
+
+  // Delete all keys from GCP
+  try {
+    const keysJson = gcloudExec(
+      `gcloud iam service-accounts keys list --iam-account=${email} --project ${project} --format=json 2>/dev/null`,
+      true,
+    );
+    const keys = JSON.parse(keysJson);
+    for (const k of keys) {
+      if (k.keyType === 'USER_MANAGED') {
+        gcloudExec(
+          `gcloud iam service-accounts keys delete ${k.name.split('/').pop()} --iam-account=${email} --project ${project} --quiet`,
+          true,
+        );
+      }
+    }
+    writeLine(`  ${colors.dim}Deleted remote keys${RESET}`);
+  } catch { /* SA may not exist */ }
+
+  // Delete service account
+  try {
+    gcloudExec(`gcloud iam service-accounts delete ${email} --project ${project} --quiet`);
+    writeLine(`  ${colors.dim}Deleted service account${RESET}`);
+  } catch { /* already deleted */ }
+
+  writeLine(`  ${icons.success} ${colors.green}${squad}${RESET} credential revoked`);
+  writeLine();
+}
+
+async function createAll(opts: { force?: boolean }): Promise<void> {
+  const squads = Object.keys(SQUAD_PERMISSIONS).sort();
+  writeLine(`  ${bold}Creating credentials for ${squads.length} squads${RESET}`);
+  writeLine();
+
+  for (const squad of squads) {
+    await createCredential(squad, opts);
+  }
+
+  writeLine(`  ${bold}Done.${RESET} Run ${colors.cyan}squads credentials list${RESET} to verify.`);
+  writeLine();
+}
+
+// ── Register ────────────────────────────────────────────────────────────
+
+export function registerCredentialsCommand(program: Command): void {
+  const creds = program
+    .command('credentials')
+    .description('Manage per-squad GCP service accounts and credentials');
+
+  creds
+    .command('create <squad>')
+    .description('Create a service account and key for a squad')
+    .option('--force', 'Recreate even if credential exists')
+    .action(async (squad: string, opts) => {
+      if (squad === '--all') {
+        await createAll(opts);
+      } else {
+        await createCredential(squad, opts);
+      }
+    });
+
+  creds
+    .command('create-all')
+    .description('Create credentials for all squads with permission mappings')
+    .option('--force', 'Recreate even if credentials exist')
+    .action(async (opts) => {
+      await createAll(opts);
+    });
+
+  creds
+    .command('rotate <squad>')
+    .description('Rotate a squad credential (create new key, delete old)')
+    .action(async (squad: string) => {
+      await rotateCredential(squad);
+    });
+
+  creds
+    .command('list')
+    .description('List all squad credentials and their status')
+    .action(async () => {
+      await listCredentials();
+    });
+
+  creds
+    .command('revoke <squad>')
+    .description('Delete a squad service account and all keys')
+    .action(async (squad: string) => {
+      await revokeCredential(squad);
+    });
+}
+
+// ── Helper for execution engine ─────────────────────────────────────────
+
+/**
+ * Resolve the credential path for a squad. Returns the path to the
+ * service account key file if it exists, or undefined.
+ * Used by the execution engine to inject GOOGLE_APPLICATION_CREDENTIALS.
+ */
+export function resolveSquadCredential(squad: string): string | undefined {
+  const key = keyPath(squad);
+  return existsSync(key) ? key : undefined;
+}

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -7,7 +7,7 @@
 
 import { Command } from 'commander';
 import { execSync } from 'child_process';
-import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join, basename } from 'path';
 import { findSquadsDir } from '../lib/squad-parser.js';
 import { colors, bold, RESET, writeLine, icons } from '../lib/terminal.js';
@@ -203,7 +203,6 @@ async function rotateCredential(squad: string): Promise<void> {
 
   // Replace old key file
   unlinkSync(key);
-  const { renameSync } = await import('fs');
   renameSync(tmpKey, key);
 
   // Delete old key from GCP
@@ -323,11 +322,7 @@ export function registerCredentialsCommand(program: Command): void {
     .description('Create a service account and key for a squad')
     .option('--force', 'Recreate even if credential exists')
     .action(async (squad: string, opts) => {
-      if (squad === '--all') {
-        await createAll(opts);
-      } else {
-        await createCredential(squad, opts);
-      }
+      await createCredential(squad, opts);
     });
 
   creds

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -28,32 +28,20 @@ interface SquadPermissions {
 }
 
 /**
- * Read credentials config from SQUAD.md `credentials.gcp` field.
- * Falls back to empty permissions if not defined.
+ * Parse GCP credentials config from SQUAD.md content.
+ * Exported for testing. Looks for a credentials.gcp block with roles and apis.
  */
-function getSquadPermissions(squadName: string): SquadPermissions | null {
-  const squad = loadSquad(squadName);
-  if (!squad) return null;
-
-  // Read raw SQUAD.md to parse credentials section
-  const squadsDir = findSquadsDir();
-  if (!squadsDir) return null;
-
-  const squadMd = join(squadsDir, squadName, 'SQUAD.md');
-  if (!existsSync(squadMd)) return null;
-
-  const content = readFileSync(squadMd, 'utf-8');
-
-  // Parse YAML-like credentials block from SQUAD.md frontmatter or body
+export function parseGcpCredentials(content: string): SquadPermissions | null {
   const roles: string[] = [];
   const apis: string[] = [];
 
-  // Match roles: [role1, role2] or roles:\n  - role1\n  - role2
+  // Match: gcp:\n  roles: [role1, role2]
   const rolesMatch = content.match(/gcp:\s*\n\s*roles:\s*\[([^\]]+)\]/);
   if (rolesMatch) {
     roles.push(...rolesMatch[1].split(',').map(r => r.trim().replace(/['"]/g, '')));
   }
 
+  // Match: gcp:\n  ...\n  apis: [api1, api2]
   const apisMatch = content.match(/gcp:\s*\n(?:.*\n)*?\s*apis:\s*\[([^\]]+)\]/);
   if (apisMatch) {
     apis.push(...apisMatch[1].split(',').map(a => a.trim().replace(/['"]/g, '')));
@@ -66,6 +54,23 @@ function getSquadPermissions(squadName: string): SquadPermissions | null {
     apis,
     description: `${roles.length} roles, ${apis.length} APIs`,
   };
+}
+
+/**
+ * Read credentials config from SQUAD.md `credentials.gcp` field.
+ * Falls back to empty permissions if not defined.
+ */
+function getSquadPermissions(squadName: string): SquadPermissions | null {
+  const squad = loadSquad(squadName);
+  if (!squad) return null;
+
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return null;
+
+  const squadMd = join(squadsDir, squadName, 'SQUAD.md');
+  if (!existsSync(squadMd)) return null;
+
+  return parseGcpCredentials(readFileSync(squadMd, 'utf-8'));
 }
 
 const SECRETS_DIR = join(homedir(), '.squads', 'secrets');

--- a/src/commands/credentials.ts
+++ b/src/commands/credentials.ts
@@ -2,78 +2,71 @@
  * squads credentials — manage per-squad GCP service accounts and credentials.
  *
  * Creates, rotates, lists, and revokes service accounts so agents
- * can access the APIs they need without founder intervention.
+ * can access the APIs they need without manual setup.
+ *
+ * Permissions are defined per squad in SQUAD.md:
+ *   credentials:
+ *     gcp:
+ *       roles: [roles/bigquery.dataViewer, roles/bigquery.jobUser]
+ *       apis: [bigquery.googleapis.com]
  */
 
 import { Command } from 'commander';
 import { execSync } from 'child_process';
 import { existsSync, readFileSync, mkdirSync, readdirSync, unlinkSync, renameSync } from 'fs';
 import { join, basename } from 'path';
-import { findSquadsDir } from '../lib/squad-parser.js';
+import { findSquadsDir, loadSquad } from '../lib/squad-parser.js';
 import { colors, bold, RESET, writeLine, icons } from '../lib/terminal.js';
 import { homedir } from 'os';
 
-// ── Permission mapping per squad ────────────────────────────────────────
-// Each squad gets ONLY the GCP roles it needs. Principle of least privilege.
+// ── Permission resolution ──────────────────────────────────────────────
 
 interface SquadPermissions {
   roles: string[];
-  apis: string[];       // APIs to enable on the project
+  apis: string[];
   description: string;
 }
 
-const SQUAD_PERMISSIONS: Record<string, SquadPermissions> = {
-  analytics: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com'],
-    description: 'BQ telemetry read access',
-  },
-  data: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser', 'roles/cloudsql.client'],
-    apis: ['bigquery.googleapis.com', 'sqladmin.googleapis.com'],
-    description: 'BQ read + Cloud SQL client',
-  },
-  finance: {
-    roles: ['roles/drive.file', 'roles/sheets.editor'],
-    apis: ['sheets.googleapis.com', 'drive.googleapis.com'],
-    description: 'Google Sheets + Drive for financial models',
-  },
-  marketing: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com', 'searchconsole.googleapis.com'],
-    description: 'BQ read + Search Console',
-  },
-  engineering: {
-    roles: ['roles/cloudsql.admin', 'roles/run.developer', 'roles/secretmanager.secretAccessor'],
-    apis: ['sqladmin.googleapis.com', 'run.googleapis.com', 'secretmanager.googleapis.com'],
-    description: 'Cloud SQL admin + Cloud Run deploy + secrets',
-  },
-  customer: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com'],
-    description: 'BQ telemetry for user analysis',
-  },
-  intelligence: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com'],
-    description: 'BQ read for intelligence queries',
-  },
-  product: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com'],
-    description: 'BQ telemetry for product analytics',
-  },
-  growth: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser'],
-    apis: ['bigquery.googleapis.com'],
-    description: 'BQ telemetry for growth metrics',
-  },
-  operations: {
-    roles: ['roles/bigquery.dataViewer', 'roles/bigquery.jobUser', 'roles/monitoring.viewer'],
-    apis: ['bigquery.googleapis.com', 'monitoring.googleapis.com'],
-    description: 'BQ read + monitoring for ops health',
-  },
-};
+/**
+ * Read credentials config from SQUAD.md `credentials.gcp` field.
+ * Falls back to empty permissions if not defined.
+ */
+function getSquadPermissions(squadName: string): SquadPermissions | null {
+  const squad = loadSquad(squadName);
+  if (!squad) return null;
+
+  // Read raw SQUAD.md to parse credentials section
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) return null;
+
+  const squadMd = join(squadsDir, squadName, 'SQUAD.md');
+  if (!existsSync(squadMd)) return null;
+
+  const content = readFileSync(squadMd, 'utf-8');
+
+  // Parse YAML-like credentials block from SQUAD.md frontmatter or body
+  const roles: string[] = [];
+  const apis: string[] = [];
+
+  // Match roles: [role1, role2] or roles:\n  - role1\n  - role2
+  const rolesMatch = content.match(/gcp:\s*\n\s*roles:\s*\[([^\]]+)\]/);
+  if (rolesMatch) {
+    roles.push(...rolesMatch[1].split(',').map(r => r.trim().replace(/['"]/g, '')));
+  }
+
+  const apisMatch = content.match(/gcp:\s*\n(?:.*\n)*?\s*apis:\s*\[([^\]]+)\]/);
+  if (apisMatch) {
+    apis.push(...apisMatch[1].split(',').map(a => a.trim().replace(/['"]/g, '')));
+  }
+
+  if (roles.length === 0 && apis.length === 0) return null;
+
+  return {
+    roles,
+    apis,
+    description: `${roles.length} roles, ${apis.length} APIs`,
+  };
+}
 
 const SECRETS_DIR = join(homedir(), '.squads', 'secrets');
 const SA_SUFFIX = '-agent';
@@ -119,11 +112,15 @@ async function createCredential(squad: string, opts: { force?: boolean }): Promi
   const project = getProject();
   const email = saEmail(squad, project);
   const key = keyPath(squad);
-  const perms = SQUAD_PERMISSIONS[squad];
+  const perms = getSquadPermissions(squad);
 
   if (!perms) {
-    writeLine(`  ${icons.error} ${colors.red}No permission mapping for squad "${squad}"${RESET}`);
-    writeLine(`  ${colors.dim}Known squads: ${Object.keys(SQUAD_PERMISSIONS).join(', ')}${RESET}`);
+    writeLine(`  ${icons.error} ${colors.red}No credentials config for squad "${squad}"${RESET}`);
+    writeLine(`  ${colors.dim}Add to SQUAD.md:${RESET}`);
+    writeLine(`  ${colors.dim}  credentials:${RESET}`);
+    writeLine(`  ${colors.dim}    gcp:${RESET}`);
+    writeLine(`  ${colors.dim}      roles: [roles/bigquery.dataViewer]${RESET}`);
+    writeLine(`  ${colors.dim}      apis: [bigquery.googleapis.com]${RESET}`);
     return;
   }
 
@@ -223,34 +220,35 @@ async function rotateCredential(squad: string): Promise<void> {
 async function listCredentials(): Promise<void> {
   ensureSecretsDir();
   const squadsDir = findSquadsDir();
-  const allSquads = Object.keys(SQUAD_PERMISSIONS).sort();
+
+  // Discover squads dynamically
+  const squads: string[] = [];
+  if (squadsDir) {
+    const dirs = readdirSync(squadsDir).filter(d =>
+      existsSync(join(squadsDir, d, 'SQUAD.md'))
+    );
+    squads.push(...dirs.sort());
+  }
+
+  if (squads.length === 0) {
+    writeLine(`  ${colors.dim}No squads found. Run squads init first.${RESET}`);
+    return;
+  }
 
   writeLine();
   writeLine(`  ${bold}Squad Credentials${RESET}`);
   writeLine();
-  writeLine(`  ${'Squad'.padEnd(16)} ${'Status'.padEnd(10)} ${'Roles'.padEnd(40)} Key`);
-  writeLine(`  ${'-'.repeat(90)}`);
+  writeLine(`  ${'Squad'.padEnd(16)} ${'Status'.padEnd(10)} ${'GCP Config'.padEnd(20)} Key`);
+  writeLine(`  ${'-'.repeat(70)}`);
 
-  for (const squad of allSquads) {
+  for (const squad of squads) {
     const key = keyPath(squad);
-    const perms = SQUAD_PERMISSIONS[squad];
+    const perms = getSquadPermissions(squad);
     const hasKey = existsSync(key);
     const status = hasKey ? `${colors.green}active${RESET}` : `${colors.dim}none${RESET}  `;
-    const roles = perms.roles.map(r => r.split('/')[1]).join(', ');
+    const config = perms ? `${perms.roles.length} roles` : `${colors.dim}not configured${RESET}`;
 
-    writeLine(`  ${squad.padEnd(16)} ${status} ${colors.dim}${roles.slice(0, 38).padEnd(40)}${RESET} ${hasKey ? '~/.squads/secrets/' + basename(key) : ''}`);
-  }
-
-  // Show squads without permission mapping
-  if (squadsDir) {
-    const dirs = readdirSync(squadsDir).filter(d =>
-      existsSync(join(squadsDir, d, 'SQUAD.md')) && !SQUAD_PERMISSIONS[d]
-    );
-    if (dirs.length > 0) {
-      writeLine();
-      writeLine(`  ${colors.dim}Squads without permission mapping: ${dirs.join(', ')}${RESET}`);
-      writeLine(`  ${colors.dim}Add to SQUAD_PERMISSIONS in credentials.ts if they need GCP access.${RESET}`);
-    }
+    writeLine(`  ${squad.padEnd(16)} ${status} ${config.padEnd(20)} ${hasKey ? '~/.squads/secrets/' + basename(key) : ''}`);
   }
 
   writeLine();
@@ -298,7 +296,22 @@ async function revokeCredential(squad: string): Promise<void> {
 }
 
 async function createAll(opts: { force?: boolean }): Promise<void> {
-  const squads = Object.keys(SQUAD_PERMISSIONS).sort();
+  const squadsDir = findSquadsDir();
+  if (!squadsDir) {
+    writeLine(`  ${icons.error} ${colors.red}No squads directory found.${RESET}`);
+    return;
+  }
+
+  // Discover squads with credentials config
+  const squads = readdirSync(squadsDir)
+    .filter(d => existsSync(join(squadsDir, d, 'SQUAD.md')) && getSquadPermissions(d) !== null)
+    .sort();
+
+  if (squads.length === 0) {
+    writeLine(`  ${colors.dim}No squads have credentials configured in SQUAD.md.${RESET}`);
+    return;
+  }
+
   writeLine(`  ${bold}Creating credentials for ${squads.length} squads${RESET}`);
   writeLine();
 
@@ -327,7 +340,7 @@ export function registerCredentialsCommand(program: Command): void {
 
   creds
     .command('create-all')
-    .description('Create credentials for all squads with permission mappings')
+    .description('Create credentials for all squads with GCP config in SQUAD.md')
     .option('--force', 'Recreate even if credentials exist')
     .action(async (opts) => {
       await createAll(opts);

--- a/src/commands/goals.ts
+++ b/src/commands/goals.ts
@@ -1,0 +1,138 @@
+/**
+ * squads goals — dashboard view of all squad goals.
+ */
+
+import { Command } from 'commander';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { findSquadsDir } from '../lib/squad-parser.js';
+import { findMemoryDir } from '../lib/memory.js';
+import { colors, bold, RESET, writeLine } from '../lib/terminal.js';
+
+interface GoalInfo {
+  name: string;
+  status: string;
+  section: 'active' | 'achieved' | 'abandoned' | 'proposed';
+}
+
+function parseGoals(filePath: string): GoalInfo[] {
+  if (!existsSync(filePath)) return [];
+  const content = readFileSync(filePath, 'utf-8');
+  const goals: GoalInfo[] = [];
+
+  let currentSection: GoalInfo['section'] = 'active';
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('## Active')) currentSection = 'active';
+    else if (line.startsWith('## Achieved')) currentSection = 'achieved';
+    else if (line.startsWith('## Abandoned')) currentSection = 'abandoned';
+    else if (line.startsWith('## Proposed')) currentSection = 'proposed';
+
+    const match = line.match(/\*\*([^*]+)\*\*.*status:\s*(\S+)/);
+    if (match) {
+      goals.push({ name: match[1].trim(), status: match[2].trim(), section: currentSection });
+    }
+
+    // Achieved goals don't have status field — detect by section
+    if (currentSection === 'achieved' && line.match(/\*\*([^*]+)\*\*.*achieved:/)) {
+      const nameMatch = line.match(/\*\*([^*]+)\*\*/);
+      if (nameMatch) {
+        goals.push({ name: nameMatch[1].trim(), status: 'achieved', section: 'achieved' });
+      }
+    }
+  }
+
+  return goals;
+}
+
+export function registerGoalsCommand(program: Command): void {
+  program
+    .command('goals')
+    .description('Dashboard of all squad goals — status at a glance')
+    .option('-s, --squad <squad>', 'Show goals for a specific squad')
+    .option('--json', 'Output as JSON')
+    .action((opts) => {
+      const squadsDir = findSquadsDir();
+      const memoryDir = findMemoryDir();
+      if (!squadsDir || !memoryDir) {
+        writeLine(`\n  ${colors.dim}No squads found. Run squads init.${RESET}\n`);
+        return;
+      }
+
+      const squadDirs = readdirSync(squadsDir).filter(d => {
+        return existsSync(join(squadsDir, d, 'SQUAD.md'));
+      }).sort();
+
+      const allData: Record<string, { goals: GoalInfo[]; active: number; achieved: number; blocked: number }> = {};
+
+      for (const squad of squadDirs) {
+        if (opts.squad && squad !== opts.squad) continue;
+        const goalsPath = join(memoryDir, squad, 'goals.md');
+        const goals = parseGoals(goalsPath);
+        const active = goals.filter(g => g.section === 'active').length;
+        const achieved = goals.filter(g => g.section === 'achieved').length;
+        const blocked = goals.filter(g => g.status === 'blocked' || g.status === 'AT-RISK').length;
+        allData[squad] = { goals, active, achieved, blocked };
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(allData, null, 2));
+        return;
+      }
+
+      // Summary view
+      const totalActive = Object.values(allData).reduce((s, d) => s + d.active, 0);
+      const totalAchieved = Object.values(allData).reduce((s, d) => s + d.achieved, 0);
+      const totalBlocked = Object.values(allData).reduce((s, d) => s + d.blocked, 0);
+
+      writeLine();
+      writeLine(`  ${bold}Goals Dashboard${RESET}  ${totalActive} active | ${colors.green}${totalAchieved} achieved${RESET} | ${totalBlocked > 0 ? colors.red : colors.dim}${totalBlocked} blocked${RESET}`);
+      writeLine();
+      writeLine(`  ${'Squad'} ${''.padEnd(10)} ${'Active'.padStart(6)} ${'Done'.padStart(6)} ${'Block'.padStart(6)}  Top Goal`);
+      writeLine(`  ${'-'.repeat(78)}`);
+
+      for (const [squad, data] of Object.entries(allData)) {
+        const frozen = data.active === 0 && data.achieved === 0;
+        if (frozen) continue; // Skip frozen squads in summary
+
+        const activeGoals = data.goals.filter(g => g.section === 'active');
+        const topGoal = activeGoals[0];
+        const topStr = topGoal
+          ? `${topGoal.name.slice(0, 30).padEnd(30)} ${statusIcon(topGoal.status)}`
+          : `${colors.dim}(no active goals)${RESET}`;
+
+        writeLine(`  ${squad.padEnd(15)} ${String(data.active).padStart(6)} ${String(data.achieved).padStart(6)} ${String(data.blocked).padStart(6)}  ${topStr}`);
+      }
+
+      // Detail view for specific squad
+      if (opts.squad && allData[opts.squad]) {
+        const data = allData[opts.squad];
+        writeLine();
+        writeLine(`  ${bold}${opts.squad} — Detail${RESET}`);
+
+        for (const section of ['active', 'achieved', 'abandoned', 'proposed'] as const) {
+          const sectionGoals = data.goals.filter(g => g.section === section);
+          if (sectionGoals.length === 0) continue;
+          writeLine(`\n  ${colors.cyan}${section.toUpperCase()}${RESET}`);
+          for (const g of sectionGoals) {
+            writeLine(`    ${statusIcon(g.status)}  ${g.name}`);
+          }
+        }
+      }
+
+      writeLine();
+    });
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'achieved':
+    case 'complete': return `${colors.green}done${RESET}`;
+    case 'in-progress':
+    case 'improving': return `${colors.cyan}prog${RESET}`;
+    case 'not-started': return `${colors.dim}todo${RESET}`;
+    case 'blocked':
+    case 'AT-RISK': return `${colors.red}block${RESET}`;
+    default: return `${colors.dim}${status.slice(0, 5)}${RESET}`;
+  }
+}

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -1,0 +1,150 @@
+/**
+ * squads log — run history with timestamps, duration, status, and cost
+ *
+ * Reads from .agents/observability/executions.jsonl (local, no server required).
+ * Gives returning users immediate visibility into what ran and whether it worked.
+ */
+
+import { track, Events } from '../lib/telemetry.js';
+import { queryExecutions } from '../lib/observability.js';
+import { formatDuration } from '../lib/executions.js';
+import {
+  colors,
+  bold,
+  RESET,
+  gradient,
+  box,
+  padEnd,
+  writeLine,
+  icons,
+} from '../lib/terminal.js';
+
+interface LogOptions {
+  squad?: string;
+  agent?: string;
+  limit?: number;
+  since?: string;
+  json?: boolean;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function formatCost(usd: number): string {
+  if (!usd || usd === 0) return '—';
+  if (usd < 0.01) return `$${(usd * 100).toFixed(2)}¢`;
+  return `$${usd.toFixed(3)}`;
+}
+
+export async function logCommand(options: LogOptions = {}): Promise<void> {
+  await track(Events.CLI_LOG, { squad: options.squad, limit: options.limit });
+
+  const records = queryExecutions({
+    squad: options.squad,
+    agent: options.agent,
+    since: options.since,
+    limit: options.limit || 20,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(records, null, 2));
+    return;
+  }
+
+  writeLine();
+  writeLine(`  ${gradient('squads')} ${colors.dim}log${RESET}${options.squad ? ` ${colors.cyan}${options.squad}${RESET}` : ''}`);
+  writeLine();
+
+  if (records.length === 0) {
+    writeLine(`  ${colors.dim}No runs found${RESET}`);
+    writeLine();
+    writeLine(`  ${colors.dim}Runs are logged after executing agents:${RESET}`);
+    writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}<squad>${RESET}`);
+    writeLine();
+    return;
+  }
+
+  // Column widths
+  const w = { ts: 17, agent: 28, duration: 10, status: 12, cost: 8 };
+  const tableWidth = w.ts + w.agent + w.duration + w.status + w.cost + 6;
+
+  writeLine(`  ${colors.purple}${box.topLeft}${colors.dim}${box.horizontal.repeat(tableWidth)}${colors.purple}${box.topRight}${RESET}`);
+
+  const header = `  ${colors.purple}${box.vertical}${RESET} ` +
+    `${bold}${padEnd('TIMESTAMP', w.ts)}${RESET}` +
+    `${bold}${padEnd('SQUAD/AGENT', w.agent)}${RESET}` +
+    `${bold}${padEnd('DURATION', w.duration)}${RESET}` +
+    `${bold}${padEnd('STATUS', w.status)}${RESET}` +
+    `${bold}COST${RESET}` +
+    ` ${colors.purple}${box.vertical}${RESET}`;
+  writeLine(header);
+
+  writeLine(`  ${colors.purple}${box.teeRight}${colors.dim}${box.horizontal.repeat(tableWidth)}${colors.purple}${box.teeLeft}${RESET}`);
+
+  for (const r of records) {
+    const agentLabel = `${r.squad}/${r.agent}`;
+    const truncatedAgent = agentLabel.length > w.agent - 1
+      ? agentLabel.slice(0, w.agent - 4) + '...'
+      : agentLabel;
+
+    let statusIcon: string;
+    let statusColor: string;
+
+    if (r.status === 'completed') {
+      statusIcon = icons.success;
+      statusColor = colors.green;
+    } else if (r.status === 'failed') {
+      statusIcon = icons.error;
+      statusColor = colors.red;
+    } else {
+      statusIcon = icons.warning;
+      statusColor = colors.yellow;
+    }
+
+    const statusStr = `${statusColor}${statusIcon} ${r.status}${RESET}`;
+    const durationStr = formatDuration(r.duration_ms);
+    const tsStr = formatTimestamp(r.ts);
+    const costStr = formatCost(r.cost_usd);
+
+    const row = `  ${colors.purple}${box.vertical}${RESET} ` +
+      `${colors.dim}${padEnd(tsStr, w.ts)}${RESET}` +
+      `${colors.cyan}${padEnd(truncatedAgent, w.agent)}${RESET}` +
+      `${padEnd(durationStr, w.duration)}` +
+      `${padEnd(statusStr, w.status + 10)}` +  // +10 for ANSI escape codes
+      `${colors.dim}${costStr}${RESET}` +
+      ` ${colors.purple}${box.vertical}${RESET}`;
+
+    writeLine(row);
+  }
+
+  writeLine(`  ${colors.purple}${box.bottomLeft}${colors.dim}${box.horizontal.repeat(tableWidth)}${colors.purple}${box.bottomRight}${RESET}`);
+  writeLine();
+
+  // Summary line
+  const completed = records.filter(r => r.status === 'completed').length;
+  const failed = records.filter(r => r.status === 'failed').length;
+  const totalCost = records.reduce((sum, r) => sum + (r.cost_usd || 0), 0);
+  const parts: string[] = [];
+  if (completed > 0) parts.push(`${colors.green}${completed} completed${RESET}`);
+  if (failed > 0) parts.push(`${colors.red}${failed} failed${RESET}`);
+  if (totalCost > 0) parts.push(`${colors.dim}${formatCost(totalCost)} total${RESET}`);
+
+  if (parts.length > 0) {
+    writeLine(`  ${parts.join(` ${colors.dim}|${RESET} `)}`);
+    writeLine();
+  }
+
+  if (records.length >= (options.limit || 20)) {
+    writeLine(`  ${colors.dim}Showing ${records.length} most recent. Use --limit to see more.${RESET}`);
+    writeLine();
+  }
+
+  writeLine(`  ${colors.dim}$${RESET} squads log --squad ${colors.cyan}<name>${RESET}   ${colors.dim}Filter by squad${RESET}`);
+  writeLine(`  ${colors.dim}$${RESET} squads log --since ${colors.cyan}7d${RESET}        ${colors.dim}Filter by date${RESET}`);
+  writeLine(`  ${colors.dim}$${RESET} squads log --json           ${colors.dim}JSON output${RESET}`);
+  writeLine();
+}

--- a/src/commands/observability.ts
+++ b/src/commands/observability.ts
@@ -12,7 +12,8 @@ import { colors, bold, RESET, writeLine } from '../lib/terminal.js';
 export function registerObservabilityCommands(program: Command): void {
   const obs = program
     .command('obs')
-    .description('Observability — execution history, token costs, and trends');
+    .description('Observability — execution history, token costs, and trends')
+    .action(() => { obs.outputHelp(); });
 
   obs
     .command('history')

--- a/src/commands/release-check.ts
+++ b/src/commands/release-check.ts
@@ -21,7 +21,8 @@ async function checkHealth(url: string, expect: number): Promise<{ ok: boolean; 
 export function registerReleaseCommands(program: Command): void {
   const release = program
     .command('release')
-    .description('Release management — pre-deploy checks and status');
+    .description('Release management — pre-deploy checks and status')
+    .action(() => { release.outputHelp(); });
 
   release
     .command('pre-check <service>')

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,462 @@
+/**
+ * squads review — post-cycle evaluation dashboard.
+ *
+ * Optimized for founder + COO:
+ * - Overview: scan all squads in 10 seconds
+ * - Founder actions: what needs human input (separated from agent blockers)
+ * - Goal progress: only meaningful changes (achieved, blocked, new — not churn)
+ * - Cost efficiency: cost per goal change
+ * - Detail: drill into any squad
+ */
+
+import { Command } from 'commander';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { findSquadsDir } from '../lib/squad-parser.js';
+import { findMemoryDir } from '../lib/memory.js';
+import { queryExecutions, calculateCostSummary, type ObservabilityRecord } from '../lib/observability.js';
+import { colors, bold, RESET, writeLine } from '../lib/terminal.js';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+interface GoalInfo {
+  name: string;
+  status: string;
+  section: 'active' | 'achieved' | 'abandoned' | 'proposed';
+  deadline?: string;
+  blocker?: string;
+}
+
+interface GoalChange {
+  name: string;
+  before: string;
+  after: string;
+}
+
+interface SquadRow {
+  squad: string;
+  exec: ObservabilityRecord | null;
+  goals: GoalInfo[];
+  status: string;
+  topAction: string;
+  founderBlockers: string[];
+  agentBlockers: string[];
+}
+
+// ── Parsers ─────────────────────────────────────────────────────────────
+
+function parseGoalsDetailed(filePath: string): GoalInfo[] {
+  if (!existsSync(filePath)) return [];
+  const content = readFileSync(filePath, 'utf-8');
+  const goals: GoalInfo[] = [];
+  let currentSection: GoalInfo['section'] = 'active';
+
+  for (const line of content.split('\n')) {
+    if (line.startsWith('## Active')) currentSection = 'active';
+    else if (line.startsWith('## Achieved')) currentSection = 'achieved';
+    else if (line.startsWith('## Abandoned')) currentSection = 'abandoned';
+    else if (line.startsWith('## Proposed')) currentSection = 'proposed';
+
+    const match = line.match(/\*\*([^*]+)\*\*/);
+    if (!match) continue;
+
+    const name = match[1].trim();
+    const statusMatch = line.match(/status:\s*(\S+)/);
+    const deadlineMatch = line.match(/deadline:\s*(\S+)/);
+    const blockerMatch = line.match(/blocker:\s*([^|]+)/);
+
+    if (statusMatch || (currentSection === 'achieved' && line.includes('achieved:'))) {
+      goals.push({
+        name,
+        status: statusMatch ? statusMatch[1].trim() : 'achieved',
+        section: currentSection,
+        deadline: deadlineMatch ? deadlineMatch[1].trim() : undefined,
+        blocker: blockerMatch ? blockerMatch[1].trim() : undefined,
+      });
+    }
+  }
+  return goals;
+}
+
+function readLeadState(memoryDir: string, squad: string): {
+  status: string;
+  topAction: string;
+  founderBlockers: string[];
+  agentBlockers: string[];
+} {
+  const squadMemDir = join(memoryDir, squad);
+  if (!existsSync(squadMemDir)) return { status: 'unknown', topAction: '', founderBlockers: [], agentBlockers: [] };
+
+  let stateFile: string | null = null;
+  try {
+    const dirs = readdirSync(squadMemDir).filter(d =>
+      d.endsWith('-lead') && existsSync(join(squadMemDir, d, 'state.md'))
+    );
+    if (dirs.length > 0) stateFile = join(squadMemDir, dirs[0], 'state.md');
+  } catch { /* */ }
+
+  if (!stateFile) return { status: 'unknown', topAction: '', founderBlockers: [], agentBlockers: [] };
+
+  const content = readFileSync(stateFile, 'utf-8');
+  const lines = content.split('\n');
+
+  // Status from frontmatter
+  const statusMatch = content.match(/status:\s*"?(\w+)"?/);
+  const status = statusMatch ? statusMatch[1] : 'unknown';
+
+  // Top action: first completed item (✅, [x], Done, DONE) or first bullet under ## Current / ## Actions
+  let topAction = '';
+  let inActions = false;
+  for (const line of lines) {
+    if (/^## (Current|Actions|This Run|What was done|Done|Completed)/i.test(line)) {
+      inActions = true;
+      continue;
+    }
+    if (inActions && line.startsWith('## ')) break;
+    if (inActions && line.trim()) {
+      // Look for completed items first
+      const cleaned = line.replace(/\*\*/g, '').replace(/[\u{1F534}\u{1F7E1}\u{1F7E2}\u{2705}\u{274C}\u2713]/gu, '').replace(/^[-*]\s*/, '').replace(/^\[x\]\s*/i, '').trim();
+      if (cleaned.length > 10 && !cleaned.startsWith('---')) {
+        topAction = cleaned.slice(0, 60);
+        break;
+      }
+    }
+  }
+
+  // Blockers: split by founder-needing vs agent-resolvable
+  const founderBlockers: string[] = [];
+  const agentBlockers: string[] = [];
+  let inBlockers = false;
+
+  for (const line of lines) {
+    if (/^## Blocker/i.test(line)) { inBlockers = true; continue; }
+    if (inBlockers && line.startsWith('## ')) break;
+    if (inBlockers && line.trim().startsWith('-')) {
+      const text = line.replace(/^-\s*/, '').replace(/\*\*/g, '').trim();
+      if (!text || text.toLowerCase() === 'none' || text === '(none)') continue;
+
+      const link = extractLink(text);
+      const entry = link ? `${text.slice(0, 65)}\n         ${colors.dim}${link}${RESET}` : text.slice(0, 80);
+
+      // Founder blockers: mention founder, kokevidaurre, needs:human, "enable", "login", "auth"
+      const isFounder = /founder|kokevidaurre|needs:human|needs founder|assigned to founder|enable at|auth login|bank cartola|CPA/i.test(text);
+      if (isFounder) {
+        founderBlockers.push(entry);
+      } else {
+        agentBlockers.push(entry);
+      }
+    }
+  }
+
+  return { status, topAction, founderBlockers, agentBlockers };
+}
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'achieved': case 'complete': return `${colors.green}done${RESET}`;
+    case 'in-progress': case 'improving': return `${colors.cyan}prog${RESET}`;
+    case 'not-started': return `${colors.dim}todo${RESET}`;
+    case 'blocked': case 'AT-RISK': return `${colors.red}risk${RESET}`;
+    default: return `${colors.dim}${status.slice(0, 4)}${RESET}`;
+  }
+}
+
+function daysUntil(dateStr: string): number | null {
+  if (!dateStr || dateStr === 'ongoing') return null;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return null;
+  return Math.ceil((d.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+}
+
+/** Extract a URL or GitHub issue link from text */
+function extractLink(text: string): string {
+  // Direct URL
+  const urlMatch = text.match(/(https?:\/\/[^\s)]+)/);
+  if (urlMatch) return urlMatch[1];
+
+  // Issue reference: "org/repo#N" format
+  const orgRepoIssue = text.match(/([a-z][\w-]+)\/([a-z][\w-]*)#(\d+)/i);
+  if (orgRepoIssue) {
+    return `https://github.com/${orgRepoIssue[1]}/${orgRepoIssue[2]}/issues/${orgRepoIssue[3]}`;
+  }
+
+  // Bare "repo#N" — can't resolve without org context
+  const repoIssue = text.match(/([a-z][\w-]*)#(\d+)/i);
+  if (repoIssue) {
+    return ''; // No hardcoded org — need full org/repo#N format
+  }
+
+  // Bare #N — can't resolve without repo context
+  return '';
+}
+
+function parseSinceToISO(since: string): string {
+  const match = since.match(/^(\d+)(h|d|w)$/);
+  if (!match) return since;
+  const val = parseInt(match[1]);
+  const unit = match[2];
+  const ms = unit === 'h' ? val * 3600000 : unit === 'd' ? val * 86400000 : val * 604800000;
+  return new Date(Date.now() - ms).toISOString();
+}
+
+// ── Overview ────────────────────────────────────────────────────────────
+
+function showOverview(squadsDir: string, memoryDir: string, since: string): void {
+  const squadDirs = readdirSync(squadsDir).filter(d =>
+    existsSync(join(squadsDir, d, 'SQUAD.md'))
+  ).sort();
+
+  const sinceISO = parseSinceToISO(since);
+  const execs = queryExecutions({ since: sinceISO, limit: 500 });
+  const costSummary = calculateCostSummary('7d');
+
+  // Last execution per squad
+  const lastExec = new Map<string, ObservabilityRecord>();
+  for (const e of execs) {
+    if (!lastExec.has(e.squad) || e.ts > lastExec.get(e.squad)!.ts) {
+      lastExec.set(e.squad, e);
+    }
+  }
+
+  // Build rows
+  const rows: SquadRow[] = [];
+  for (const squad of squadDirs) {
+    const goals = parseGoalsDetailed(join(memoryDir, squad, 'goals.md'));
+    const exec = lastExec.get(squad) || null;
+    if (goals.length === 0 && !exec) continue; // frozen
+
+    const state = readLeadState(memoryDir, squad);
+    rows.push({ squad, exec, goals, ...state });
+  }
+
+  // ── Metrics ──
+  const totalActive = rows.reduce((s, r) => s + r.goals.filter(g => g.section === 'active').length, 0);
+  const totalAchieved = rows.reduce((s, r) => s + r.goals.filter(g => g.section === 'achieved').length, 0);
+  const totalBlocked = rows.reduce((s, r) => s + r.goals.filter(g => g.status === 'blocked' || g.status === 'AT-RISK').length, 0);
+  const meaningfulChanges = execs.reduce((s, e) => s + (e.goals_changed?.filter(c =>
+    c.after === 'achieved' || c.after === 'blocked' || c.before === 'not-started'
+  ).length || 0), 0);
+  const costPerChange = meaningfulChanges > 0 ? costSummary.total_cost / meaningfulChanges : 0;
+
+  writeLine();
+  writeLine(`  ${bold}Cycle Review${RESET}`);
+  writeLine(`  ${costSummary.total_runs} runs  $${costSummary.total_cost.toFixed(0)} (7d)  ${costPerChange > 0 ? `$${costPerChange.toFixed(1)}/goal-change` : ''}  ${totalActive} active  ${colors.green}${totalAchieved} achieved${RESET}  ${totalBlocked > 0 ? `${colors.red}${totalBlocked} blocked${RESET}` : ''}`);
+  writeLine();
+
+  // ── Squad table ──
+  writeLine(`  ${'Squad'.padEnd(15)} ${'Run'.padEnd(8)} ${'$'.padStart(5)} ${'G'.padStart(4)} Top Action`);
+  writeLine(`  ${'-'.repeat(80)}`);
+
+  for (const r of rows) {
+    const active = r.goals.filter(g => g.section === 'active').length;
+    const achieved = r.goals.filter(g => g.section === 'achieved').length;
+    const goalStr = achieved > 0 ? `${colors.green}${achieved}${RESET}/${active + achieved}` : `${active}`;
+
+    let runStr: string;
+    let costStr: string;
+    if (r.exec) {
+      const d = new Date(r.exec.ts);
+      const ago = Math.round((Date.now() - d.getTime()) / 3600000);
+      runStr = ago < 24 ? `${ago}h ago` : `${Math.round(ago / 24)}d ago`;
+      costStr = `$${r.exec.cost_usd.toFixed(1)}`;
+      if (r.exec.status !== 'completed') {
+        runStr = `${colors.red}${runStr}${RESET}`;
+      }
+    } else {
+      runStr = `${colors.dim}—${RESET}      `;
+      costStr = `${colors.dim}—${RESET}   `;
+    }
+
+    const action = r.topAction || `${colors.dim}(no state)${RESET}`;
+    writeLine(`  ${r.squad.padEnd(15)} ${runStr.padEnd(8)} ${costStr.padStart(5)} ${goalStr.padStart(4)}  ${action}`);
+  }
+
+  // ── Founder Action Required ──
+  const founderItems = rows.flatMap(r =>
+    r.founderBlockers.map(b => ({ squad: r.squad, text: b }))
+  );
+
+  // Add deadline-driven items
+  const urgentDeadlines = rows.flatMap(r =>
+    r.goals.filter(g => g.deadline && g.section === 'active')
+      .map(g => ({ squad: r.squad, days: daysUntil(g.deadline!), name: g.name }))
+      .filter(g => g.days !== null && g.days <= 14)
+  ).sort((a, b) => (a.days || 99) - (b.days || 99));
+
+  if (founderItems.length > 0 || urgentDeadlines.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}Founder Action${RESET}`);
+
+    for (const d of urgentDeadlines) {
+      const color = (d.days || 0) <= 3 ? colors.red : colors.yellow;
+      writeLine(`  ${color}${String(d.days).padStart(2)}d${RESET}  ${d.squad}: ${d.name}`);
+    }
+
+    for (const f of founderItems) {
+      writeLine(`  ${colors.yellow}>>>${RESET}  ${f.squad}: ${f.text.slice(0, 70)}`);
+    }
+  }
+
+  // ── Blocked goals (agent-resolvable) ──
+  const blockedGoals = rows.flatMap(r =>
+    r.goals.filter(g => g.status === 'blocked' || g.status === 'AT-RISK')
+      .map(g => ({ squad: r.squad, name: g.name, blocker: g.blocker }))
+  );
+
+  if (blockedGoals.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}Blocked Goals${RESET}`);
+    for (const b of blockedGoals) {
+      const link = b.blocker ? extractLink(b.blocker) : '';
+      writeLine(`  ${colors.red}block${RESET}  ${b.squad}: ${b.name}${b.blocker ? ` ${colors.dim}← ${b.blocker.slice(0, 45)}${RESET}` : ''}`);
+      if (link) writeLine(`         ${colors.dim}${link}${RESET}`);
+    }
+  }
+
+  // ── Goal changes: only meaningful (achieved, blocked, new starts) ──
+  const allChanges: Array<{ squad: string; change: GoalChange }> = [];
+  for (const e of execs) {
+    if (!e.goals_changed) continue;
+    for (const c of e.goals_changed) {
+      // Skip noise: in-progress→in-progress, status churn
+      if (c.before === c.after) continue;
+      // Only show: achieved, blocked, removed, or first start
+      const isMeaningful =
+        c.after === 'achieved' || c.after === 'blocked' || c.after === 'removed' ||
+        c.before === 'not-started' || c.before === 'new' ||
+        c.after === 'AT-RISK';
+      if (isMeaningful) {
+        // Deduplicate: keep only latest change per goal per squad
+        const existing = allChanges.findIndex(x => x.squad === e.squad && x.change.name === c.name);
+        if (existing >= 0) {
+          allChanges[existing] = { squad: e.squad, change: c };
+        } else {
+          allChanges.push({ squad: e.squad, change: c });
+        }
+      }
+    }
+  }
+
+  // Group by type for readability
+  const achieved = allChanges.filter(c => c.change.after === 'achieved');
+  const blocked = allChanges.filter(c => c.change.after === 'blocked' || c.change.after === 'AT-RISK');
+  const started = allChanges.filter(c => c.change.before === 'not-started' || c.change.before === 'new');
+  const removed = allChanges.filter(c => c.change.after === 'removed');
+
+  if (allChanges.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}Goal Changes${RESET}  ${achieved.length} achieved  ${started.length} started  ${blocked.length} blocked  ${removed.length} removed`);
+
+    if (achieved.length > 0) {
+      for (const c of achieved) {
+        writeLine(`  ${colors.green}achieved${RESET}  ${c.squad}: ${c.change.name}`);
+      }
+    }
+    if (blocked.length > 0) {
+      for (const c of blocked) {
+        writeLine(`  ${colors.red}blocked${RESET}   ${c.squad}: ${c.change.name}`);
+      }
+    }
+    if (started.length > 0 && started.length <= 8) {
+      for (const c of started) {
+        writeLine(`  ${colors.cyan}started${RESET}   ${c.squad}: ${c.change.name}`);
+      }
+    } else if (started.length > 8) {
+      writeLine(`  ${colors.cyan}started${RESET}   ${started.length} goals across ${new Set(started.map(s => s.squad)).size} squads`);
+    }
+  }
+
+  writeLine();
+  writeLine(`  ${colors.dim}squads review --squad <name>   drill into squad${RESET}`);
+  writeLine();
+}
+
+// ── Squad Detail ────────────────────────────────────────────────────────
+
+function showSquadDetail(squad: string, memoryDir: string): void {
+  writeLine();
+  writeLine(`  ${bold}${squad}${RESET}`);
+
+  // Goals
+  const goals = parseGoalsDetailed(join(memoryDir, squad, 'goals.md'));
+  if (goals.length > 0) {
+    writeLine();
+    for (const section of ['active', 'achieved', 'abandoned', 'proposed'] as const) {
+      const sg = goals.filter(g => g.section === section);
+      if (sg.length === 0) continue;
+      writeLine(`  ${colors.cyan}${section.toUpperCase()}${RESET}`);
+      for (const g of sg) {
+        const days = g.deadline ? daysUntil(g.deadline) : null;
+        const dl = days !== null ? ` ${days <= 7 ? colors.red : colors.dim}(${days}d)${RESET}` : '';
+        const bl = g.blocker ? ` ${colors.red}← ${g.blocker.slice(0, 45)}${RESET}` : '';
+        writeLine(`    ${statusIcon(g.status)}  ${g.name}${dl}${bl}`);
+      }
+    }
+  }
+
+  // Runs
+  const execs = queryExecutions({ squad, limit: 5 });
+  if (execs.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}Runs${RESET}`);
+    for (const e of execs) {
+      const d = new Date(e.ts);
+      const date = `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`;
+      const icon = e.status === 'completed' ? `${colors.green}pass${RESET}` : `${colors.red}fail${RESET}`;
+      const dur = Math.round(e.duration_ms / 60000);
+      const gc = e.goals_changed?.length || 0;
+      writeLine(`    ${icon}  ${date}  ${dur}m  $${e.cost_usd.toFixed(2)}  ${e.agent}${gc > 0 ? `  ${colors.green}+${gc} goals${RESET}` : ''}`);
+    }
+
+    // Cost trend
+    const totalCost = execs.reduce((s, e) => s + e.cost_usd, 0);
+    const totalGoalChanges = execs.reduce((s, e) => s + (e.goals_changed?.length || 0), 0);
+    writeLine(`    ${colors.dim}total: $${totalCost.toFixed(2)} / ${totalGoalChanges} goal changes${RESET}`);
+  }
+
+  // State + blockers
+  const state = readLeadState(memoryDir, squad);
+  if (state.topAction) {
+    writeLine();
+    writeLine(`  ${bold}Last Action${RESET}  ${state.topAction}`);
+  }
+
+  if (state.founderBlockers.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}${colors.yellow}Founder Action${RESET}`);
+    for (const b of state.founderBlockers) writeLine(`    ${colors.yellow}>>>${RESET} ${b}`);
+  }
+
+  if (state.agentBlockers.length > 0) {
+    writeLine();
+    writeLine(`  ${bold}Agent Blockers${RESET}`);
+    for (const b of state.agentBlockers) writeLine(`    ${colors.dim}-${RESET} ${b}`);
+  }
+
+  writeLine();
+}
+
+// ── Register ────────────────────────────────────────────────────────────
+
+export function registerReviewCommand(program: Command): void {
+  program
+    .command('review')
+    .description('Post-cycle evaluation — goals, costs, blockers, founder actions')
+    .option('-s, --squad <squad>', 'Detail view for a specific squad')
+    .option('--since <period>', 'Look back period (e.g. 24h, 7d, 30d)', '7d')
+    .option('--json', 'Output as JSON')
+    .action((opts) => {
+      const squadsDir = findSquadsDir();
+      const memoryDir = findMemoryDir();
+      if (!squadsDir || !memoryDir) {
+        writeLine(`\n  ${colors.dim}No squads found. Run squads init.${RESET}\n`);
+        return;
+      }
+
+      if (opts.squad) {
+        showSquadDetail(opts.squad, memoryDir);
+      } else {
+        showOverview(squadsDir, memoryDir, opts.since);
+      }
+    });
+}

--- a/src/commands/services.ts
+++ b/src/commands/services.ts
@@ -47,7 +47,8 @@ function dockerComposeAvailable(): boolean {
 export function registerServicesCommands(program: Command): void {
   const services = program
     .command('services')
-    .description('Manage Tier 2 local services (Postgres, Redis, API, Bridge)');
+    .description('Manage Tier 2 local services (Postgres, Redis, API, Bridge)')
+    .action(() => { services.outputHelp(); });
 
   // ── services up ──
   services

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -311,6 +311,7 @@ export const Events = {
   // Commands
   CLI_RUN: 'cli.run',
   CLI_RUN_COMPLETE: 'cli.run.complete',
+  CLI_LOG: 'cli.log',
   CLI_STATUS: 'cli.status',
   CLI_DASHBOARD: 'cli.dashboard',
   CLI_WORKERS: 'cli.workers',

--- a/test/commands/credentials.test.ts
+++ b/test/commands/credentials.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { parseGcpCredentials } from '../../src/commands/credentials.js';
+
+describe('parseGcpCredentials', () => {
+  it('parses roles and apis from inline YAML format', () => {
+    const content = `# My Squad
+
+credentials:
+  gcp:
+    roles: [roles/bigquery.dataViewer, roles/bigquery.jobUser]
+    apis: [bigquery.googleapis.com]
+`;
+    const result = parseGcpCredentials(content);
+    expect(result).not.toBeNull();
+    expect(result!.roles).toEqual(['roles/bigquery.dataViewer', 'roles/bigquery.jobUser']);
+    expect(result!.apis).toEqual(['bigquery.googleapis.com']);
+    expect(result!.description).toBe('2 roles, 1 APIs');
+  });
+
+  it('parses quoted values', () => {
+    const content = `credentials:
+  gcp:
+    roles: ['roles/storage.admin', "roles/run.developer"]
+    apis: ['storage.googleapis.com']
+`;
+    const result = parseGcpCredentials(content);
+    expect(result).not.toBeNull();
+    expect(result!.roles).toEqual(['roles/storage.admin', 'roles/run.developer']);
+    expect(result!.apis).toEqual(['storage.googleapis.com']);
+  });
+
+  it('parses multiple APIs', () => {
+    const content = `credentials:
+  gcp:
+    roles: [roles/cloudsql.admin, roles/run.developer, roles/secretmanager.secretAccessor]
+    apis: [sqladmin.googleapis.com, run.googleapis.com, secretmanager.googleapis.com]
+`;
+    const result = parseGcpCredentials(content);
+    expect(result).not.toBeNull();
+    expect(result!.roles).toHaveLength(3);
+    expect(result!.apis).toHaveLength(3);
+  });
+
+  it('returns null when no credentials block exists', () => {
+    const content = `# My Squad
+
+mission: Do great things
+`;
+    expect(parseGcpCredentials(content)).toBeNull();
+  });
+
+  it('returns null when gcp block has no roles or apis', () => {
+    const content = `credentials:
+  github:
+    token: ghp_xxx
+`;
+    expect(parseGcpCredentials(content)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseGcpCredentials('')).toBeNull();
+  });
+
+  it('parses roles even without apis', () => {
+    const content = `credentials:
+  gcp:
+    roles: [roles/viewer]
+`;
+    const result = parseGcpCredentials(content);
+    expect(result).not.toBeNull();
+    expect(result!.roles).toEqual(['roles/viewer']);
+    expect(result!.apis).toEqual([]);
+  });
+
+  it('handles credentials block mixed with other SQUAD.md content', () => {
+    const content = `# Engineering Squad
+
+mission: Build and maintain infrastructure
+
+agents:
+  - name: infra-lead
+    role: orchestrates deployments
+
+credentials:
+  gcp:
+    roles: [roles/cloudsql.admin, roles/run.developer]
+    apis: [sqladmin.googleapis.com, run.googleapis.com]
+
+model:
+  default: sonnet
+`;
+    const result = parseGcpCredentials(content);
+    expect(result).not.toBeNull();
+    expect(result!.roles).toEqual(['roles/cloudsql.admin', 'roles/run.developer']);
+    expect(result!.apis).toEqual(['sqladmin.googleapis.com', 'run.googleapis.com']);
+  });
+});


### PR DESCRIPTION
## Summary — PR 4 of 7 for v0.3.0 release
4 new commands + minor fixes to existing commands.

## Changes (10 files)
**New commands:**
- **credentials.ts**: per-squad GCP service account management
- **goals.ts**: goals dashboard with status tracking
- **log.ts**: run history with timestamps, duration, status
- **review.ts**: post-cycle evaluation dashboard for founder/COO

**Updated:**
- **cli.ts**: register new commands
- **catalog.ts**, **context.ts**, **observability.ts**, **release-check.ts**, **services.ts**: minor fixes

## Merge order
Depends on #731, #732, #733. Merge fourth:
1. ✅ core-refactor (#731)
2. ✅ run-engine (#732)
3. ✅ conversation (#733)
4. **→ new-commands** (this PR)
5. init-ux
6. security-guardrails
7. tests-docs

## Test plan
- [x] `npm run build` passes
- [ ] Review each new command for UX and correctness
- [ ] Review credentials command for security

Reorganized from 219-commit develop branch for proper review.