### PR TITLE
fix(ci): tune Codecov — informational statuses, comment only on change, ignore CLI wrappers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+# Codecov tuned for signal over noise (#864).
+#
+# Philosophy: coverage is a TREND we watch, not a GATE we fail. The lib layer
+# (src/lib) carries the logic and the tests; src/commands are thin CLI
+# wrappers exercised by the E2E/smoke jobs, not unit tests — counting them in
+# patch status made every substantive PR a red X nobody acted on.
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true # never block; badge + trend only
+    patch:
+      default:
+        informational: true
+        target: 70% # the bar the comment reports against
+
+comment:
+  require_changes: true # comment only when coverage actually moves
+  layout: "condensed_header, diff, files"
+  hide_project_coverage: false
+
+ignore:
+  - "src/commands/**" # thin CLI wrappers — covered by E2E/smoke, not unit tests
+  - "templates/**"
+  - "test/**"
+  - "scripts/**"


### PR DESCRIPTION
Closes #864.

Adds `codecov.yml` (validated via codecov.io/validate):

- **Statuses informational** — coverage is a trend we watch, never a gate; kills the meaningless red ❌ on every PR
- **Comment only when coverage moves** (`require_changes`), condensed layout — release PRs that don't shift coverage stay silent
- **Ignore `src/commands/**`, `templates/**`, `test/**`, `scripts/**`** — commands are thin wrappers covered by the E2E/smoke CI jobs, not unit tests; counting them dragged every patch report to ~50-60% while the lib layer (the actual logic) sits at 80-90%
- Patch target 70% as the reported bar for what IS counted

Uploads stay (badge + trend for the public repo). Founder one-click follow-up, optional: install the Codecov GitHub app so tokenless uploads stop being best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)