### PR TITLE
release: v0.3.0 — promote rc.1 to @latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squads-cli",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squads-cli",
-      "version": "0.3.0-rc.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squads-cli",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0",
   "description": "Your AI workforce. Every user gets an AI manager that runs their team — finance, marketing, engineering, operations — for the cost of API calls.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Promotes `0.3.0-rc.1` (published on `@next` since 2026-04-24) to the stable `0.3.0` release.

After merge, tag `v0.3.0` triggers `release.yml` → publishes to `@latest` via OIDC trusted publishing.

## Changes
- `package.json`: `0.3.0-rc.1` → `0.3.0`
- `package-lock.json`: synced

## v0.3.0 highlights (since 0.2.2)
- Run engine rewrite, conversation protocol (agents talk + use tools)
- New commands: review, credentials, goals, log
- Project-level config system (`.squads/config.yml`)
- Role-based timeouts + anti-collision in org runs
- PreToolUse guardrail hooks
- OIDC trusted publishing (no more NPM_TOKEN)
- Audit remediation: no hardcoded values, extracted prompts, parameterized config

## Post-merge steps
```bash
git checkout main && git pull
git tag v0.3.0
git push origin v0.3.0   # release.yml publishes to @latest
```

## Test plan
- [ ] CI green on release branch
- [ ] rc.1 burn-in completed on `@next` (24+ hours)
- [ ] Tested `npm i -g squads-cli@next` on Mac
- [ ] Tested on Windows