### PR TITLE
feat(windows): smoke-test script + setup docs (Phase 1)

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,111 @@
+# Windows setup
+
+`squads-cli` runs on Windows. There are two install paths — pick the one that matches how you'd ship to your users.
+
+## Path A — Native Windows (PowerShell)
+
+For users who prefer to stay on Windows-native tooling.
+
+### Install
+
+1. **Node.js 18+** — https://nodejs.org (the LTS installer is fine)
+2. **Git for Windows** — https://git-scm.com/download/win
+3. **squads-cli**:
+   ```powershell
+   npm install -g squads-cli
+   squads --version
+   ```
+
+### Smoke test
+
+Verify the install with the shipped script:
+
+```powershell
+git clone https://github.com/agents-squads/squads-cli.git
+cd squads-cli
+pwsh scripts/windows-smoke-test.ps1
+```
+
+This runs an end-to-end check: install, init, list, dry-run.
+
+## Path B — WSL2 (Linux on Windows)
+
+For developers who want a Linux shell. This is what most Windows devs use day-to-day.
+
+### Install
+
+1. **Enable WSL2** (one-time, in elevated PowerShell):
+   ```powershell
+   wsl --install
+   # Reboot, then open the Ubuntu shell
+   ```
+2. **Inside Ubuntu**, follow the standard Linux instructions:
+   ```bash
+   curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+   sudo apt-get install -y nodejs git
+   npm install -g squads-cli
+   ```
+
+### Tier 2 services in WSL2
+
+Docker Desktop integrates with WSL2 — once installed, `docker` works inside the Ubuntu shell. Tier 2 setup is identical to native Linux.
+
+## Remote testing via SSH
+
+If you have a Windows machine you want to drive from another machine (e.g. testing from a Mac):
+
+### One-time setup on the Windows machine (elevated PowerShell)
+
+```powershell
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+
+# Allow SSH through the firewall
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH Server' `
+    -Enabled True -Direction Inbound -Protocol TCP `
+    -Action Allow -LocalPort 22
+
+# Find your LAN IP
+ipconfig | Select-String "IPv4"
+```
+
+### From the remote machine
+
+```bash
+ssh <windows-username>@<windows-ip>
+# default shell is cmd.exe; switch to PowerShell:
+powershell
+```
+
+The smoke script runs the same way over SSH as locally.
+
+## Troubleshooting
+
+### `squads: command not found`
+After global npm install, the npm prefix bin directory needs to be on `PATH`. Restart your shell or run:
+```powershell
+$env:Path += ";$(npm config get prefix)"
+```
+
+### Long path errors
+Windows has a default 260-char path limit that breaks deep `node_modules` trees. Enable long paths once:
+```powershell
+# Elevated PowerShell
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+    -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+```
+
+### `Set-ExecutionPolicy` blocks scripts
+PowerShell may refuse to run `.ps1` files. For a one-time smoke run:
+```powershell
+pwsh -ExecutionPolicy Bypass -File scripts/windows-smoke-test.ps1
+```
+
+### Tier 2 needs Docker Desktop
+Tier 2 (Postgres + Redis + API + Bridge) requires Docker Desktop. Note: Docker Desktop **does not work inside a virtual machine** that uses nested virtualization (UTM, Parallels in some configs) — install on bare-metal Windows or use WSL2 + Docker Desktop.
+
+## Known limitations
+
+- **Tier 2 image availability**: At the time of writing, public Docker images for `squads-bridge` and `squads-api` are not yet published. Tier 2 currently requires building locally from the `agents-squads` source tree. See the [Tier 2 epic](https://github.com/agents-squads/squads-cli/issues) for status.
+- **Native shell only**: The `squads` binary works in PowerShell, cmd, and WSL2. Older Windows shells (Windows 7 cmd, etc.) are not supported.

--- a/scripts/windows-smoke-test.ps1
+++ b/scripts/windows-smoke-test.ps1
@@ -1,0 +1,136 @@
+# Windows smoke test: PowerShell parity for scripts/e2e-smoke.sh
+#
+# Simulates a real Windows user installing squads-cli from npm and running
+# their first commands. Catches Windows-specific packaging or path bugs
+# that Linux/macOS CI misses.
+#
+# Usage (from repo root):
+#   pwsh scripts/windows-smoke-test.ps1                  # use published @latest
+#   pwsh scripts/windows-smoke-test.ps1 -FromTarball     # build + pack local tarball
+#   pwsh scripts/windows-smoke-test.ps1 -Tag next        # use @next dist-tag
+#
+# Requirements: PowerShell 7+, Node 18+, npm, git.
+
+[CmdletBinding()]
+param(
+    [switch]$FromTarball,
+    [string]$Tag = 'latest'
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Step($name) {
+    Write-Host ""
+    Write-Host "=== STEP: $name ===" -ForegroundColor Cyan
+}
+
+function Require($cmd, $hint) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        Write-Host "  Missing: $cmd" -ForegroundColor Red
+        Write-Host "  $hint" -ForegroundColor DarkGray
+        exit 1
+    }
+}
+
+# ── Pre-flight ──────────────────────────────────────────────────────────────
+
+Step "Pre-flight checks"
+Require 'node' 'Install Node.js 18+ from https://nodejs.org'
+Require 'npm'  'npm ships with Node.js'
+Require 'git'  'Install Git from https://git-scm.com'
+
+$nodeVersion = (node --version) -replace 'v',''
+$nodeMajor = [int]($nodeVersion.Split('.')[0])
+if ($nodeMajor -lt 18) {
+    Write-Host "  Node $nodeVersion is too old. Need 18+." -ForegroundColor Red
+    exit 1
+}
+Write-Host "  Node $nodeVersion - OK" -ForegroundColor Green
+Write-Host "  npm  $(npm --version) - OK" -ForegroundColor Green
+
+# ── Determine install source ────────────────────────────────────────────────
+
+$repoRoot = Resolve-Path "$PSScriptRoot/.."
+$tarballPath = $null
+
+if ($FromTarball) {
+    Step "Building local tarball"
+    Push-Location $repoRoot
+    try {
+        npm run build
+        $tarball = (npm pack --quiet | Select-Object -Last 1).Trim()
+        $tarballPath = Join-Path $repoRoot $tarball
+        Write-Host "  Built: $tarball" -ForegroundColor Green
+    } finally {
+        Pop-Location
+    }
+}
+
+# ── Cleanup hook ────────────────────────────────────────────────────────────
+
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "squads-smoke-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+
+function Cleanup {
+    Write-Host ""
+    Write-Host "▶ Cleaning up..." -ForegroundColor DarkGray
+    npm uninstall -g squads-cli 2>$null
+    if (Test-Path $tmpDir) { Remove-Item -Recurse -Force $tmpDir }
+    if ($tarballPath -and (Test-Path $tarballPath)) { Remove-Item -Force $tarballPath }
+}
+
+try {
+    # ── Install ─────────────────────────────────────────────────────────────
+
+    Step "Installing squads-cli"
+    if ($FromTarball) {
+        npm install -g $tarballPath
+    } else {
+        npm install -g "squads-cli@$Tag"
+    }
+
+    # ── Smoke ───────────────────────────────────────────────────────────────
+
+    New-Item -ItemType Directory -Force -Path $tmpDir | Out-Null
+    Push-Location $tmpDir
+    try {
+        git init -q
+        git config user.email "smoke@test.local"
+        git config user.name "Smoke Test"
+        git commit --allow-empty -q -m "init"
+
+        Step "squads --version"
+        squads --version
+
+        Step "squads --help (footer should show Resources block)"
+        $help = squads --help
+        $help | Select-Object -Last 8
+        if ($help -notmatch 'Changelog') {
+            Write-Host "  WARN: Resources footer missing from --help output" -ForegroundColor Yellow
+        }
+
+        Step "squads init --yes --force"
+        squads init --yes --force
+
+        Step "squads status"
+        squads status
+
+        Step "squads doctor"
+        try { squads doctor } catch { Write-Host "  doctor reported issues (non-fatal)" -ForegroundColor Yellow }
+
+        Step "squads run <squad> --dry-run"
+        $statusOutput = squads status 2>$null
+        $firstSquad = ($statusOutput | Select-String -Pattern '^\s+(\w+)' | Select-Object -First 1).Matches.Groups[1].Value
+        if ($firstSquad) {
+            try { squads run $firstSquad --dry-run } catch { Write-Host "  dry-run reported issues (non-fatal)" -ForegroundColor Yellow }
+        } else {
+            Write-Host "  skip: no squads found after init" -ForegroundColor Yellow
+        }
+    } finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+    Write-Host "All Windows smoke test steps passed" -ForegroundColor Green
+} finally {
+    Cleanup
+}


