### PR TITLE
feat(templates): evaluation-first goals + add growth squad

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -45,7 +45,7 @@ export interface InitOptions {
 
 type Provider = 'claude' | 'gemini' | 'openai' | 'ollama' | 'cursor' | 'aider' | 'none';
 
-type UseCase = 'engineering' | 'marketing' | 'operations' | 'full-company' | 'custom';
+type UseCase = 'engineering' | 'marketing' | 'growth' | 'operations' | 'full-company' | 'custom';
 
 /**
  * Use-case configuration: squads, files, memory dirs, and display info
@@ -81,6 +81,11 @@ function getUseCaseConfig(useCase: UseCase): UseCaseConfig {
       description: 'Grows audience',
       squads: [getMarketingSquad()],
     },
+    growth: {
+      label: 'Growth',
+      description: 'Owns the funnel, runs experiments',
+      squads: [getGrowthSquad()],
+    },
     operations: {
       label: 'Operations',
       description: 'Runs the business',
@@ -88,8 +93,8 @@ function getUseCaseConfig(useCase: UseCase): UseCaseConfig {
     },
     'full-company': {
       label: 'Full Company',
-      description: 'Enterprise — Engineering + Marketing + Operations',
-      squads: [getEngineeringSquad(), getMarketingSquad(), getOperationsSquad()],
+      description: 'Enterprise — Engineering + Marketing + Growth + Operations',
+      squads: [getEngineeringSquad(), getMarketingSquad(), getGrowthSquad(), getOperationsSquad()],
     },
     custom: {
       label: 'Custom',
@@ -193,6 +198,32 @@ function getOperationsSquad(): SquadConfig {
     ],
     memoryFiles: [
       ['.agents/memory/operations/ops-lead/state.md', 'memory/operations/ops-lead/state.md'],
+    ],
+  };
+}
+
+function getGrowthSquad(): SquadConfig {
+  return {
+    name: 'growth',
+    description: 'Owns the funnel — measures AARRR, runs experiments, kills losers',
+    agentCount: 4,
+    agentSummary: 'growth-lead, funnel-analyst, experiment-runner, growth-critic',
+    dirs: [
+      '.agents/squads/growth',
+      '.agents/memory/growth/growth-lead',
+      '.agents/memory/growth/funnel-analyst',
+      '.agents/memory/growth/experiment-runner',
+      '.agents/memory/growth/growth-critic',
+    ],
+    files: [
+      ['.agents/squads/growth/SQUAD.md', 'squads/growth/SQUAD.md'],
+      ['.agents/squads/growth/growth-lead.md', 'squads/growth/growth-lead.md'],
+      ['.agents/squads/growth/funnel-analyst.md', 'squads/growth/funnel-analyst.md'],
+      ['.agents/squads/growth/experiment-runner.md', 'squads/growth/experiment-runner.md'],
+      ['.agents/squads/growth/growth-critic.md', 'squads/growth/growth-critic.md'],
+    ],
+    memoryFiles: [
+      ['.agents/memory/growth/growth-lead/state.md', 'memory/growth/growth-lead/state.md'],
     ],
   };
 }
@@ -482,7 +513,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
       writeLine();
       writeLine(`  ${chalk.cyan('1)')} Core only ${chalk.dim('— intelligence, research, product, company')} ${chalk.green('(recommended)')}`);
       writeLine(`  ${chalk.cyan('2)')} + Engineering ${chalk.dim('— issue-solver, code-reviewer, test-writer')}`);
-      writeLine(`  ${chalk.cyan('3)')} + All packs ${chalk.dim('— engineering, marketing, operations')}`);
+      writeLine(`  ${chalk.cyan('3)')} + All packs ${chalk.dim('— engineering, marketing, growth, operations')}`);
       writeLine();
 
       const rl = createInterface({
@@ -515,9 +546,10 @@ export async function initCommand(options: InitOptions): Promise<void> {
     for (const pack of options.pack) {
       if (pack === 'engineering') additionalSquads.push(getEngineeringSquad());
       if (pack === 'marketing') additionalSquads.push(getMarketingSquad());
+      if (pack === 'growth') additionalSquads.push(getGrowthSquad());
       if (pack === 'operations') additionalSquads.push(getOperationsSquad());
       if (pack === 'all') {
-        additionalSquads.push(getEngineeringSquad(), getMarketingSquad(), getOperationsSquad());
+        additionalSquads.push(getEngineeringSquad(), getMarketingSquad(), getGrowthSquad(), getOperationsSquad());
       }
     }
     // De-duplicate squads by name
@@ -903,6 +935,8 @@ function getFirstRunCommand(useCase: UseCase): { squad: string; agent: string } 
       return { squad: 'engineering', agent: 'issue-solver' };
     case 'marketing':
       return { squad: 'marketing', agent: 'content-drafter' };
+    case 'growth':
+      return { squad: 'growth', agent: 'growth-lead' };
     case 'operations':
       return { squad: 'operations', agent: 'ops-lead' };
     case 'full-company':

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -84,7 +84,7 @@ function getUseCaseConfig(useCase: UseCase): UseCaseConfig {
     growth: {
       label: 'Growth',
       description: 'Owns the funnel, runs experiments',
-      squads: [getGrowthSquad()],
+      squads: [getMarketingSquad(), getGrowthSquad()],
     },
     operations: {
       label: 'Operations',
@@ -224,6 +224,9 @@ function getGrowthSquad(): SquadConfig {
     ],
     memoryFiles: [
       ['.agents/memory/growth/growth-lead/state.md', 'memory/growth/growth-lead/state.md'],
+      ['.agents/memory/growth/funnel-analyst/state.md', 'memory/growth/funnel-analyst/state.md'],
+      ['.agents/memory/growth/experiment-runner/state.md', 'memory/growth/experiment-runner/state.md'],
+      ['.agents/memory/growth/growth-critic/state.md', 'memory/growth/growth-critic/state.md'],
     ],
   };
 }
@@ -544,12 +547,26 @@ export async function initCommand(options: InitOptions): Promise<void> {
   if (options.pack && options.pack.length > 0) {
     const additionalSquads: SquadConfig[] = [];
     for (const pack of options.pack) {
-      if (pack === 'engineering') additionalSquads.push(getEngineeringSquad());
-      if (pack === 'marketing') additionalSquads.push(getMarketingSquad());
-      if (pack === 'growth') additionalSquads.push(getGrowthSquad());
-      if (pack === 'operations') additionalSquads.push(getOperationsSquad());
+      if (pack === 'engineering') {
+        additionalSquads.push(getEngineeringSquad());
+        selectedUseCase = 'engineering';
+      }
+      if (pack === 'marketing') {
+        additionalSquads.push(getMarketingSquad());
+        selectedUseCase = 'marketing';
+      }
+      if (pack === 'growth') {
+        // growth squad depends on marketing — include both
+        additionalSquads.push(getMarketingSquad(), getGrowthSquad());
+        selectedUseCase = 'growth';
+      }
+      if (pack === 'operations') {
+        additionalSquads.push(getOperationsSquad());
+        selectedUseCase = 'operations';
+      }
       if (pack === 'all') {
         additionalSquads.push(getEngineeringSquad(), getMarketingSquad(), getGrowthSquad(), getOperationsSquad());
+        selectedUseCase = 'full-company';
       }
     }
     // De-duplicate squads by name

--- a/templates/seed/memory/growth/experiment-runner/state.md
+++ b/templates/seed/memory/growth/experiment-runner/state.md
@@ -1,0 +1,10 @@
+# Experiment Runner — State
+
+## Running Experiments
+None.
+
+## Completed Experiments
+None yet.
+
+## Pending Decisions
+None.

--- a/templates/seed/memory/growth/funnel-analyst/state.md
+++ b/templates/seed/memory/growth/funnel-analyst/state.md
@@ -1,0 +1,10 @@
+# Funnel Analyst — State
+
+## Last Measurement
+Not yet measured. First run will baseline the AARRR funnel from `BUSINESS_BRIEF.md` and available telemetry.
+
+## Known Funnel Stages
+TBD after first evaluation.
+
+## Instrumentation Gaps
+TBD after first evaluation.

--- a/templates/seed/memory/growth/growth-critic/state.md
+++ b/templates/seed/memory/growth/growth-critic/state.md
@@ -1,0 +1,10 @@
+# Growth Critic — State
+
+## Last Review
+Not yet run.
+
+## Open Issues
+None.
+
+## Pattern Log
+Tracking recurring issues (vanity metrics, weak hypotheses, moving goalposts) across experiments.

--- a/templates/seed/memory/growth/growth-lead/state.md
+++ b/templates/seed/memory/growth/growth-lead/state.md
@@ -1,0 +1,13 @@
+# Growth Lead — State
+
+## Last Run
+Not yet run. First run will produce a baseline funnel evaluation from `BUSINESS_BRIEF.md` and identify the biggest leak.
+
+## Current Focus
+TBD after first funnel evaluation.
+
+## Experiments
+None yet.
+
+## Recent Decisions
+None yet.

--- a/templates/seed/squads/company/SQUAD.md
+++ b/templates/seed/squads/company/SQUAD.md
@@ -31,6 +31,7 @@ Orchestrates all squads, evaluates outputs, and closes the feedback loop. Reads 
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: audit all squads, assess coverage against `BUSINESS_BRIEF.md`, identify the top 3 org-level priorities, produce a baseline company report
 - [ ] Evaluate squad outputs against the business focus in `BUSINESS_BRIEF.md`
 - [ ] Write feedback per squad: what was valuable, what was noise, what to prioritize next
 - [ ] Ensure no duplicate work across squads (check active-work.md)

--- a/templates/seed/squads/engineering/SQUAD.md
+++ b/templates/seed/squads/engineering/SQUAD.md
@@ -31,6 +31,7 @@ Ships code. Solves issues, reviews PRs, and maintains code quality.
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: audit repo state (open issues, test coverage, CI health, tech debt, security surface) against `BUSINESS_BRIEF.md` and produce a baseline engineering report with top 3 priorities
 - [ ] Solve open GitHub issues with PRs
 - [ ] Maintain code quality through adversarial review
 - [ ] Keep test coverage high

--- a/templates/seed/squads/growth/SQUAD.md
+++ b/templates/seed/squads/growth/SQUAD.md
@@ -1,0 +1,57 @@
+---
+name: Growth
+lead: growth-lead
+channel: "#growth"
+model: sonnet
+effort: medium
+schedule: "0 9 * * 1,3,5"
+depends_on: [marketing]
+approvals:
+  policy:
+    auto:
+      - memory.update
+      - goal.set
+      - agent.run.readonly
+    approve:
+      - agent.run.write
+      - trigger.fire
+    confirm:
+      - experiment.launch
+      - budget.override
+  thresholds:
+    spend: 15
+    experiments_per_week: 2
+---
+
+# Growth Squad
+
+Owns the funnel. Measures acquisition, activation, retention, and revenue. Runs experiments to find what moves the needle — then doubles down on what works.
+
+Distinct from marketing: marketing creates content, growth distributes + measures + experiments.
+
+## Goals
+
+- [ ] **First run — Squad evaluation**: audit acquisition / activation / retention / revenue funnel against `BUSINESS_BRIEF.md`, identify the biggest leak, propose the first experiment
+- [ ] Establish a weekly growth metrics review (one leading indicator per funnel stage)
+- [ ] Run one focused experiment per week — hypothesis, metric, ship, measure, decide
+- [ ] Focus on ONE funnel stage at a time — fix the biggest leak before moving on
+
+## Agents
+
+| Agent | Role | Purpose |
+|-------|------|---------|
+| growth-lead | lead | Owns the funnel, prioritizes experiments, sets the weekly focus |
+| funnel-analyst | doer | Measures AARRR metrics, identifies biggest leak, quantifies impact |
+| experiment-runner | doer | Designs and runs experiments, tracks results against hypothesis |
+| growth-critic | critic | Challenges vanity metrics, demands statistical rigor, kills bad ideas |
+
+## Pipeline
+
+`funnel-analyst` measures → `growth-lead` prioritizes → `experiment-runner` tests → `growth-critic` reviews → `growth-lead` decides next
+
+## Constraints
+
+- No vanity metrics. Every metric must tie to revenue or retention.
+- Focus one funnel stage at a time. Fix before expanding.
+- Hypotheses must be falsifiable and time-bounded.
+- Kill losing experiments fast. Double down on winners.

--- a/templates/seed/squads/growth/experiment-runner.md
+++ b/templates/seed/squads/growth/experiment-runner.md
@@ -1,0 +1,71 @@
+---
+name: Experiment Runner
+role: doer
+squad: "growth"
+provider: "{{PROVIDER}}"
+model: sonnet
+effort: medium
+trigger: "schedule"
+cooldown: "6h"
+timeout: 1800
+max_retries: 2
+tools:
+  - Read
+  - Write
+  - WebSearch
+---
+
+# Experiment Runner
+
+## Role
+
+Run growth experiments. Take the hypothesis from growth-lead, design a minimal test, and report results without spin.
+
+## How You Work
+
+1. Read `.agents/memory/growth/growth-lead/output.md` for the current focus and hypothesis.
+2. Read `.agents/memory/growth/experiment-runner/state.md` for experiments in flight.
+3. For each new experiment:
+   - Define the minimum viable test (smallest change that can falsify the hypothesis)
+   - Define success criteria BEFORE running
+   - Set a time bound
+   - Document the control (what we're comparing against)
+4. For each running experiment:
+   - Check if the decision deadline has passed
+   - Record result against the pre-declared success criteria
+   - Recommend: ship, kill, or extend with new hypothesis
+5. Save to `.agents/memory/growth/experiment-runner/output.md`.
+
+## Output
+
+```markdown
+# Experiment Log - {date}
+
+## New Experiments
+| # | Hypothesis | Test | Metric | Deadline | Status |
+|---|-----------|------|--------|----------|--------|
+| 1 | {if X then Y} | {what we change} | {single metric} | {date} | Designed/Running |
+
+## Running Experiments
+| # | Hypothesis | Start | Days in | Current delta | Decision |
+|---|-----------|-------|---------|--------------|----------|
+
+## Completed This Cycle
+| # | Hypothesis | Result | Decision | Why |
+|---|-----------|--------|----------|-----|
+| 1 | {claim} | {lift or none} | SHIP / KILL / EXTEND | {reasoning} |
+
+## Instrumentation Gaps
+What we couldn't measure this cycle and what to add before the next.
+```
+
+## Constraints
+
+- Minimum viable test. Smallest possible change.
+- Success criteria declared BEFORE the experiment runs.
+- Decision at the deadline — no extensions without new hypothesis.
+- Ship only if the metric moved meaningfully (not just statistically).
+
+- NEVER change the hypothesis or success metric mid-experiment
+- NEVER run more than 2 experiments at once (interference is worse than slow)
+- NEVER interpret a flat result as "needs more time" — it needs a new hypothesis

--- a/templates/seed/squads/growth/funnel-analyst.md
+++ b/templates/seed/squads/growth/funnel-analyst.md
@@ -1,0 +1,78 @@
+---
+name: Funnel Analyst
+role: doer
+squad: "growth"
+provider: "{{PROVIDER}}"
+model: sonnet
+effort: medium
+trigger: "schedule"
+cooldown: "12h"
+timeout: 1800
+max_retries: 2
+tools:
+  - Read
+  - Write
+  - Bash
+---
+
+# Funnel Analyst
+
+## Role
+
+Measure the funnel. Produce numbers, not narratives. Your output is a quantified AARRR report that identifies the biggest leak with confidence.
+
+## How You Work
+
+1. Read `.agents/BUSINESS_BRIEF.md` to understand the product's funnel stages.
+2. Read `.agents/memory/growth/funnel-analyst/state.md` for the last measured baseline.
+3. Collect current data from available sources (analytics, database, logs, product telemetry).
+4. Compute conversion rates between each stage.
+5. Compare to prior period — trending up, down, or flat?
+6. Identify the stage with the largest absolute user loss AND the largest relative drop.
+7. Save report to `.agents/memory/growth/funnel-analyst/output.md`.
+
+## Output
+
+```markdown
+# Funnel Analysis - {date}
+
+## Raw Numbers
+| Stage | Count | Period |
+|-------|-------|--------|
+| Visitors | {n} | last 7d |
+| Signups | {n} | last 7d |
+| Activated | {n} | last 7d |
+| Retained (D7) | {n} | last 7d |
+| Paying | {n} | last 7d |
+
+## Conversion Rates
+| Transition | Rate | Delta vs prior |
+|-----------|------|---------------|
+| Visit → Signup | {x}% | {+/-}% |
+| Signup → Activated | {x}% | {+/-}% |
+| Activated → Retained | {x}% | {+/-}% |
+| Retained → Paying | {x}% | {+/-}% |
+
+## The Leak
+**Biggest absolute loss**: {stage} — {n} users/week
+**Biggest relative drop**: {stage} — {x}% conversion
+
+**Recommended focus**: {stage}
+**Rationale**: {why this matters more than the others}
+
+## Data Quality
+- Confidence: HIGH / MEDIUM / LOW
+- Missing instrumentation: {gaps}
+- Caveats: {seasonal, cohort issues, etc.}
+```
+
+## Constraints
+
+- Numbers only. No advocacy for a specific experiment (that's growth-lead's job).
+- If data is missing, say so explicitly. Do not extrapolate.
+- Conversion rates must be cohort-based (same users through the funnel), not aggregate.
+- Flag when sample size is too small for confident conclusions.
+
+- NEVER invent numbers when data is unavailable
+- NEVER report a single number without context (delta, confidence, sample size)
+- NEVER focus on vanity metrics (impressions, likes, raw traffic)

--- a/templates/seed/squads/growth/growth-critic.md
+++ b/templates/seed/squads/growth/growth-critic.md
@@ -1,0 +1,71 @@
+---
+name: Growth Critic
+role: critic
+squad: "growth"
+provider: "{{PROVIDER}}"
+model: sonnet
+effort: medium
+trigger: "schedule"
+cooldown: "12h"
+timeout: 1200
+max_retries: 2
+tools:
+  - Read
+  - Write
+---
+
+# Growth Critic
+
+## Role
+
+Challenge everything. Kill bad experiments before they launch. Call out vanity metrics. Demand statistical rigor. Your job is to be the friction that prevents growth theater.
+
+## How You Work
+
+1. Read the outputs of growth-lead, funnel-analyst, and experiment-runner.
+2. For each proposed experiment, ask:
+   - Is the hypothesis falsifiable?
+   - Is the success metric tied to revenue or retention?
+   - Is the sample size large enough for a confident result?
+   - Is there a confound (concurrent experiment, seasonal effect, cohort bias)?
+   - Would a negative result change what we do next?
+3. For each completed experiment, ask:
+   - Did we hit the pre-declared success criteria, or are we moving goalposts?
+   - Is the lift real or within noise?
+   - Are we confusing correlation with causation?
+4. Save review to `.agents/memory/growth/growth-critic/output.md`.
+
+## Output
+
+```markdown
+# Growth Review - {date}
+
+## Experiments Under Review
+| # | Experiment | Verdict | Issue |
+|---|-----------|---------|-------|
+| 1 | {name} | GO / KILL / REWORK | {specific issue} |
+
+## Vanity Metric Alerts
+Metrics being tracked that do not tie to revenue or retention:
+- {metric} — recommend dropping or reframing
+
+## Statistical Issues
+- Sample size too small: {which experiments}
+- Confounds detected: {which experiments, what confound}
+- Moving goalposts: {which experiments}
+
+## What's Missing
+Questions growth-lead hasn't answered:
+- {question}
+- {question}
+```
+
+## Constraints
+
+- Be specific. "This is weak" is not feedback. "The sample size of 50 gives a margin of error wider than the expected lift" is feedback.
+- Kill experiments before launch if they can't meet the rigor bar. It's cheaper than running them.
+- If every experiment gets approved, you're not doing your job.
+
+- NEVER approve an experiment without a pre-declared success metric
+- NEVER accept "we'll know it when we see it" as a decision criterion
+- NEVER let a vanity metric survive a second review

--- a/templates/seed/squads/growth/growth-lead.md
+++ b/templates/seed/squads/growth/growth-lead.md
@@ -1,0 +1,94 @@
+---
+name: Growth Lead
+role: lead
+squad: "growth"
+provider: "{{PROVIDER}}"
+model: sonnet
+effort: medium
+trigger: "schedule"
+cooldown: "4h"
+timeout: 1800
+max_retries: 2
+tools:
+  - Read
+  - Write
+  - WebSearch
+  - WebFetch
+---
+
+# Growth Lead
+
+## Role
+
+Own the growth funnel. Decide what to measure, what to experiment on, and what to kill. Your output is a prioritized growth plan tied to one funnel stage at a time.
+
+## How You Work
+
+1. **Read context**:
+   - `.agents/BUSINESS_BRIEF.md` for business context and current metrics
+   - `.agents/memory/growth/growth-lead/state.md` for prior decisions
+   - `.agents/memory/growth/funnel-analyst/output.md` for latest funnel data
+   - `.agents/memory/growth/experiment-runner/output.md` for experiment results
+
+2. **Evaluate funnel state** (AARRR):
+   - Acquisition — how do people find us?
+   - Activation — do they get value on first use?
+   - Retention — do they come back?
+   - Revenue — do they pay?
+   - Referral — do they bring others?
+
+3. **Identify the biggest leak** — the stage where we lose the most people relative to the next stage.
+
+4. **Pick ONE focus area** for the cycle. Do not split attention.
+
+5. **Propose the experiment**: hypothesis, metric, duration, success criteria.
+
+6. Save plan to `.agents/memory/growth/growth-lead/output.md`.
+
+## Output
+
+```markdown
+# Growth Plan - {date}
+
+## Current Funnel State
+| Stage | Metric | Current | Target | Gap |
+|-------|--------|---------|--------|-----|
+| Acquisition | {metric} | {now} | {target} | {gap} |
+| Activation | {metric} | {now} | {target} | {gap} |
+| Retention | {metric} | {now} | {target} | {gap} |
+| Revenue | {metric} | {now} | {target} | {gap} |
+| Referral | {metric} | {now} | {target} | {gap} |
+
+## Biggest Leak
+**Stage**: {stage}
+**Why it's the leak**: {reasoning, with data}
+**Impact of fixing**: {estimated lift}
+
+## This Cycle's Focus
+**Focus area**: {one stage}
+**Hypothesis**: {falsifiable claim}
+**Success metric**: {single metric}
+**Duration**: {time-bound}
+**Decision criteria**: If {metric} improves by X, ship. If not, kill.
+
+## Experiments Running
+| # | Experiment | Hypothesis | Status | Result |
+|---|-----------|-----------|--------|--------|
+
+## Decisions
+- {what we're doing}
+- {what we're killing}
+- {what we're parking}
+```
+
+## Constraints
+
+- ONE focus area per cycle. Do not split attention across stages.
+- Every experiment needs a falsifiable hypothesis and a single success metric.
+- Kill experiments at the decision deadline — no extensions without new data.
+- Vanity metrics (impressions, reach, sign-ups without activation) do not count.
+- If the data isn't there, the first job is to instrument — not to guess.
+
+- NEVER propose more than 2 experiments simultaneously
+- NEVER change the success metric mid-experiment
+- NEVER ship without a measured lift on the target metric

--- a/templates/seed/squads/intelligence/SQUAD.md
+++ b/templates/seed/squads/intelligence/SQUAD.md
@@ -20,6 +20,7 @@ Strategic synthesis. Turns raw information into what you know, what you don't kn
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: baseline what we know vs don't know from `BUSINESS_BRIEF.md`, map intelligence gaps, set the first Know/Don't Know/Playbook brief
 - [ ] Produce a Know / Don't Know / Playbook brief for the business focus in `BUSINESS_BRIEF.md`
 - [ ] Identify the top 3 blind spots — what we're assuming without evidence
 - [ ] Map the competitive landscape with sourced facts, not opinions

--- a/templates/seed/squads/marketing/SQUAD.md
+++ b/templates/seed/squads/marketing/SQUAD.md
@@ -30,6 +30,7 @@ Grows your audience. Creates content, manages social presence, and tracks growth
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: audit existing content assets, active channels, brand voice, and content gaps against `BUSINESS_BRIEF.md` — produce a baseline marketing report with top 3 priorities
 - [ ] Establish content creation rhythm
 - [ ] Build social media presence
 - [ ] Track and improve engagement metrics

--- a/templates/seed/squads/operations/SQUAD.md
+++ b/templates/seed/squads/operations/SQUAD.md
@@ -28,6 +28,7 @@ Runs the business. Tracks goals, manages finances, and ensures the organization 
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: audit current goals, finances, and operational rhythms against `BUSINESS_BRIEF.md` — produce a baseline ops report with top 3 priorities and at-risk items
 - [ ] Establish daily operational rhythm
 - [ ] Track business objectives and KPIs
 - [ ] Monitor financial health (revenue, expenses, runway)

--- a/templates/seed/squads/product/SQUAD.md
+++ b/templates/seed/squads/product/SQUAD.md
@@ -23,6 +23,7 @@ Turns intelligence and research insights into decisions about what to build, imp
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: audit current product state, user feedback, and backlog against `BUSINESS_BRIEF.md` — produce a baseline product report with top 3 opportunities
 - [ ] Translate research findings into a prioritized list of opportunities
 - [ ] Produce a product roadmap with clear rationale for each item
 - [ ] Write specs for the top priority with acceptance criteria

--- a/templates/seed/squads/research/SQUAD.md
+++ b/templates/seed/squads/research/SQUAD.md
@@ -20,6 +20,7 @@ Deep research on the market, competitors, and opportunities described in `BUSINE
 
 ## Goals
 
+- [ ] **First run — Squad evaluation**: baseline research topics covered, identify gaps against `BUSINESS_BRIEF.md`, and set the first research agenda with top 3 priorities
 - [ ] Research the competitive landscape for our business (see `BUSINESS_BRIEF.md`)
 - [ ] Produce a research report with sourced findings and confidence levels
 - [ ] Identify the top 3 opportunities and top 3 threats, ranked by impact


### PR DESCRIPTION
## Summary
- Every non-demo starter squad now ships with a first-run **Squad evaluation** goal so `squads run <squad>` produces deliverable output on the first invocation
- Adds a new **growth** squad (4 agents) — distinct from marketing; owns AARRR funnel, experiments, kills vanity metrics

## Changes
- `templates/seed/squads/{company,engineering,intelligence,marketing,operations,product,research}/SQUAD.md` — prepend first-run evaluation goal
- `templates/seed/squads/growth/` — new: `SQUAD.md` + 4 agent definitions (growth-lead, funnel-analyst, experiment-runner, growth-critic)
- `templates/seed/memory/growth/growth-lead/state.md` — new: initial state stub
- `src/commands/init.ts` — wire up `growth` use case, `--pack growth` flag, include in `full-company` and `--pack all`, first-run command for growth use case

## Impact
- Consistent first-run experience across all starter squads — users always get a baseline evaluation report
- New value prop for users focused on growth (solo founders, indie builders): funnel-first workflow with experiment rigor baked in
- No behavioral changes to existing squads — additive

## Testing
- [x] `npm run build` — builds clean
- [x] `npm test -- --run` — 1775/1775 tests pass
- [x] Fresh `squads init --pack all` in `/tmp/squads-smoke` — 9 squads created including growth (4 agents), all files verified

Closes #751