### PR TITLE
fix(ci): migrate publish workflows to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,13 +62,29 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1)
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - run: npm ci
 
       - run: npm run build
 
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Determine npm dist-tag from package.json
+        id: dist_tag
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+            echo "Publishing pre-release $VERSION to @next"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "Publishing $VERSION to @latest"
+          fi
+
+      # Authentication via OIDC trusted publisher (configured on npmjs.com).
+      # No NPM_TOKEN needed.
+      - run: npm publish --provenance --access public --tag ${{ steps.dist_tag.outputs.npm_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,13 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1)
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -93,10 +97,10 @@ jobs:
             echo "Publishing $TAG to @latest"
           fi
 
+      # Authentication via OIDC trusted publisher (configured on npmjs.com).
+      # No NPM_TOKEN needed.
       - name: Publish to npm
         run: npm publish --provenance --access public --tag ${{ steps.dist_tag.outputs.npm_tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- npm publish failed 404 because NODE_AUTH_TOKEN (stale NPM_TOKEN) was used instead of the OIDC trusted publisher already configured on npmjs.com
- Remove the token env var from both publish.yml (manual) and release.yml (tag-triggered)
- Upgrade Node to 22 + install npm@latest (OIDC trusted publishing needs npm >= 11.5.1)
- publish.yml now detects @next vs @latest dist-tag from package.json (pre-release versions go to @next)

## Impact
- Future publishes authenticate via short-lived OIDC tokens minted per run
- NPM_TOKEN secret can be deleted from repo after verification
- After merging develop→main, re-run publish.yml to ship v0.3.0-rc.1 to @next

## Testing
- [ ] Workflow YAML validates
- [ ] After merge, re-run publish workflow and confirm v0.3.0-rc.1 lands on npm under @next

Closes #754