### PR TITLE
feat(observability): record every provider run — usage parsed from executor output

### DIFF
--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -360,6 +360,10 @@ ${systemContext}${squadContext}${cognitionContext}${learningContext}`;
             foreground: !isBackground,
             squadName,
             agentName,
+            model: options.model || frontmatter.model,
+            executionId,
+            trigger: options.trigger || 'manual',
+            startMs,
           });
         }
 

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -955,6 +955,9 @@ export async function executeWithProvider(
     squadName?: string;
     agentName?: string;
     model?: string;
+    executionId?: string;
+    trigger?: ExecutionContext['trigger'];
+    startMs?: number;
   }
 ): Promise<string> {
   const cliConfig = getCLIConfig(provider);
@@ -1029,11 +1032,27 @@ export async function executeWithProvider(
   // Foreground mode: run directly in terminal
   if (options.foreground) {
     return new Promise((resolve, reject) => {
+      // When the provider prints usage (aider et al), pipe output through so
+      // it can be parsed for observability — still streamed live to the user.
+      const captureUsage = typeof cliConfig.parseUsage === 'function';
       const proc = spawn(cliConfig.command, args, {
-        stdio: cliConfig.stdinPrompt ? ['pipe', 'inherit', 'inherit'] : 'inherit',
+        stdio: captureUsage
+          ? [cliConfig.stdinPrompt ? 'pipe' : 'inherit', 'pipe', 'pipe']
+          : cliConfig.stdinPrompt ? ['pipe', 'inherit', 'inherit'] : 'inherit',
         cwd: workDir,
         env: providerEnv,
       });
+
+      // Tail buffer for usage parsing (cap to keep memory bounded)
+      const OUTPUT_TAIL_MAX = 256 * 1024;
+      let outputTail = '';
+      if (captureUsage) {
+        const append = (chunk: Buffer) => {
+          outputTail = (outputTail + chunk.toString('utf-8')).slice(-OUTPUT_TAIL_MAX);
+        };
+        proc.stdout?.on('data', (c: Buffer) => { process.stdout.write(c); append(c); });
+        proc.stderr?.on('data', (c: Buffer) => { process.stderr.write(c); append(c); });
+      }
 
       // For stdinPrompt providers (e.g. Ollama), pipe the prompt via stdin
       if (cliConfig.stdinPrompt && proc.stdin) {
@@ -1042,6 +1061,31 @@ export async function executeWithProvider(
       }
 
       proc.on('close', async (code) => {
+        // Observability: every run gets a record, whatever the provider (#824).
+        // Token/cost figures come from the provider's own output when parseable.
+        const startMs = options.startMs || timestamp;
+        const usage = captureUsage ? cliConfig.parseUsage!(outputTail) : null;
+        logObservability({
+          ts: new Date().toISOString(),
+          id: options.executionId || generateExecutionId(),
+          squad: squadName,
+          agent: agentName,
+          provider,
+          model: options.model || 'unknown',
+          trigger: (options.trigger || 'manual') as ObservabilityRecord['trigger'],
+          status: code === 0 ? 'completed' : 'failed',
+          duration_ms: Date.now() - startMs,
+          input_tokens: usage?.input_tokens || 0,
+          output_tokens: usage?.output_tokens || 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          cost_usd: usage?.cost_usd || 0,
+          context_tokens: 0,
+          error: code !== 0 ? `${cliConfig.command} exited with code ${code}` : undefined,
+        });
+        if (usage && options.verbose) {
+          writeLine(`  ${colors.dim}Usage: ${usage.input_tokens} in / ${usage.output_tokens} out, $${usage.cost_usd.toFixed(4)}${RESET}`);
+        }
         // Harvest regardless of exit code — partial work from a failed run
         // must not evaporate either.
         let harvest: HarvestOutcome = { outcome: 'in-place' };

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -27,6 +27,12 @@ export interface CLIConfig {
 
   /** If true, pipe prompt via stdin instead of CLI arg (avoids shell arg length limits) */
   stdinPrompt?: boolean;
+
+  /**
+   * Extract token/cost usage from the CLI's captured output, if the provider
+   * prints it. Enables observability records for non-anthropic runs (#824).
+   */
+  parseUsage?: (output: string) => ProviderUsage | null;
 }
 
 export interface RunOptions {
@@ -38,6 +44,43 @@ export interface RunOptions {
 
   /** Dry run - just show what would execute */
   dryRun?: boolean;
+}
+
+export interface ProviderUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+/** Parse "57k" / "2.3k" / "1,234" / "1.2M" style counts into integers */
+function parseTokenCount(raw: string): number {
+  const cleaned = raw.replace(/,/g, '');
+  const match = cleaned.match(/^([\d.]+)([kM]?)$/);
+  if (!match) return 0;
+  const base = parseFloat(match[1]);
+  const mult = match[2] === 'k' ? 1_000 : match[2] === 'M' ? 1_000_000 : 1;
+  return Math.round(base * mult);
+}
+
+/**
+ * Parse aider's usage lines, e.g.:
+ *   "Tokens: 57k sent, 1.7k received. Cost: $0.02 message, $0.02 session."
+ * Multi-message sessions print one line per message — token counts are summed,
+ * cost uses the last (cumulative) session figure. Cost may be absent.
+ */
+export function parseAiderUsage(output: string): ProviderUsage | null {
+  const re = /Tokens:\s*([\d.,]+[kM]?)\s*sent,\s*([\d.,]+[kM]?)\s*received\.(?:\s*Cost:\s*\$([\d.]+)\s*message,\s*\$([\d.]+)\s*session\.)?/g;
+  let input = 0;
+  let output_ = 0;
+  let sessionCost = 0;
+  let found = false;
+  for (const m of output.matchAll(re)) {
+    found = true;
+    input += parseTokenCount(m[1]);
+    output_ += parseTokenCount(m[2]);
+    if (m[4] !== undefined) sessionCost = parseFloat(m[4]);
+  }
+  return found ? { input_tokens: input, output_tokens: output_, cost_usd: sessionCost } : null;
 }
 
 /**
@@ -98,6 +141,7 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
       '--yes',
       '--no-auto-commits',
     ],
+    parseUsage: parseAiderUsage,
   },
 
   mistral: {
@@ -122,6 +166,7 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     command: 'aider',
     install: 'pip install aider-install && aider-install',
     buildArgs: (prompt) => ['--message', prompt, '--yes'],
+    parseUsage: parseAiderUsage,
   },
 
   ollama: {

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -155,6 +155,13 @@ export function parseAgentFrontmatter(agentPath: string): AgentFrontmatter {
     result.cooldown = cooldownMatch[1].trim();
   }
 
+  // model: "deepseek-chat" — declared in AgentFrontmatter but was never
+  // extracted; needed so provider observability records carry the real model
+  const modelMatch = yaml.match(/^model:\s*["']?([^"'\n]+)["']?/m);
+  if (modelMatch) {
+    result.model = modelMatch[1].trim();
+  }
+
   // role: <free-text>
   // Primary signal for mapping to context role (scanner/worker/lead/verifier).
   for (const line of yamlLines) {

--- a/test/llm-usage.test.ts
+++ b/test/llm-usage.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { parseAiderUsage, LLM_CLIS } from '../src/lib/llm-clis.js';
+
+describe('parseAiderUsage (#824 — provider runs must be observable)', () => {
+  it('parses a single usage line with cost', () => {
+    const out = 'Applied edit to report.md\nTokens: 57k sent, 1.7k received. Cost: $0.02 message, $0.02 session.\n';
+    expect(parseAiderUsage(out)).toEqual({ input_tokens: 57_000, output_tokens: 1_700, cost_usd: 0.02 });
+  });
+
+  it('sums tokens across messages and keeps the last (cumulative) session cost', () => {
+    const out = [
+      'Tokens: 2.3k sent, 150 received. Cost: $0.001 message, $0.001 session.',
+      'Tokens: 4.1k sent, 1.2k received. Cost: $0.002 message, $0.003 session.',
+    ].join('\n');
+    expect(parseAiderUsage(out)).toEqual({ input_tokens: 6_400, output_tokens: 1_350, cost_usd: 0.003 });
+  });
+
+  it('handles plain counts and missing cost (free/local models)', () => {
+    const out = 'Tokens: 1,234 sent, 1 received.\n';
+    expect(parseAiderUsage(out)).toEqual({ input_tokens: 1_234, output_tokens: 1, cost_usd: 0 });
+  });
+
+  it('returns null when no usage line is present', () => {
+    expect(parseAiderUsage('no usage here')).toBeNull();
+  });
+
+  it('is wired into the aider-backed registry entries', () => {
+    expect(LLM_CLIS.aider.parseUsage).toBe(parseAiderUsage);
+    expect(LLM_CLIS.deepseek.parseUsage).toBe(parseAiderUsage);
+  });
+});


### PR DESCRIPTION
## Summary
Live-validated gap (#824): completed runs via non-anthropic providers wrote NO ObservabilityRecord — invisible to `executions.jsonl`, analytics, and per-run budget enforcement, while the executor's own printed usage was discarded.

## Changes
- `executeWithProvider` foreground runs always log an ObservabilityRecord (provider, model, trigger, status, duration), wired to the real `executionId`/`startMs`/`trigger` from agent-runner
- `CLIConfig.parseUsage` seam: providers that print usage contribute real token/cost figures. Implemented for the aider-backed entries (`aider`, `deepseek`) — output is streamed through live and tail-buffered (256KB cap) for parsing
- `parseAgentFrontmatter` now extracts `model:` (declared in `AgentFrontmatter` but never parsed) so records carry the agent's real model

## Testing
- `test/llm-usage.test.ts`: parser cases (k/M suffixes, multi-message summation, cumulative session cost, missing cost, registry wiring)
- Full suite: 1911 passed, 11 skipped; typecheck + lint + build clean
- **Live validation**: the exact #824 scenario re-run — record landed: `{provider: deepseek, model: deepseek-chat, status: completed, 21000 in / 740 out, $0.0063}`

Known limitation (documented): detached/background provider runs still skip the record — the process outlives the CLI. Follows the same gap as background Claude runs; tracked under the v0.8.0 containment theme.

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)