### PR TITLE
fix: harden contract/secret-scan/brief/sandbox (Gemini #797 review)

### DIFF
--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -94,6 +94,9 @@ async function briefCommand(options: { sessions: number; dryRun: boolean; coo: b
     const jsonMatch = proc.stdout.match(/\{[\s\S]*\}/);
     if (!jsonMatch) throw new Error('No JSON found in response');
     result = JSON.parse(jsonMatch[0]) as BriefResult;
+    if (!result || typeof result.focus !== 'string' || !Array.isArray(result.tasks)) {
+      throw new Error('Unexpected JSON schema from extraction (need focus:string, tasks:[])');
+    }
   } catch (err) {
     writeLine(`  ${colors.red}Extraction failed:${RESET} ${err instanceof Error ? err.message : String(err)}`);
     return;

--- a/src/commands/brief.ts
+++ b/src/commands/brief.ts
@@ -94,8 +94,11 @@ async function briefCommand(options: { sessions: number; dryRun: boolean; coo: b
     const jsonMatch = proc.stdout.match(/\{[\s\S]*\}/);
     if (!jsonMatch) throw new Error('No JSON found in response');
     result = JSON.parse(jsonMatch[0]) as BriefResult;
-    if (!result || typeof result.focus !== 'string' || !Array.isArray(result.tasks)) {
-      throw new Error('Unexpected JSON schema from extraction (need focus:string, tasks:[])');
+    if (
+      !result || typeof result.focus !== 'string' || !Array.isArray(result.tasks) ||
+      result.tasks.some((t) => !t || typeof t.squad !== 'string' || typeof t.title !== 'string' || typeof t.body !== 'string')
+    ) {
+      throw new Error('Unexpected JSON schema from extraction (need focus:string, tasks: Array<{squad,title,body: string}>)');
     }
   } catch (err) {
     writeLine(`  ${colors.red}Extraction failed:${RESET} ${err instanceof Error ? err.message : String(err)}`);

--- a/src/lib/agent-contract.ts
+++ b/src/lib/agent-contract.ts
@@ -72,7 +72,7 @@ export interface AgentContract {
 // ── Tool-grant vocabulary (what the Claude Code allowlist can enforce) ───────
 const TOOL_NAME =
   /^(Read|Write|Edit|MultiEdit|Grep|Glob|Bash|Agent|Task|WebFetch|WebSearch|TodoWrite|NotebookEdit)$/;
-const BASH_SCOPED = /^Bash\([A-Za-z0-9_./\s-]+(:\*)?\)$/; // Bash(git:*) | Bash(ls) | Bash(git status:*)
+const BASH_SCOPED = /^Bash\([A-Za-z0-9_./ -]+(:\*)?\)$/; // Bash(git:*) | Bash(git status:*) — literal space only (not \s, which allows \n/\r/\t)
 const MCP_TOOL = /^mcp__[a-z0-9_]+__([a-z0-9_]+|\*)$/;
 
 export function isEnforceableTool(tool: string): boolean {
@@ -220,6 +220,9 @@ export function validateContract(c: AgentContract): ContractViolation[] {
         fail('tool_grants', 'invalid tool grant structure');
         continue;
       }
+      if (!['read', 'write', 'consequential'].includes(t.sensitivity)) {
+        fail('tool_grants', `invalid sensitivity "${t.sensitivity}" for tool "${t.tool}"`);
+      }
       if (!isEnforceableTool(t.tool)) {
         fail('tool_grants', `"${t.tool}" is not expressible in the allowedTools vocabulary (tool name | Bash(cmd:*) | mcp__server__tool) — unenforceable`);
       }
@@ -233,6 +236,8 @@ export function validateContract(c: AgentContract): ContractViolation[] {
       fail('write_scope', 'must be an array of glob patterns');
     } else if (c.write_scope.length === 0) {
       fail('write_scope', `has ${writers.length} write/consequential grant(s) but no write_scope (unjailed write)`);
+    } else if (c.write_scope.some((s) => typeof s !== 'string')) {
+      fail('write_scope', 'glob patterns must be strings');
     }
   }
 
@@ -252,6 +257,10 @@ export function validateContract(c: AgentContract): ContractViolation[] {
     fail('credential_scope', 'must be an array of secret names');
   } else {
     for (const s of c.credential_scope) {
+      if (typeof s !== 'string') {
+        fail('credential_scope', 'secret names must be strings');
+        continue;
+      }
       if (!KNOWN_SECRETS.has(s)) fail('credential_scope', `unknown secret "${s}"`);
     }
   }

--- a/src/lib/agent-contract.ts
+++ b/src/lib/agent-contract.ts
@@ -72,7 +72,7 @@ export interface AgentContract {
 // ── Tool-grant vocabulary (what the Claude Code allowlist can enforce) ───────
 const TOOL_NAME =
   /^(Read|Write|Edit|MultiEdit|Grep|Glob|Bash|Agent|Task|WebFetch|WebSearch|TodoWrite|NotebookEdit)$/;
-const BASH_SCOPED = /^Bash\([A-Za-z0-9_./-]+(:\*)?\)$/; // Bash(git:*) | Bash(ls)
+const BASH_SCOPED = /^Bash\([A-Za-z0-9_./\s-]+(:\*)?\)$/; // Bash(git:*) | Bash(ls) | Bash(git status:*)
 const MCP_TOOL = /^mcp__[a-z0-9_]+__([a-z0-9_]+|\*)$/;
 
 export function isEnforceableTool(tool: string): boolean {
@@ -190,8 +190,9 @@ export interface ContractViolation {
 }
 
 const KNOWN_SECRETS = new Set([
-  'ANTHROPIC_API_KEY', 'SLACK_BOT_TOKEN', 'GH_TOKEN', 'MERCADOPUBLICO_API_KEY',
+  'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'SLACK_BOT_TOKEN', 'GH_TOKEN', 'MERCADOPUBLICO_API_KEY',
   'STRIPE_API_KEY', 'GOOGLE_APPLICATION_CREDENTIALS', 'DATABASE_URL',
+  'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_DEFAULT_REGION',
 ]);
 
 /**
@@ -208,19 +209,34 @@ export function validateContract(c: AgentContract): ContractViolation[] {
   const validRoles: ContextRole[] = ['scanner', 'worker', 'lead', 'coo', 'verifier'];
   if (!validRoles.includes(c.role)) fail('role', `unknown role "${c.role}"`);
 
-  if (c.tool_grants.length === 0) fail('tool_grants', 'empty — an agent with no grants cannot act');
-  for (const t of c.tool_grants) {
-    if (!isEnforceableTool(t.tool)) {
-      fail('tool_grants', `"${t.tool}" is not expressible in the allowedTools vocabulary (tool name | Bash(cmd:*) | mcp__server__tool) — unenforceable`);
+  // Defensive: these fields come from arbitrary user frontmatter — a non-array
+  // (e.g. a string) would otherwise spread into chars / throw downstream (security bypass).
+  if (!Array.isArray(c.tool_grants)) {
+    fail('tool_grants', 'must be an array of tool grants');
+  } else {
+    if (c.tool_grants.length === 0) fail('tool_grants', 'empty — an agent with no grants cannot act');
+    for (const t of c.tool_grants) {
+      if (!t || typeof t.tool !== 'string') {
+        fail('tool_grants', 'invalid tool grant structure');
+        continue;
+      }
+      if (!isEnforceableTool(t.tool)) {
+        fail('tool_grants', `"${t.tool}" is not expressible in the allowedTools vocabulary (tool name | Bash(cmd:*) | mcp__server__tool) — unenforceable`);
+      }
     }
   }
 
-  const writers = c.tool_grants.filter((t) => t.sensitivity !== 'read');
-  if (writers.length > 0 && c.write_scope.length === 0) {
-    fail('write_scope', `has ${writers.length} write/consequential grant(s) but no write_scope (unjailed write)`);
+  const grants = Array.isArray(c.tool_grants) ? c.tool_grants.filter((t) => t && typeof t.tool === 'string') : [];
+  const writers = grants.filter((t) => t.sensitivity !== 'read');
+  if (writers.length > 0) {
+    if (!Array.isArray(c.write_scope)) {
+      fail('write_scope', 'must be an array of glob patterns');
+    } else if (c.write_scope.length === 0) {
+      fail('write_scope', `has ${writers.length} write/consequential grant(s) but no write_scope (unjailed write)`);
+    }
   }
 
-  const consequential = c.tool_grants.filter((t) => t.sensitivity === 'consequential');
+  const consequential = grants.filter((t) => t.sensitivity === 'consequential');
   if (consequential.length > 0 && c.hitl_gate === 'none') {
     fail('hitl_gate', `has consequential grant(s) (${consequential.map((t) => t.tool).join(', ')}) but hitl_gate is "none"`);
   }
@@ -232,8 +248,12 @@ export function validateContract(c: AgentContract): ContractViolation[] {
     fail('resource_ceiling', 'needs a cost ceiling (per_run_usd or daily_usd)');
   }
 
-  for (const s of c.credential_scope) {
-    if (!KNOWN_SECRETS.has(s)) fail('credential_scope', `unknown secret "${s}"`);
+  if (!Array.isArray(c.credential_scope)) {
+    fail('credential_scope', 'must be an array of secret names');
+  } else {
+    for (const s of c.credential_scope) {
+      if (!KNOWN_SECRETS.has(s)) fail('credential_scope', `unknown secret "${s}"`);
+    }
   }
 
   if (c.autonomy === 'autonomous' && c.hitl_gate !== 'none') {

--- a/src/lib/sandbox-settings.ts
+++ b/src/lib/sandbox-settings.ts
@@ -42,7 +42,7 @@ export interface SandboxSettingsOptions {
 }
 
 export const DEFAULT_ALLOWED_DOMAINS = [
-  'api.anthropic.com',
+  'api.anthropic.com', 'api.openai.com',
   'github.com', '*.github.com', 'codeload.github.com', 'objects.githubusercontent.com',
   'registry.npmjs.org', 'pypi.org', 'files.pythonhosted.org',
   '*.googleapis.com',

--- a/src/lib/secret-scan.ts
+++ b/src/lib/secret-scan.ts
@@ -76,6 +76,7 @@ export function scanText(text: string, opts: ScanOptions = {}): SecretFinding[] 
     out.push({ type: 'secret', ruleId: `assigned:${a[1]}`, redacted: redact(a[3]) });
   }
   for (const term of opts.forbidden ?? []) {
+    if (typeof term !== 'string') continue;
     const t = term.trim();
     // Require >= 3 chars: a 1-2 char term ("to", "me") would match almost any
     // text and block every auto-commit (catastrophic false positives).

--- a/src/lib/secret-scan.ts
+++ b/src/lib/secret-scan.ts
@@ -77,7 +77,9 @@ export function scanText(text: string, opts: ScanOptions = {}): SecretFinding[] 
   }
   for (const term of opts.forbidden ?? []) {
     const t = term.trim();
-    if (t && text.toLowerCase().includes(t.toLowerCase())) {
+    // Require >= 3 chars: a 1-2 char term ("to", "me") would match almost any
+    // text and block every auto-commit (catastrophic false positives).
+    if (t.length >= 3 && text.toLowerCase().includes(t.toLowerCase())) {
       out.push({ type: 'forbidden', ruleId: 'denylist', redacted: redact(t) });
     }
   }


### PR DESCRIPTION
Addresses 6 of the 7 Gemini comments on release PR #797 (all on already-merged features). Goes into develop → folds into the 0.3.2 release.

- **agent-contract** (high/med): `Array.isArray` guards on `tool_grants`/`write_scope`/`credential_scope` (non-array string would spread to chars → bypass); `BASH_SCOPED` regex allows spaces so `Bash(git status:*)` validates; +OPENAI/AWS in `KNOWN_SECRETS`
- **secret-scan** (security-high): forbidden denylist terms must be ≥3 chars (a 1-2 char term blocks *every* auto-commit)
- **brief** (high): validate extracted JSON (`focus:string`, `tasks:[]`) before access — no crash on bad LLM output
- **sandbox** (med): allow `api.openai.com` for multi-LLM

**Skipped #6** (`Bash(squads:*)` for lead) per founder — letting a lead spawn squad runs is a deliberate capability expansion, not hardening.

Build green; 35/35 tests pass across contract/secret-scan/sandbox suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)