### PR TITLE
feat(org-run): quota-aware org runner — pre-flight probe, fail-fast, --wait-for-quota

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -322,6 +322,7 @@ program
   .option('--org', 'Run all squads as a coordinated org cycle (scan → plan → execute → report)')
   .option('--force', 'Force re-run squads that already completed today')
   .option('--resume', 'Resume org cycle from where quota stopped it')
+  .option('--wait-for-quota', 'Org cycle: on quota cap, poll until the session window reopens instead of stopping')
   .option('-y, --yes', 'Skip the org-run cost confirmation (for deliberate/non-interactive triggers)')
   .option('--focus <mode>', 'Cycle focus: create, resolve, review, ship, research, cost (default: create)')
   .addHelpText('after', `

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -28,6 +28,7 @@ import {
 import { runCloudDispatch } from '../lib/cloud-dispatch.js';
 import { runConversation, saveTranscript, type ConversationOptions } from '../lib/workflow.js';
 import { isQuotaMessage } from '../lib/conversation.js';
+import { probeQuota, waitForQuota } from '../lib/quota-probe.js';
 import { reportExecutionStart, reportConversationResult, pushCognitionSignal } from '../lib/api-client.js';
 import { runAgent } from '../lib/agent-runner.js';
 import { findMemoryDir } from '../lib/memory.js';
@@ -295,6 +296,39 @@ export async function runCommand(
       writeLine();
       writeLine(`  ${bold}Wave ${waveNum}${RESET} ${colors.dim}(${waveSquads.join(', ')})${RESET}`);
 
+      // Pre-flight quota probe (#856): never dispatch a wave into an exhausted
+      // session window — the 2026-06-11 cycle launched 15 squads into a dead
+      // window and burned every conversation on quota errors. One haiku ping.
+      let preflight = await probeQuota();
+      if (preflight.capped && options.waitForQuota) {
+        writeLine(`  ${colors.yellow}Quota window exhausted${preflight.resetHint ? ` · resets ${preflight.resetHint}` : ''} — waiting (--wait-for-quota, polling every 10m)${RESET}`);
+        const reopened = await waitForQuota({
+          onPoll: (p, waitedMs) => writeLine(`  ${colors.dim}${p.capped ? 'still capped' : 'window open'} after ${Math.round(waitedMs / 60_000)}m${p.resetHint ? ` · resets ${p.resetHint}` : ''}${RESET}`),
+        });
+        if (reopened) {
+          writeLine(`  ${colors.green}Window reopened — dispatching.${RESET}`);
+          preflight = { capped: false, raw: '' };
+        }
+      }
+      if (preflight.capped) {
+        const notDispatched = waves.slice(waveIdx).flat().filter(s => plannedSquads.has(s) && (!resumeSquads || resumeSquads.has(s)));
+        writeLine(`\n  ${colors.red}Quota limit reached before dispatch${preflight.resetHint ? ` — resets ${preflight.resetHint}` : ''}.${RESET} ${notDispatched.length} squads NOT dispatched (nothing burned).`);
+        writeLine(`  ${colors.dim}Resume later: squads run --org --resume  ·  or re-run with --wait-for-quota${RESET}`);
+        for (const s of notDispatched) {
+          results.push({ squad: s, agent: 'unknown', status: 'quota-skipped', durationMs: 0 });
+        }
+        try {
+          const obsDir = join(process.cwd(), '.agents', 'observability');
+          if (!existsSync(obsDir)) mkdirSync(obsDir, { recursive: true });
+          writeFileSync(resumeFile, JSON.stringify({
+            squads: notDispatched,
+            stoppedAt: new Date().toISOString(),
+            waveIdx,
+          }));
+        } catch { /* best effort */ }
+        break;
+      }
+
       // Run all squads in this wave in parallel
       const waveResults = await Promise.all(
         waveSquads.map(s => runSquadConversation(s))
@@ -319,6 +353,17 @@ export async function runCommand(
       if (quotaHit) {
         const remainingWaves = waves.slice(waveIdx + 1).flat().filter(s => plannedSquads.has(s) && (!resumeSquads || resumeSquads.has(s)));
         if (remainingWaves.length > 0) {
+          // Mid-cycle cap with --wait-for-quota: hold for the window instead of skipping
+          if (options.waitForQuota) {
+            writeLine(`\n  ${colors.yellow}Quota hit mid-cycle — waiting for the window before ${remainingWaves.length} remaining squads (--wait-for-quota)${RESET}`);
+            const reopened = await waitForQuota({
+              onPoll: (p, waitedMs) => writeLine(`  ${colors.dim}${p.capped ? 'still capped' : 'window open'} after ${Math.round(waitedMs / 60_000)}m${p.resetHint ? ` · resets ${p.resetHint}` : ''}${RESET}`),
+            });
+            if (reopened) {
+              writeLine(`  ${colors.green}Window reopened — continuing.${RESET}`);
+              continue;
+            }
+          }
           writeLine(`\n  ${colors.red}Quota limit reached.${RESET} Skipping ${remainingWaves.length} remaining squads.`);
           writeLine(`  ${colors.dim}Resume later: squads run --org --resume${RESET}`);
           for (const s of remainingWaves) {

--- a/src/lib/quota-probe.ts
+++ b/src/lib/quota-probe.ts
@@ -1,0 +1,101 @@
+/**
+ * Quota probe — cheap pre-flight check of the Claude session window.
+ *
+ * The org runner dispatches every squad in parallel; launching into an
+ * exhausted Max 5h window burns the whole cycle on "hit your session limit"
+ * turns (squads-cli#856, live evidence 2026-06-11). A 1-prompt haiku ping
+ * (~$0.0001) before dispatch tells us whether the window is open.
+ */
+import { spawn } from 'child_process';
+import { isQuotaMessage } from './conversation.js';
+
+export interface QuotaProbeResult {
+  /** True when the session window is exhausted */
+  capped: boolean;
+  /** Human-readable reset hint extracted from the limit message, e.g. "3:10am (America/Santiago)" */
+  resetHint?: string;
+  /** First chars of the raw response (diagnostics) */
+  raw: string;
+}
+
+/** Extract the reset time from a limit message like "hit your session limit · resets 3:10am (America/Santiago)" */
+export function extractResetHint(text: string): string | undefined {
+  const m = text.match(/resets?\s+(?:at\s+)?([^\n]+)/i);
+  return m ? m[1].trim() : undefined;
+}
+
+/**
+ * Probe the quota window with a minimal haiku call.
+ * Fails OPEN (capped: false) on timeout or spawn error — a broken probe must
+ * never block real work; the per-turn quota sentinels still catch a cap.
+ */
+export function probeQuota(timeoutMs = 90_000): Promise<QuotaProbeResult> {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn('claude', ['--print', '--model', 'haiku', '--disable-slash-commands'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch {
+      resolve({ capped: false, raw: '[probe spawn failed]' });
+      return;
+    }
+
+    let out = '';
+    let done = false;
+    const finish = (result: QuotaProbeResult) => {
+      if (done) return;
+      done = true;
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish({ capped: false, raw: '[probe timeout]' });
+    }, timeoutMs);
+
+    child.stdout.on('data', (d) => { out += d.toString(); });
+    child.stderr.on('data', (d) => { out += d.toString(); });
+    child.on('error', () => {
+      clearTimeout(timer);
+      finish({ capped: false, raw: '[probe spawn failed]' });
+    });
+    child.on('close', () => {
+      clearTimeout(timer);
+      const capped = isQuotaMessage(out);
+      finish({
+        capped,
+        resetHint: capped ? extractResetHint(out) : undefined,
+        raw: out.slice(0, 200),
+      });
+    });
+
+    child.stdin.write('Reply with exactly: ok');
+    child.stdin.end();
+  });
+}
+
+/**
+ * Poll until the quota window reopens. Polling beats parsing the reset
+ * timestamp: "resets 3:10am (America/Santiago)" is locale/timezone-dependent
+ * and the format is not a contract. Each poll is one haiku ping.
+ *
+ * Returns true when the window opened, false when maxWaitMs elapsed.
+ */
+export async function waitForQuota(opts: {
+  pollMs?: number;
+  maxWaitMs?: number;
+  onPoll?: (probe: QuotaProbeResult, waitedMs: number) => void;
+} = {}): Promise<boolean> {
+  const pollMs = opts.pollMs ?? 10 * 60_000;      // 10 min between pings
+  const maxWaitMs = opts.maxWaitMs ?? 6 * 60 * 60_000; // 6h cap (> one full 5h window)
+  let waited = 0;
+  while (waited < maxWaitMs) {
+    await new Promise((r) => setTimeout(r, pollMs));
+    waited += pollMs;
+    const probe = await probeQuota();
+    opts.onPoll?.(probe, waited);
+    if (!probe.capped) return true;
+  }
+  return false;
+}

--- a/src/lib/run-types.ts
+++ b/src/lib/run-types.ts
@@ -47,6 +47,7 @@ export interface RunOptions {
   resume?: boolean; // Resume org cycle from quota-skipped squads
   focus?: string; // Cycle focus: create, resolve, review, ship, research, cost
   yes?: boolean; // Skip the org-run cost confirmation gate (deliberate trigger)
+  waitForQuota?: boolean; // Org cycle: on quota cap, poll until the window reopens instead of stopping
 }
 
 /**

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -635,6 +635,33 @@ ${planOutput.slice(0, 3000)}`;
       }
       addTurn(transcript, agent.name, agent.role, output, estimateTurnCost(options.model || 'sonnet'));
     }
