### PR TITLE
chore: regen seed skill reference for run [target] [agent] (#866 follow-up)

### DIFF
--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -10,7 +10,7 @@
 |---------|-------------|
 | `squads init` | Plant the seed: create manager agent, CLI skill, and starter squads |
 | `squads add <name>` | Add a new squad with directory structure and starter files |
-| `squads run [target]` | Run a squad or agent (no target lists squads). Use --org to run all squads as one coordinated cycle. |
+| `squads run [target] [agent]` | Run a squad or agent (no target lists squads). Use --org to run all squads as one coordinated cycle. |
 | `squads list` | List squads (alias for: squads status) |
 | `squads orchestrate <squad>` | Run squad with lead agent orchestration |
 | `squads env show <squad>` | Show execution environment for a squad |


### PR DESCRIPTION
Part of #858. The #866 auto-merge raced my drift-guard fix commit — the squash landed without the regenerated `templates/seed/skills/squads-cli/references/commands.md`, so develop's seed reference is behind the command registry and the drift guard will fail the next PR. This is that one-line regen (`npm run build && npm run gen:skill`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)