### PR TITLE
refactor(runs): drop useless NaN initializer (code-quality review on #854)

### DIFF
--- a/src/lib/runs-inventory.ts
+++ b/src/lib/runs-inventory.ts
@@ -85,7 +85,7 @@ export function listDetachedRuns(projectRoot: string): DetachedRun[] {
         const m = f.match(/^(.+)-(\d+)\.pid$/);
         if (!m) continue;
         const pidFile = join(dir, f);
-        let pid = NaN;
+        let pid: number;
         try {
           pid = parseInt(readFileSync(pidFile, 'utf8').trim(), 10);
         } catch { continue; }


### PR DESCRIPTION
Cherry-pick of release/v0.8.1 ec82ccd — the github-code-quality finding on PR #854 (`src/lib/runs-inventory.ts`: `let pid = NaN` always overwritten → uninitialized `let pid: number`). Applied to develop separately because the main→develop back-merge uses `-s ours` and would discard it.

Review thread: https://github.com/agents-squads/squads-cli/pull/854#discussion_r3399622264

🤖 Generated with [Claude Code](https://claude.com/claude-code)