### PR TITLE
fix(run): accept agent as 2nd positional — stop silently running the whole squad

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -290,8 +290,9 @@ program.command('create <name>', { hidden: true }).description('[renamed]').acti
 
 // Run command - execute squads or individual agents
 program
-  .command('run [target]')
+  .command('run [target] [agent]')
   .description('Run a squad or agent (no target lists squads). Use --org to run all squads as one coordinated cycle.')
+  .allowExcessArguments(false)
   .option('-v, --verbose', 'Verbose output')
   .option('-d, --dry-run', 'Show what would be run without executing')
   .option('-a, --agent <agent>', 'Run specific agent within squad')
@@ -330,6 +331,7 @@ Examples:
   $ squads run engineering              Run squad conversation (lead → scan → work → review)
   $ squads run engineering --task "fix CI"  Conversation with founder directive
   $ squads run engineering/code-review  Run specific agent (slash notation)
+  $ squads run engineering code-review  Same as above (space notation)
   $ squads run engineering -a code-review  Same as above (flag notation)
   $ squads run engineering --dry-run    Preview what would run
   $ squads run engineering --parallel   Run all agents in parallel (tmux)
@@ -343,9 +345,14 @@ Examples:
   $ squads run --once --dry-run         Preview one autopilot cycle
   $ squads run -i 15 --budget 50       Autopilot: 15min cycles, $50/day cap
 `)
-  .action(async (target, options) => {
-    const { runCommand } = await import('./commands/run.js');
-    return runCommand(target || null, { ...options, timeout: options.timeout != null ? parseInt(options.timeout, 10) : undefined });
+  .action(async (target, agent, options) => {
+    const { runCommand, mergeAgentPositional } = await import('./commands/run.js');
+    const merged = mergeAgentPositional(target || null, agent, options.agent);
+    if (merged.error) {
+      console.error(chalk.red(`\n  ${merged.error}\n`));
+      process.exit(1);
+    }
+    return runCommand(merged.target, { ...options, timeout: options.timeout != null ? parseInt(options.timeout, 10) : undefined });
   });
 
 // List command — alias for status

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -91,6 +91,28 @@ async function confirmProceed(n: number, est: number): Promise<boolean> {
   }
 }
 
+// `squads run <squad> <agent>` used to silently drop the agent positional and
+// run the whole squad (#858). Merge the 2nd positional into slash notation,
+// erroring loudly when it conflicts with --agent or an agent already in target.
+export function mergeAgentPositional(
+  target: string | null,
+  positionalAgent: string | undefined,
+  flagAgent: string | undefined
+): { target: string | null; error?: string } {
+  if (!positionalAgent || !target) return { target };
+  if (flagAgent && flagAgent !== positionalAgent) {
+    return { target, error: `Conflicting agents: "${positionalAgent}" (positional) vs "${flagAgent}" (--agent). Use one.` };
+  }
+  if (target.includes('/')) {
+    const slashAgent = target.split('/')[1];
+    if (slashAgent && slashAgent !== positionalAgent) {
+      return { target, error: `Target "${target}" already names an agent — drop the extra positional "${positionalAgent}".` };
+    }
+    return { target };
+  }
+  return { target: `${target}/${positionalAgent}` };
+}
+
 export async function runCommand(
   target: string | null,
   options: RunOptions

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -174,7 +174,7 @@ vi.mock('../../src/lib/run-context.js', () => ({
 }));
 
 // ── Imports (after mocks) ──────────────────────────────────────────────────
-import { runCommand, runSquadCommand } from '../../src/commands/run.js';
+import { runCommand, runSquadCommand, mergeAgentPositional } from '../../src/commands/run.js';
 import { findSquadsDir, loadSquad, listAgents, findSimilarSquads } from '../../src/lib/squad-parser.js';
 import { writeLine } from '../../src/lib/terminal.js';
 import { isProviderCLIAvailable } from '../../src/lib/llm-clis.js';
@@ -494,5 +494,42 @@ describe('runSquadCommand', () => {
     expect(mockWriteLine).toHaveBeenCalledWith(
       expect.stringContaining('--cloud requires a specific agent')
     );
+  });
+});
+
+// ── mergeAgentPositional (#858) ────────────────────────────────────────────
+describe('mergeAgentPositional', () => {
+  it('rewrites squad + agent positionals to slash notation', () => {
+    expect(mergeAgentPositional('research', 'weekly-reporter', undefined))
+      .toEqual({ target: 'research/weekly-reporter' });
+  });
+
+  it('passes target through when no agent positional given', () => {
+    expect(mergeAgentPositional('research', undefined, undefined))
+      .toEqual({ target: 'research' });
+    expect(mergeAgentPositional(null, undefined, undefined))
+      .toEqual({ target: null });
+  });
+
+  it('errors when positional conflicts with --agent flag', () => {
+    const result = mergeAgentPositional('research', 'weekly-reporter', 'housekeeper');
+    expect(result.target).toBe('research');
+    expect(result.error).toContain('Conflicting agents');
+  });
+
+  it('rewrites when positional and --agent flag name the same agent', () => {
+    expect(mergeAgentPositional('research', 'weekly-reporter', 'weekly-reporter'))
+      .toEqual({ target: 'research/weekly-reporter' });
+  });
+
+  it('errors when target already has a different agent via slash', () => {
+    const result = mergeAgentPositional('research/housekeeper', 'weekly-reporter', undefined);
+    expect(result.target).toBe('research/housekeeper');
+    expect(result.error).toContain('already names an agent');
+  });
+
+  it('accepts a redundant positional matching the slash agent', () => {
+    expect(mergeAgentPositional('research/weekly-reporter', 'weekly-reporter', undefined))
+      .toEqual({ target: 'research/weekly-reporter' });
   });
 });


### PR DESCRIPTION
Closes #858

## What

`squads run <squad> <agent>` silently dropped the 2nd positional and ran the **whole squad** — a containment bug (does more than asked, full squad-cycle quota cost instead of one agent).

- `run [target] [agent]` — 2nd positional is rewritten to slash notation (`research weekly-reporter` → `research/weekly-reporter`) via a new pure `mergeAgentPositional()` helper in `commands/run.ts`
- Conflicts error loudly with exit 1: positional vs `--agent` mismatch, or target already carrying a different `/agent`
- `.allowExcessArguments(false)` — a 3rd positional now errors (`too many arguments`) instead of being ignored
- Help text gains the space-notation example

## Why it matters

Live-hit during the 2026-06-08 org cycle week: `squads run research weekly-reporter` launched the entire research squad conversation. Fits milestone "CLI: trustworthy background execution" — a runner that escalates scope silently is unsafe to schedule.

## Validation

- 6 new unit tests for `mergeAgentPositional` (rewrite, passthrough, flag conflict, flag agreement, slash conflict, redundant slash) — `test/commands/run.test.ts` 34/34 green
- `npx tsc --noEmit` clean
- Live dry-run against hq: `run research weekly-reporter --dry-run` → "Would run weekly-reporter" only; conflict and excess-args cases exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)