### PR TITLE
feat(obs): post-run ingest ping to local API (fire-and-forget)

### DIFF
--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -424,6 +424,53 @@ async function pushToBridge(record: ObservabilityRecord): Promise<void> {
   }
 }
 
+/**
+ * Fire-and-forget ingest trigger ping.
+ *
+ * After the execution record is written to JSONL, POST to
+ * `${SQUADS_API_URL}/ingest/trigger` so the local squads-api defers an
+ * immediate `ingest_usage` run — providing near-real-time substrate data
+ * instead of waiting for the 2-minute periodic sweep.
+ *
+ * Safety contract:
+ *   - NEVER throws or rejects — failure must never affect the run path.
+ *   - Skipped silently when SQUADS_API_URL or SCHEDULER_API_KEY is unset.
+ *   - 2-second AbortController timeout so a dead API doesn't stall the process.
+ *   - Errors caught and discarded (debug-level: no console output in production).
+ *
+ * Uses process.env.SQUADS_API_URL directly (same source getApiUrl() reads) to
+ * avoid pulling the env-config module into the call path and to keep the
+ * function easily testable without dynamic-import mocking.
+ */
+async function pingIngestTrigger(): Promise<void> {
+  try {
+    const apiUrl = process.env.SQUADS_API_URL;
+    if (!apiUrl) return; // SQUADS_API_URL unset — skip silently
+
+    const apiKey = process.env.SCHEDULER_API_KEY;
+    if (!apiKey) return; // key unset — skip silently
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 2000);
+    try {
+      await fetch(`${apiUrl}/ingest/trigger`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': apiKey,
+        },
+        body: JSON.stringify({ source: 'squads-cli' }),
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // Silent — API down, key missing, timeout, or any other error.
+    // The periodic sweep (every 2 minutes) will cover the gap.
+  }
+}
+
 export function logObservability(record: ObservabilityRecord): void {
   const logPath = getLogPath();
   if (!logPath) return;
@@ -440,6 +487,8 @@ export function logObservability(record: ObservabilityRecord): void {
   pushToApi(record).catch(() => {});
   // Best-effort Bridge push (no-op/silent if Bridge unset or down).
   pushToBridge(record).catch(() => {});
+  // Real-time ingest trigger: notify local squads-api immediately (fire-and-forget).
+  pingIngestTrigger().catch(() => {});
 }
 
 // ── Read ─────────────────────────────────────────────────────────────

--- a/test/ingest-trigger.test.ts
+++ b/test/ingest-trigger.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the post-run ingest trigger ping in observability.ts.
+ *
+ * Verifies that:
+ * 1. pingIngestTrigger fires AFTER the JSONL record is appended (via logObservability)
+ * 2. The correct URL, headers, and body are sent
+ * 3. Missing SQUADS_API_URL → no fetch call (silent)
+ * 4. Missing SCHEDULER_API_KEY → no fetch call (silent)
+ * 5. fetch failure → caught, no throw (run path unaffected)
+ * 6. JSONL is always written even when fetch fails
+ *
+ * logObservability is tested indirectly: we call it and assert fetch was
+ * called (or not), which proves the ping fires after append.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, existsSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const TEST_ROOT = join(tmpdir(), `squads-obs-test-${Date.now()}`);
+const OBS_DIR = join(TEST_ROOT, '.agents', 'observability');
+const JSONL_PATH = join(OBS_DIR, 'executions.jsonl');
+
+const API_URL = 'http://localhost:8090';
+const API_KEY = 'test-scheduler-key';
+
+// Mock squad-parser so findProjectRoot returns our temp dir
+vi.mock('../src/lib/squad-parser.js', () => ({
+  findProjectRoot: vi.fn(() => TEST_ROOT),
+  loadSquad: vi.fn(),
+  listSquads: vi.fn(() => []),
+}));
+
+// Mock tier-detect so pushToApi (Tier 2 path) doesn't fire
+vi.mock('../src/lib/tier-detect.js', () => ({
+  isTier2: vi.fn(() => false),
+  getTierSync: vi.fn(() => ({ tier: 1, urls: { api: '' } })),
+}));
+
+// Mock env-config so pushToBridge (Bridge path) is skipped
+vi.mock('../src/lib/env-config.js', () => ({
+  getApiUrl: vi.fn(() => ''),
+  getBridgeUrl: vi.fn(() => ''),
+  getEnv: vi.fn(() => ({ api_url: '', bridge_url: '' })),
+}));
+
+import { logObservability, type ObservabilityRecord } from '../src/lib/observability.js';
+
+function makeRecord(overrides: Partial<ObservabilityRecord> = {}): ObservabilityRecord {
+  return {
+    ts: new Date().toISOString(),
+    id: 'exec-test-001',
+    squad: 'cli',
+    agent: 'test-agent',
+    provider: 'anthropic',
+    model: 'claude-haiku',
+    trigger: 'manual',
+    status: 'completed',
+    duration_ms: 1000,
+    input_tokens: 100,
+    output_tokens: 50,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    cost_usd: 0.001,
+    ...overrides,
+  };
+}
+
+// ── Setup / teardown ─────────────────────────────────────────────────
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  mkdirSync(OBS_DIR, { recursive: true });
+  process.env.SQUADS_API_URL = API_URL;
+  process.env.SCHEDULER_API_KEY = API_KEY;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // Restore env
+  for (const key of ['SQUADS_API_URL', 'SCHEDULER_API_KEY']) {
+    if (originalEnv[key] !== undefined) {
+      process.env[key] = originalEnv[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+  if (existsSync(TEST_ROOT)) rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('ingest trigger ping (via logObservability)', () => {
+  it('fires fetch AFTER the JSONL record is appended', async () => {
+    let jsonlWrittenAtFetchTime = false;
+
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/ingest/trigger')) {
+        // By the time fetch is called, the JSONL must already be written
+        jsonlWrittenAtFetchTime = existsSync(JSONL_PATH);
+      }
+      return { ok: true, status: 202 };
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    logObservability(makeRecord());
+
+    // Allow microtasks / the fire-and-forget promises to settle
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    // JSONL was present when fetch fired
+    expect(jsonlWrittenAtFetchTime).toBe(true);
+
+    // fetch was called with the correct ingest trigger URL + headers + body
+    const ingestCall = mockFetch.mock.calls.find(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/ingest/trigger'),
+    );
+    expect(ingestCall).toBeDefined();
+    const [url, opts] = ingestCall as [string, RequestInit];
+    expect(url).toBe(`${API_URL}/ingest/trigger`);
+    expect((opts.headers as Record<string, string>)['X-API-Key']).toBe(API_KEY);
+    expect((opts.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(JSON.parse(opts.body as string)).toMatchObject({ source: 'squads-cli' });
+    expect(opts.method).toBe('POST');
+  });
+
+  it('does NOT call fetch when SQUADS_API_URL is unset', async () => {
+    delete process.env.SQUADS_API_URL;
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    logObservability(makeRecord());
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const ingestCalls = mockFetch.mock.calls.filter(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/ingest/trigger'),
+    );
+    expect(ingestCalls).toHaveLength(0);
+  });
+
+  it('does NOT call fetch when SCHEDULER_API_KEY is unset', async () => {
+    delete process.env.SCHEDULER_API_KEY;
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    logObservability(makeRecord());
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const ingestCalls = mockFetch.mock.calls.filter(
+      ([url]: [string]) => typeof url === 'string' && url.includes('/ingest/trigger'),
+    );
+    expect(ingestCalls).toHaveLength(0);
+  });
+
+  it('swallows fetch errors — run path is unaffected', async () => {
+    const mockFetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/ingest/trigger')) throw new Error('ECONNREFUSED');
+      return { ok: true };
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Must NOT throw
+    expect(() => logObservability(makeRecord())).not.toThrow();
+
+    // Also wait for the async promise to settle — still no unhandled rejection
+    await expect(
+      new Promise(resolve => setTimeout(resolve, 50)),
+    ).resolves.toBeUndefined();
+  });
+
+  it('JSONL record is always written even when fetch fails', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    logObservability(makeRecord({ id: 'exec-always-written' }));
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(existsSync(JSONL_PATH)).toBe(true);
+    const content = readFileSync(JSONL_PATH, 'utf-8');
+    expect(content).toContain('exec-always-written');
+  });
+});


### PR DESCRIPTION
## What

After `logObservability` appends the execution record to `.agents/observability/executions.jsonl`, fire a silent `POST ${SQUADS_API_URL}/ingest/trigger` so the local squads-api defers an immediate `ingest_usage` run instead of waiting for the 2-minute periodic sweep.

## Why

Real-time usage substrate enables accurate cost analytics, live dashboards, and quota observability. The periodic sweep remains the authoritative fallback — this ping makes it near-real-time.

## Changes

- **src/lib/observability.ts** — adds `pingIngestTrigger()` called from `logObservability()` after the JSONL append. Uses `process.env.SQUADS_API_URL` + `process.env.SCHEDULER_API_KEY` directly. AbortController 2s timeout.
- **test/ingest-trigger.test.ts** — 5 vitest tests: fires after append, skips on missing URL, skips on missing key, swallows errors, JSONL always written.

## Safety contract

- NEVER throws — all errors caught, run path completely unaffected
- Skip silently when either env var is unset
- 2-second timeout via AbortController
- Periodic sweep covers the gap if this fails

## env var note

Uses `process.env.SQUADS_API_URL` directly (same source `getApiUrl()` reads) to avoid dynamic-import coupling in a hot path and to keep tests simple — no env-config mock needed.

## Verification

```
npx tsc --noEmit       # no errors
npm run build          # Build success
npx vitest run test/ingest-trigger.test.ts  # 5 passed
```

Closes #869
Part of agents-squads/squads-api#89

🤖 Generated with [Claude Code](https://claude.com/claude-code)