### PR TITLE
fix(ci): --force on npm self-upgrade — unblock v0.3.1 publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,9 +65,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1)
+      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1).
+      # --force bypasses the self-upgrade MODULE_NOT_FOUND bug where mid-upgrade
+      # npm fails to resolve its own internal modules (e.g. 'promise-retry').
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --force
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,11 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1)
+      # Upgrade npm to a version that supports OIDC trusted publishing (>= 11.5.1).
+      # --force bypasses the self-upgrade MODULE_NOT_FOUND bug where mid-upgrade
+      # npm fails to resolve its own internal modules (e.g. 'promise-retry').
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --force
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
The v0.3.1 release ran successfully through CI + security but **failed at npm publish** because the npm self-upgrade step crashed:

\`\`\`
npm install -g npm@latest
→ Cannot find module 'promise-retry'
→ ##[error]Process completed with exit code 1.
\`\`\`

Documented npm bug: when `npm@latest` self-upgrades from `npm@10.x`, the partially-installed new package can't resolve its own arborist internals mid-install. \`--force\` bypasses the broken intermediate state.

## Changes
- `release.yml`: \`npm install -g npm@latest\` → \`npm install -g npm@latest --force\`
- `publish.yml`: same fix (also affected)

## Why this blocks the release
- @latest is still at 0.2.2
- v0.3.1 tag exists but never published
- After merge, we re-push the v0.3.1 tag to re-trigger release.yml with the fix

## Post-merge steps
\`\`\`bash
git checkout main && git pull
git tag -d v0.3.1
git push origin :refs/tags/v0.3.1
git tag v0.3.1
git push origin v0.3.1   # re-triggers release.yml with the fix
\`\`\`

## Test plan
- [ ] CI green
- [ ] After tag re-push: release.yml completes successfully
- [ ] \`npm view squads-cli dist-tags\` shows \`latest: 0.3.1\`