### PR TITLE
fix(conversation): quota session-limit detection + loud dispatch-parse failure

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -27,6 +27,7 @@ import {
 } from '../lib/terminal.js';
 import { runCloudDispatch } from '../lib/cloud-dispatch.js';
 import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
+import { isQuotaMessage } from '../lib/conversation.js';
 import { reportExecutionStart, reportConversationResult, pushCognitionSignal } from '../lib/api-client.js';
 import { runAgent } from '../lib/agent-runner.js';
 import { findMemoryDir } from '../lib/memory.js';
@@ -309,7 +310,7 @@ export async function runCommand(
           const files = readdirSync(convDir).sort().reverse();
           if (files.length > 0) {
             const latest = readFileSync(join(convDir, files[0]), 'utf-8');
-            return latest.includes('hit your limit') || latest.includes('rate limit') || latest.includes('[QUOTA]') || latest.includes('Quota limit reached');
+            return isQuotaMessage(latest);
           }
         } catch { /* no transcript */ }
         return false;

--- a/src/lib/conversation.ts
+++ b/src/lib/conversation.ts
@@ -42,6 +42,19 @@ export function classifyAgent(agentName: string, roleDescription?: string): Agen
   return null; // Unclassified — excluded from conversation
 }
 
+/**
+ * Detect a quota/limit response from the provider.
+ * Live formats observed: "You've hit your limit", "You've hit your session limit ·
+ * resets 3:10am" — the `session` variant slips past a bare 'hit your limit'
+ * substring check, letting capped turns flow into task parsing (hq#452).
+ */
+export function isQuotaMessage(text: string): boolean {
+  return /hit your (?:\w+ )?limit/i.test(text)
+    || /rate.?limit/i.test(text)
+    || text.includes('[QUOTA]')
+    || text.includes('Quota limit reached');
+}
+
 /** Map roles to model tiers for cost routing */
 export function modelForRole(role: AgentRole): string {
   switch (role) {

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -23,6 +23,7 @@ import {
   type AgentRole,
   type Transcript,
   classifyAgent,
+  isQuotaMessage,
   modelForRole,
   createTranscript,
   serializeTranscript,
@@ -327,7 +328,7 @@ ${squadContext}
       // Preserve the contract: still RETURN the agent's response text (now from
       // the result event), and keep the [QUOTA]/[ERROR]/no-output sentinels the
       // downstream plan/convergence parsing depends on.
-      if (text.includes('hit your limit') || text.includes('rate limit')) {
+      if (isQuotaMessage(text)) {
         resolve({ text: `[QUOTA] ${agentName}: API limit reached`, usage, outcomes });
       } else if (isError && text.length > 0) {
         // is_error:true — return the error text as before, but keep real usage.
@@ -477,7 +478,10 @@ export async function runConversation(
 
   log(`  plan: ${lead.name}...`);
 
-  const workerNames = workers.map(w => w.name).join(', ') || '(no workers — do the work yourself)';
+  const workerNames = workers.map(w => w.name).join(', ')
+    || (scanners.length > 0
+      ? '(no workers — dispatch scanners with "- scanner: [name] | task: [...]" lines, or do the work yourself)'
+      : '(no workers — do the work yourself)');
   const scannerNames = scanners.map(s => s.name).join(', ');
 
   // Load focus-specific instructions from .agents/config/cycle-focus.md
@@ -514,7 +518,7 @@ export async function runConversation(
   addTurn(transcript, lead.name, 'lead', planOutput, estimateTurnCost(options.model || 'sonnet'));
 
   // Quota detection — if plan hit the API limit, stop immediately
-  if (planOutput.includes('[QUOTA]') || planOutput.includes('hit your limit')) {
+  if (isQuotaMessage(planOutput)) {
     logObservability({
       ts: new Date().toISOString(),
       id: executionId,
@@ -573,11 +577,40 @@ export async function runConversation(
   // ═══════════════════════════════════════════════════════════════════
 
   // Parse task assignments from lead's plan
-  const taskAssignments = parseTaskAssignments(planOutput, [...workers, ...scanners]);
+  let taskAssignments = parseTaskAssignments(planOutput, [...workers, ...scanners]);
+
+  // Zero parsed tasks with agents available = format failure, not "nothing to do".
+  // Fail the turn loudly: re-prompt the lead ONCE with the exact dispatch format
+  // before falling back to lead-works-directly (hq#452 — intelligence stalled here).
+  if (taskAssignments.length === 0 && workers.length + scanners.length > 0) {
+    writeLine(`  ${colors.yellow}[WARN] ${lead.name}: plan had no parseable task assignments — retrying with format reminder${RESET}`);
+    const formatReminder = `Your previous plan could not be parsed into task assignments — no worker received any work. Re-emit ONLY the task list, one line per task, in EXACTLY this format (no prose around it):
+
+- worker: [worker-name] | task: [specific instruction]
+- scanner: [scanner-name] | task: [specific instruction]
+
+Available workers: ${workers.map(w => w.name).join(', ') || '(none)'}
+Available scanners: ${scanners.map(s => s.name).join(', ') || '(none)'}
+
+Your previous plan, for reference:
+
+${planOutput.slice(0, 3000)}`;
+    const retryResult = await runIndependentAgent({
+      agentName: lead.name, agentPath: lead.path, role: 'lead',
+      squadName: squad.name, model: options.model || modelForRole('lead'),
+      task: formatReminder, squadContext: '', cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+    });
+    cycleUsage = addUsage(cycleUsage, retryResult.usage);
+    cycleOutcomes = addOutcomes(cycleOutcomes, retryResult.outcomes);
+    if (!isQuotaMessage(retryResult.text)) {
+      addTurn(transcript, lead.name, 'lead', retryResult.text, estimateTurnCost(options.model || 'sonnet'));
+      taskAssignments = parseTaskAssignments(retryResult.text, [...workers, ...scanners]);
+    }
+  }
 
   if (taskAssignments.length === 0) {
     // No tasks parsed — lead does the work directly
-    log(`  execute: no task assignments found, lead works directly`);
+    writeLine(`  ${colors.yellow}[WARN] ${lead.name}: no parseable task assignments after retry — lead works directly, ${workers.length + scanners.length} agents idle${RESET}`);
     addTurn(transcript, lead.name, 'lead', '[Lead produced plan but no parseable task assignments. Lead should do the work directly in the review phase.]', estimateTurnCost('sonnet'));
   } else {
     log(`  execute: ${taskAssignments.length} tasks in parallel...`);
@@ -768,17 +801,9 @@ function parseTaskAssignments(planOutput: string, availableAgents: ClassifiedAge
     }
   }
 
-  // If no assignments parsed but workers exist, assign all workers the lead's full plan
-  if (assignments.length === 0 && availableAgents.length > 0) {
-    const workers = availableAgents.filter(a => a.role === 'worker');
-    for (const worker of workers) {
-      assignments.push({
-        agent: worker,
-        task: `The lead produced this plan. Execute the most important task:\n\n${planOutput.slice(0, 3000)}`,
-      });
-    }
-  }
-
+  // No silent fallback on parse failure — the caller re-prompts the lead once
+  // with the exact format, then fails loudly (hq#452). The old behavior (assign
+  // every worker the full plan) hid format failures and ignored scanner-only squads.
   return assignments;
 }
 

--- a/templates/prompts/plan.md
+++ b/templates/prompts/plan.md
@@ -28,7 +28,10 @@ GOAL: [which goal this cycle advances]
 TASKS:
 - worker: [worker-name] | task: [specific instruction with issue number or PR number]
 - worker: [worker-name] | task: [specific instruction]
+- scanner: [scanner-name] | task: [specific scan/monitor instruction]
 ```
+
+These `- worker:`/`- scanner:` lines are parsed by the runtime to dispatch agents — emit them EXACTLY in this format or nobody receives work. If your squad has no workers, dispatch scanners.
 
 Then end with:
 ## STATUS: CONTINUE

--- a/test/conversation-quota.test.ts
+++ b/test/conversation-quota.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for isQuotaMessage — quota/limit detection in conversation turns.
+ *
+ * Regression for hq#452: the live Max-plan cap message reads
+ * "You've hit your session limit · resets 3:10am" — the `session` variant
+ * slipped past a bare 'hit your limit' substring check, so a capped lead turn
+ * was fed into task parsing and the squad burned its whole conversation.
+ */
+import { describe, it, expect } from 'vitest';
+import { isQuotaMessage } from '../src/lib/conversation.js';
+
+describe('isQuotaMessage', () => {
+  it('detects the bare limit message', () => {
+    expect(isQuotaMessage("You've hit your limit · resets 3am")).toBe(true);
+  });
+
+  it('detects the session-limit variant (hq#452 live format)', () => {
+    expect(isQuotaMessage("You've hit your session limit · resets 3:10am (America/Santiago)")).toBe(true);
+  });
+
+  it('detects the usage-limit variant', () => {
+    expect(isQuotaMessage("You've hit your usage limit")).toBe(true);
+  });
+
+  it('detects the [QUOTA] sentinel', () => {
+    expect(isQuotaMessage('[QUOTA] intel-lead: API limit reached')).toBe(true);
+  });
+
+  it('detects the org-runner abort marker', () => {
+    expect(isQuotaMessage('Quota limit reached')).toBe(true);
+  });
+
+  it('detects rate limit messages', () => {
+    expect(isQuotaMessage('rate limit exceeded, retry later')).toBe(true);
+    expect(isQuotaMessage('429 rate-limited')).toBe(true);
+  });
+
+  it('does not flag ordinary plans mentioning limits', () => {
+    expect(isQuotaMessage('Plan: ship the weekly brief without limits')).toBe(false);
+    expect(isQuotaMessage('- worker: solver | task: raise the budget limit in config')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #859. Fixes the intelligence-squad stall tracked in agents-squads/[internal].

## What changed

1. **`isQuotaMessage()`** (new, `src/lib/conversation.ts`) — matches the live cap formats `hit your limit` / `hit your session limit` / `hit your usage limit`, plus `rate limit`, `[QUOTA]`, `Quota limit reached`. Replaces the bare `'hit your limit'` substring check at all three call sites: the agent-result `[QUOTA]` sentinel (workflow.ts), the plan-phase abort guard (workflow.ts), and the org-runner wave check (run.ts).
2. **Loud dispatch-parse failure** — a lead plan that yields zero parseable task lines now gets ONE re-prompt with the exact `- worker:/- scanner: name | task: ...` format; if still empty, a visible `[WARN]` reports how many agents sit idle. The old silent fallback (assign the full plan blob to every worker) is removed — it hid format failures and did nothing for scanner-only squads.
3. **Scanner dispatch documented** — plan template now shows the `- scanner:` line and states the parse contract explicitly; the "(no workers)" hint tells leads to dispatch scanners. Intelligence has 17 scanners and 0 workers, so it previously had no documented way to delegate at all.

## Why

Org cycle 2026-06-11: intelligence's lead turn returned "You've hit your **session** limit · resets 3:10am". The quota guard missed it (substring mismatch), the capped error text went into task parsing, workers got nothing, and the squad burned 4 turns / ~$2.35 on quota messages. The same missed detection let the org runner keep dispatching waves into a dead window (see #856 for the runner-level pre-flight, which lands separately).

## Impact

- Capped turns now stop the squad conversation immediately and trip the org runner's wave abort — the biggest single waste pattern from the first containment-instrumented org run.
- Scanner-only squads can actually dispatch their roster.
- New regression tests: `test/conversation-quota.test.ts` (7 cases incl. the live session-limit string). Full suite: 1948 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)