### PR DESCRIPTION
## Summary
Phase 1 of cross-platform support — validates squads-cli actually works on Windows. Adds a PowerShell smoke test (parity with `scripts/e2e-smoke.sh`) and a setup guide covering native PowerShell, WSL2, and OpenSSH for remote testing.

Closes #747 (Windows test for v0.3.x).

## What's in the PR
- `scripts/windows-smoke-test.ps1` — runs install → init → status → doctor → run --dry-run. Supports `-FromTarball` (local build) and `-Tag <next|latest>` flags.
- `docs/windows.md` — two install paths (native vs WSL2), SSH setup commands, troubleshooting (long paths, ExecutionPolicy, PATH).

## What's NOT in the PR
- Tier 2 setup (Postgres + Redis + API + Bridge via Docker) — the Bridge and API images aren't public yet. Filed as Phase 2 epic.
- Bundled `docker-compose.yml` in `templates/` — same reason; would point at images that don't exist.
- Changes to `squads init` behaviour — Phase 1 is verification only, no scaffold changes.

## Why phased
Tier 2 needs work across 3 repos (`agents-squads`, `squads-api`, `squads-cli`) and adds a "local mode" auth path on the API (today the API requires GCP Secret Manager). That's a multi-PR epic. Phase 1 ships independently and unlocks public announcement of v0.3.1 cross-platform support.

## Test plan
- [ ] Manual run on a real Windows machine: `pwsh scripts/windows-smoke-test.ps1`
- [ ] Run with `-Tag next` to verify @next channel works end-to-end
- [ ] Run with `-FromTarball` to validate packaging before next release