### PR TITLE
feat(providers): DeepSeek provider via aider delegation

### DIFF
--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -81,6 +81,25 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     buildArgs: (prompt) => ['exec', prompt],
   },
 
+  // DeepSeek has no first-party agentic CLI; delegate to aider, which speaks
+  // DeepSeek's chat-completions API natively via DEEPSEEK_API_KEY. (codex was
+  // considered but recent versions dropped chat-completions wire support, and
+  // DeepSeek does not implement the Responses API.)
+  deepseek: {
+    provider: 'deepseek',
+    displayName: 'DeepSeek (via aider)',
+    command: 'aider',
+    install: 'pip install aider-install && aider-install, then set DEEPSEEK_API_KEY',
+    buildArgs: (prompt, opts) => [
+      '--model',
+      opts?.model ? `deepseek/${opts.model.replace(/^deepseek\//, '')}` : 'deepseek/deepseek-chat',
+      '--message',
+      prompt,
+      '--yes',
+      '--no-auto-commits',
+    ],
+  },
+
   mistral: {
     provider: 'mistral',
     displayName: 'Mistral',


### PR DESCRIPTION
## Summary
Adds a `deepseek` entry to the LLM_CLIS registry, delegating to aider (`--model deepseek/deepseek-chat`). The per-agent provider chain (agent frontmatter → `--provider` flag → squad `providers.default`) already exists, so mixed-provider squads work with just this entry.

codex was evaluated first but current versions dropped `wire_api = "chat"`, and DeepSeek doesn't implement the Responses API — aider is the cleanest installed agentic CLI with native DeepSeek support.

## Testing
- `npm run build` passes
- `squads providers` lists "DeepSeek (via aider) ● ready" (availability detection works)
- Live chain verified end-to-end: aider → DeepSeek API authenticates correctly (request reached billing — the test account needs credit, which confirms auth + wire format are right)
- `--model` override maps through (`deepseek/<model>` prefix normalized)

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)