### PR TITLE
fix(run): scope squad leads to plan+dispatch — no build tools (#790)

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -159,7 +159,10 @@ ${squadContext}
   const buildTools = ['Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)'];
 
   const toolsByRole: Record<string, string[]> = {
-    lead: [...readTools, ...writeTools],
+    // Leads PLAN and DELEGATE — they get read + dispatch (Agent), but NOT
+    // Write/Edit/build-Bash. Without this a lead authors+commits code itself
+    // instead of assigning workers (squads-cli#790).
+    lead: [...readTools, 'Agent'],
     scanner: readTools,
     worker: [...readTools, ...writeTools],
     verifier: [...readTools, ...buildTools],


### PR DESCRIPTION
Closes #790.

**Problem:** `toolsByRole.lead` granted the full write toolset, so a lead could author+commit+PR code itself instead of delegating. Observed: a ~20-min runaway lead turn that built an issue end-to-end and never ran lead→work→verify.

**Fix:** `lead: [...readTools, 'Agent']` — read + dispatch only. Workers (who keep the full write toolset) do the building.

**Validation:** with this change a real cycle ran correctly — lead planned → dispatched frontend + substrate workers in their lanes → reviewed → verifier approved → two PRs opened and merged. One line; workers/verifiers unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)