+
+    // Fail-fast (#856): every dispatched agent came back quota-capped — the
+    // window died mid-cycle. Review/verify would cap too; stop burning turns.
+    if (workerResults.length > 0 && workerResults.every(r => isQuotaMessage(r.output))) {
+      writeLine(`  ${colors.red}${squad.name}: all ${workerResults.length} dispatched agents hit the session limit — aborting cycle (skipping review/verify)${RESET}`);
+      logObservability({
+        ts: new Date().toISOString(),
+        id: executionId,
+        squad: squad.name,
+        agent: lead.name,
+        provider: 'anthropic',
+        model: options.model || modelForRole('lead'),
+        trigger: 'scheduled',
+        status: 'failed',
+        duration_ms: Date.now() - cycleStartMs,
+        input_tokens: cycleUsage.input_tokens,
+        output_tokens: cycleUsage.output_tokens,
+        cache_read_tokens: cycleUsage.cache_read_tokens,
+        cache_write_tokens: cycleUsage.cache_write_tokens,
+        cost_usd: cycleUsage.cost_usd,
+        context_tokens: 0,
+        ...outcomeFields(cycleOutcomes),
+        error: 'Quota limit reached',
+        task: options.task,
+      });
+      return { transcript, turnCount: transcript.turns.length, totalCost: cycleUsage.cost_usd, converged: false, reason: 'Quota limit reached' };
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -664,6 +691,32 @@ Summary: [what was achieved]`;
   cycleUsage = addUsage(cycleUsage, reviewResult.usage);
   cycleOutcomes = addOutcomes(cycleOutcomes, reviewResult.outcomes);
   addTurn(transcript, lead.name, 'lead', reviewOutput, estimateTurnCost(options.model || 'sonnet'));
+
+  // Fail-fast (#856): review turn capped — don't spend verifier turns on a dead window
+  if (isQuotaMessage(reviewOutput)) {
+    writeLine(`  ${colors.red}${squad.name}: review turn hit the session limit — aborting cycle (skipping verify)${RESET}`);
+    logObservability({
+      ts: new Date().toISOString(),
+      id: executionId,
+      squad: squad.name,
+      agent: lead.name,
+      provider: 'anthropic',
+      model: options.model || modelForRole('lead'),
+      trigger: 'scheduled',
+      status: 'failed',
+      duration_ms: Date.now() - cycleStartMs,
+      input_tokens: cycleUsage.input_tokens,
+      output_tokens: cycleUsage.output_tokens,
+      cache_read_tokens: cycleUsage.cache_read_tokens,
+      cache_write_tokens: cycleUsage.cache_write_tokens,
+      cost_usd: cycleUsage.cost_usd,
+      context_tokens: 0,
+      ...outcomeFields(cycleOutcomes),
+      error: 'Quota limit reached',
+      task: options.task,
+    });
+    return { transcript, turnCount: transcript.turns.length, totalCost: cycleUsage.cost_usd, converged: false, reason: 'Quota limit reached' };
+  }
 
   // Goals.md staleness check — warn if goals were not updated during review
   const goalsAfterReview = snapshotGoals(squad.name);

--- a/test/quota-probe.test.ts
+++ b/test/quota-probe.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Tests for quota-probe reset-hint extraction (#856).
+ * probeQuota/waitForQuota spawn the claude binary and are covered by the
+ * org-runner integration path; the parsing is what must not regress.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractResetHint } from '../src/lib/quota-probe.js';
+
+describe('extractResetHint', () => {
+  it('extracts the live session-limit format', () => {
+    expect(extractResetHint("You've hit your session limit · resets 3:10am (America/Santiago)"))
+      .toBe('3:10am (America/Santiago)');
+  });
+
+  it('extracts a bare reset time', () => {
+    expect(extractResetHint("You've hit your limit · resets 3am")).toBe('3am');
+  });
+
+  it('handles "resets at" phrasing', () => {
+    expect(extractResetHint('limit reached, resets at 14:00 UTC')).toBe('14:00 UTC');
+  });
+
+  it('returns undefined when no reset time present', () => {
+    expect(extractResetHint('rate limit exceeded')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #856.

## What changed

1. **Pre-flight quota probe** (`src/lib/quota-probe.ts`, new) — before dispatching each wave, the org runner pings the window with a single 1-prompt haiku call (~$0.0001). Capped → stop **before** any squad burns turns: print the reset hint, write `resume.json`, exit with the `--resume` hint. The probe fails OPEN on timeout/spawn error — a broken probe never blocks real work; per-turn sentinels still catch caps.
2. **Mid-conversation fail-fast** (`workflow.ts`) — if every dispatched agent in the execute phase returns quota-capped, the squad aborts before review; if the review turn caps, it aborts before verify. Both log to observability as `failed`/`Quota limit reached` instead of burning the remaining phases.
3. **`--wait-for-quota`** — on cap (pre-flight or mid-cycle), poll every 10 min (max 6 h) until the window reopens, then dispatch/continue. Polling instead of parsing "resets 3:10am (America/Santiago)" — the reset string is locale-dependent and not a contract. Doctrine is quota-rooftop: saturate the window, don't waste or abandon it.

## Why

Org cycle 2026-06-11 (~02:00): `squads run --org -y` launched with the Max window already capped (reset 03:10). All 15 squads dispatched in one parallel wave; 4 burned their entire conversations on session-limit turns ($0.58–0.84 each of pure waste), the rest got plans with every worker capped. The existing quota check ran only **after** the wave — useless for a single-wave layout. This was the top finding of the first containment-instrumented org run.

Builds on #860 (`isQuotaMessage` — session-limit variant detection), which this reuses at every check.

## Verification

- `npm run build` clean; full suite 1952 passing (108 files) including 4 new `extractResetHint` regression tests
- Fail-fast paths reuse the live transcript formats from `.agents/conversations/intelligence/mq93cgao.md` as test fixtures via the #860 tests

Milestone: v0.8.x (hq) — trustworthy background execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)