### PR TITLE
fix(spool): pin detached claude runs to their own session id (#857)

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -563,8 +563,12 @@ export function buildDetachedShellScript(config: {
   trigger?: string;
   /** Watchdog cap for the executor (hq#450 D3). */
   timeoutMinutes?: number;
+  /** Claude session id for this run (#857) — pins the session JSONL so reconcile attributes exactly this run's usage. */
+  sessionId?: string;
 }): string {
   const modelFlag = config.claudeModelAlias ? `--model ${config.claudeModelAlias}` : '';
+  const safeSessionId = config.sessionId ? config.sessionId.replace(/[^A-Za-z0-9-]/g, '') : '';
+  const sessionFlag = safeSessionId ? `--session-id ${safeSessionId} ` : '';
   const branchName = `agent/${config.squadName}/${config.agentName}-${config.timestamp}`;
   const worktreeDir = `${config.projectRoot}/../.worktrees/${config.squadName}-${config.agentName}-${config.timestamp}`;
   const cleanup = `if [ "\${WORK_DIR}" != '${config.projectRoot}' ]; then git -C '${config.projectRoot}' worktree remove "\${WORK_DIR}" --force 2>/dev/null; BRANCH='${branchName}'; git -C '${config.projectRoot}' branch -D "\${BRANCH}" 2>/dev/null; fi`;
@@ -582,9 +586,10 @@ export function buildDetachedShellScript(config: {
         trigger: config.trigger || 'manual',
         logFile: config.logFile,
         timeoutFlag,
+        sessionId: safeSessionId,
       })
     : '';
-  const executorCmd = `claude --print --dangerously-skip-permissions --disable-slash-commands ${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
+  const executorCmd = `claude --print --dangerously-skip-permissions --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
   const watchdogSecs = Math.max(1, Math.round((config.timeoutMinutes || 15) * 60));
   const script = `mkdir -p '${config.projectRoot}/../.worktrees'; WORK_DIR='${config.projectRoot}'; if git -C '${config.projectRoot}' worktree add '${worktreeDir}' -b '${branchName}' HEAD 2>/dev/null; then WORK_DIR='${worktreeDir}'; fi; cd "\${WORK_DIR}"; unset CLAUDECODE; ${buildWatchdogShell(executorCmd, watchdogSecs, timeoutFlag)}; ${cleanup}${spool}`;
   // pid file removed on clean wrapper exit — a surviving pid file with a dead
@@ -931,6 +936,7 @@ export async function executeWithClaude(
     claudeModelAlias, escapedPrompt, logFile, pidFile,
     obsRoot: projectRoot, executionId: execContext.executionId, trigger,
     timeoutMinutes: watchdogMinutes,
+    sessionId: randomUUID(),
   });
 
   if (runInWatch) {

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import { spawn, execSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, cpSync, unlinkSync } from 'fs';

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -150,12 +150,17 @@ interface SessionUsage {
 /**
  * Find the most recently modified Claude Code session JSONL file.
  * Claude Code writes sessions to ~/.claude/projects/<hash>/*.jsonl
+ *
+ * `beforeTimestamp` (optional) excludes files still being written after the
+ * run ended — without it a concurrent long-lived session (e.g. interactive)
+ * absorbs the attribution (#857). 2-minute grace for the final flush.
  */
-function findRecentSessionFile(afterTimestamp: number): string | null {
+function findRecentSessionFile(afterTimestamp: number, beforeTimestamp?: number): string | null {
   const home = process.env.HOME || '';
   const projectsDir = join(home, '.claude', 'projects');
   if (!existsSync(projectsDir)) return null;
 
+  const GRACE_MS = 2 * 60_000;
   let newest: { path: string; mtime: number } | null = null;
 
   try {
@@ -170,8 +175,10 @@ function findRecentSessionFile(afterTimestamp: number): string | null {
         const filePath = join(projPath, file);
         try {
           const mtime = statSync(filePath).mtimeMs;
-          // Only consider files modified after the run started
-          if (mtime > afterTimestamp && (!newest || mtime > newest.mtime)) {
+          // Only consider files modified within the run's window
+          if (mtime <= afterTimestamp) continue;
+          if (beforeTimestamp !== undefined && mtime > beforeTimestamp + GRACE_MS) continue;
+          if (!newest || mtime > newest.mtime) {
             newest = { path: filePath, mtime };
           }
         } catch { continue; }
@@ -180,6 +187,28 @@ function findRecentSessionFile(afterTimestamp: number): string | null {
   } catch { /* projects dir read error */ }
 
   return newest?.path || null;
+}
+
+/**
+ * Find a session JSONL by its exact session id (the file basename), across
+ * all project dirs. Used for detached runs launched with `--session-id` —
+ * deterministic attribution, immune to concurrent sessions (#857).
+ */
+function findSessionFileById(sessionId: string): string | null {
+  const home = process.env.HOME || '';
+  const projectsDir = join(home, '.claude', 'projects');
+  if (!existsSync(projectsDir)) return null;
+  // Defense in depth: ids are CLI-generated UUIDs, never path fragments.
+  const safe = sessionId.replace(/[^A-Za-z0-9-]/g, '');
+  if (!safe) return null;
+
+  try {
+    for (const projDir of readdirSync(projectsDir)) {
+      const candidate = join(projectsDir, projDir, `${safe}.jsonl`);
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch { /* projects dir read error */ }
+  return null;
 }
 
 /**
@@ -297,10 +326,23 @@ export function diffGoals(
 
 /**
  * Capture usage from the most recent Claude Code session.
- * Call this after a foreground run completes.
+ * Call this after a foreground run completes. Pass `runEndedAt` for runs that
+ * finished in the past (spool reconcile) so sessions still active after the
+ * run can't absorb the attribution (#857).
  */
-export function captureSessionUsage(runStartedAt: number): SessionUsage | null {
-  const sessionFile = findRecentSessionFile(runStartedAt);
+export function captureSessionUsage(runStartedAt: number, runEndedAt?: number): SessionUsage | null {
+  const sessionFile = findRecentSessionFile(runStartedAt, runEndedAt);
+  if (!sessionFile) return null;
+  return parseSessionUsage(sessionFile);
+}
+
+/**
+ * Capture usage for an exact session id — the run's own session JSONL,
+ * recorded by the detached wrapper at launch (#857). Deterministic; never
+ * picks up a concurrent session.
+ */
+export function captureSessionUsageById(sessionId: string): SessionUsage | null {
+  const sessionFile = findSessionFileById(sessionId);
   if (!sessionFile) return null;
   return parseSessionUsage(sessionFile);
 }

--- a/src/lib/spool.ts
+++ b/src/lib/spool.ts
@@ -20,6 +20,7 @@ import { getCLIConfig } from './llm-clis.js';
 import {
   logObservability,
   captureSessionUsage,
+  captureSessionUsageById,
   type ObservabilityRecord,
 } from './observability.js';
 import { updateExecutionStatus } from './execution-log.js';
@@ -42,6 +43,13 @@ export interface SpoolRecord {
   harvest: string;
   /** Watchdog fired (hq#450 D3) — run was reaped at its deadline. */
   timedOut?: boolean;
+  /**
+   * Claude session id the run was launched with (`--session-id`, #857).
+   * Lets reconcile read exactly this run's session JSONL instead of guessing
+   * by time window — concurrent runs each attributed the whole machine's
+   * usage before this. Empty/absent on provider runs and legacy spools.
+   */
+  sessionId?: string;
 }
 
 export function spoolDir(obsRoot: string): string {
@@ -75,6 +83,8 @@ export function buildSpoolWriterShell(fields: {
   logFile: string;
   /** Watchdog flag file (hq#450 D3); when present at spool time → timedOut:true, then removed. */
   timeoutFlag?: string;
+  /** Claude session id the executor was launched with (#857) — '' for provider runs. */
+  sessionId?: string;
 }): string {
   const q = (s: string) => s.replace(/'/g, '');
   // execIds are CLI-generated, but the done-file name and embedded id are
@@ -90,7 +100,7 @@ export function buildSpoolWriterShell(fields: {
   return (
     `; mkdir -p '${dir}'` +
     `; SPOOL_TMP=$(mktemp '${dir}/.tmp.XXXXXX')` +
-    `; printf '{"execId":"%s","squad":"%s","agent":"%s","provider":"%s","model":"%s","trigger":"%s","logFile":"%s","startEpoch":%s,"endEpoch":%s,"exitCode":%s,"harvest":"%s","timedOut":%s}' ` +
+    `; printf '{"execId":"%s","squad":"%s","agent":"%s","provider":"%s","model":"%s","trigger":"%s","logFile":"%s","sessionId":"${q(fields.sessionId || '').replace(/[^A-Za-z0-9-]/g, '')}","startEpoch":%s,"endEpoch":%s,"exitCode":%s,"harvest":"%s","timedOut":%s}' ` +
     `'${safeId}' '${q(fields.squad)}' '${q(fields.agent)}' '${q(fields.provider)}' '${q(fields.model)}' '${q(fields.trigger)}' '${q(fields.logFile)}' ` +
     `"\${START:-0}" "$(date +%s)" "\${EXIT:-1}" "\${HARVEST:-}" ${timedOutExpr} > "$SPOOL_TMP"` +
     `; mv "$SPOOL_TMP" '${file}'${flagCleanup}`
@@ -163,8 +173,15 @@ function toRecord(spool: SpoolRecord): ObservabilityRecord {
         cost = usage.cost_usd;
       }
     }
-  } else if (spool.startEpoch > 0) {
-    const session = captureSessionUsage(spool.startEpoch * 1000);
+  } else {
+    // Claude run: exact session-id attribution when the wrapper recorded one
+    // (#857); legacy fallback = mtime-window scan BOUNDED by endEpoch so a
+    // session still active after this run can't absorb the attribution.
+    const session = spool.sessionId
+      ? captureSessionUsageById(spool.sessionId)
+      : spool.startEpoch > 0
+        ? captureSessionUsage(spool.startEpoch * 1000, spool.endEpoch > 0 ? spool.endEpoch * 1000 : undefined)
+        : null;
     if (session) {
       input = session.input_tokens;
       output = session.output_tokens;

--- a/test/spool.test.ts
+++ b/test/spool.test.ts
@@ -211,3 +211,78 @@ describe('buildWatchdogShell (#450 D3)', () => {
     expect(String(rec.error)).toContain('watchdog');
   });
 });
+
+// ── #857: detached-claude usage attribution ──────────────────────────
+
+describe('session-id attribution (#857)', () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+
+  function writeSessionFile(projDir: string, name: string, inputTokens: number, outputTokens: number): string {
+    const dir = join(home, '.claude', 'projects', projDir);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, `${name}.jsonl`);
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: { model: 'claude-haiku-4-5', usage: { input_tokens: inputTokens, output_tokens: outputTokens } },
+    });
+    writeFileSync(path, `${line}\n`);
+    return path;
+  }
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'squads-home-'));
+    oldHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    process.env.HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('buildSpoolWriterShell embeds the (sanitized) session id in the done-file', () => {
+    const snippet = buildSpoolWriterShell({
+      obsRoot: root,
+      execId: 'exec_sid_1',
+      squad: 's',
+      agent: 'a',
+      provider: 'anthropic',
+      model: 'haiku',
+      trigger: 'scheduled',
+      logFile: '/tmp/x.log',
+      sessionId: `${SESSION_ID}'; touch /tmp/pwned; '`,
+    });
+    execSync(`EXIT=0; START=1700000000; true ${snippet}`, { shell: '/bin/sh' });
+    const parsed = JSON.parse(readFileSync(join(spoolDir(root), 'exec_sid_1.json'), 'utf8'));
+    expect(parsed.sessionId).toBe(`${SESSION_ID}touchtmppwned`);
+    expect(existsSync('/tmp/pwned')).toBe(false);
+  });
+
+  it('reconcile attributes exactly the pinned session, not a bigger concurrent one', () => {
+    writeSessionFile('proj-run', SESSION_ID, 100, 50);
+    // A concurrent giant session (e.g. interactive) — newer mtime, way bigger
+    writeSessionFile('proj-interactive', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee', 118_000, 9_000);
+
+    writeSpoolFile({ execId: 'exec_sid_2', provider: 'anthropic', model: 'haiku', sessionId: SESSION_ID });
+    reconcileDetachedRuns(root);
+    const [rec] = readExecutionsJsonl();
+    expect(rec.input_tokens).toBe(100);
+    expect(rec.output_tokens).toBe(50);
+    expect(rec.model).toBe('claude-haiku-4-5');
+  });
+
+  it('legacy records (no sessionId) bound the mtime window by endEpoch', () => {
+    // Session file modified NOW — far after the legacy run's endEpoch
+    // (1.7e9 ≈ 2023). The old global newest-after-start scan would grab it.
+    writeSessionFile('proj-later', 'ffffffff-1111-2222-3333-444444444444', 118_000, 9_000);
+
+    writeSpoolFile({ execId: 'exec_sid_3', provider: 'anthropic', model: 'haiku' });
+    reconcileDetachedRuns(root);
+    const [rec] = readExecutionsJsonl();
+    expect(rec.input_tokens).toBe(0);
+    expect(rec.output_tokens).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #857. Refs #849.

## What changed

1. **Launch**: `buildDetachedShellScript` now passes `--session-id <UUID>` (CLI-generated via `randomUUID()`, sanitized) to the detached claude executor and embeds the id in the spool done-file (`SpoolRecord.sessionId`).
2. **Reconcile**: for claude runs with a `sessionId`, `toRecord` reads exactly `~/.claude/projects/*/<sessionId>.jsonl` (`captureSessionUsageById`) — deterministic attribution, immune to concurrent sessions.
3. **Legacy fallback**: spools without a sessionId still use the mtime-window scan, but now bounded by `endEpoch` (+2 min flush grace) instead of "newest file modified after start" — a session still being written hours later can no longer absorb the attribution.

## Why

Live evidence 2026-06-11: three concurrent detached claude runs reconciled with identical usage — $130.93 / 118k input **each** — the whole machine's session activity (including a giant interactive session) triple-counted. Cost analytics for detached claude runs were unusable; this was handoff item 3 of the runner-fix batch.

## Verification

- Full suite 1955 passing; 3 new tests in `test/spool.test.ts`: shell-snippet embeds the sanitized id, reconcile picks the pinned 100-token session over a concurrent 118k-token one, legacy records ignore sessions modified after endEpoch.
- Live smoke test: `claude --print --session-id <uuid>` confirmed to write `~/.claude/projects/<cwd-hash>/<uuid>.jsonl` exactly where reconcile looks.

Milestone: v0.8.x — trustworthy background execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)