### PR TITLE
fix(run): no silent loss of run deliverables on worktree cleanup (#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Quota-aware org runner + agent-positional fix — org runs survive quota walls;
 - **Quota-aware org runner** (#861) — `squads run --org` probes quota before dispatching; `--wait-for-quota` polls until the session window reopens instead of stopping. Pre-flight `--dry-run` prints which squads would run without spending quota.
 
 ### Fixed
+- **No silent loss of run deliverables** (#875) — a squad run whose lead ended BLOCKED on git/gh write-approval left its deliverable uncommitted in the per-run worktree, which cleanup then destroyed with `git worktree remove --force`. Cleanup now auto-commits any uncommitted/untracked work to the run branch (recoverable from the shared `.git`) and best-effort pushes it before removing the directory; if the work can't be preserved, the worktree is left in place instead of deleted.
 - **`squads run SQUAD AGENT` now routes to the agent** (#866) — passing the agent as a second positional (`squads run engineering code-review`) was silently ignored and ran the whole squad. All three notations now produce identical results: `SQUAD/AGENT`, `SQUAD AGENT`, and `SQUAD -a AGENT`.
 - **Session-limit quota variant detected** (#860) — loud failure printed when quota hits mid-conversation instead of a silent empty result.
 - **Detached runs pinned to their own session id** (#862) — background runs that escaped their session were attributed to the wrong squad's usage budget.

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -11,9 +11,15 @@
  * Design: ONE worktree per squad RUN (not per agent). All agents in a single
  * squad conversation (plan → execute → review → verify) share the same worktree
  * so the worker's changes are visible to the reviewer/verifier within that run.
- * The original checkout is never touched. Any branch the agents pushed is
- * preserved on the remote; only the local worktree directory is removed on
- * cleanup.
+ * The original checkout is never touched.
+ *
+ * No silent data loss (#875): cleanup never force-removes a worktree that still
+ * holds uncommitted/untracked work. A run whose lead ended BLOCKED on git/gh
+ * write-approval leaves its deliverable only in the worktree — earlier this was
+ * destroyed by `worktree remove --force`. Cleanup now auto-commits any dirty
+ * tree to the run branch (which lives in the shared .git object store and
+ * survives worktree removal) and best-effort pushes it before removing the
+ * directory. If the work cannot be preserved, the worktree is left in place.
  *
  * Graceful degradation: if the dir isn't a git repo, or `worktree add` fails,
  * we fall back to running in-place (the original cwd) with a dim warning. We
@@ -33,8 +39,9 @@ import { colors, RESET, writeLine } from './terminal.js';
  * Result of attempting to create a per-run worktree.
  * - `cwd`     — directory the squad's agents should run in (worktree path,
  *               or the original repoDir if isolation was skipped/failed).
- * - `cleanup` — idempotent, never-throwing function that removes the worktree.
- *               A no-op when isolation was skipped or fell back in-place.
+ * - `cleanup` — idempotent, never-throwing function that preserves any
+ *               uncommitted work (auto-commit to the run branch) then removes
+ *               the worktree. A no-op when isolation was skipped/fell back.
  */
 export interface RunWorktree {
   cwd: string;
@@ -143,11 +150,62 @@ export function createRunWorktree(repoDir: string, squadName: string): RunWorktr
 
   const cleanup = () => {
     try {
-      // --force removes the worktree even with uncommitted changes. Safe:
-      // any branch the agents pushed lives on the remote; this only drops the
-      // local worktree dir. The branch ref is left for inspection (it shares
-      // objects with the main repo and is cheap; `git worktree prune` + branch
-      // cleanup can reclaim it later).
+      // No silent data loss (#875): a worktree may still hold uncommitted or
+      // untracked deliverables — e.g. the lead ended BLOCKED on git/gh
+      // write-approval and never committed. `worktree remove --force` would
+      // destroy them. Preserve first, remove second.
+      let dirty = '';
+      try {
+        dirty = execSync(`git -C '${worktreePath}' status --porcelain`, {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }).trim();
+      } catch {
+        // status failed (worktree dir already gone / corrupt) — nothing to
+        // preserve; fall through to the removal attempt below.
+      }
+
+      if (dirty) {
+        try {
+          // Commit everything to the run branch. That branch ref lives in the
+          // shared .git object store, so the commit survives worktree removal
+          // and is recoverable with `git checkout <branch>`. The `-c` identity
+          // makes the commit succeed even when the sandbox has no configured
+          // git user; --no-verify skips hooks during cleanup.
+          execSync(`git -C '${worktreePath}' add -A`, { stdio: 'pipe' });
+          execSync(
+            `git -C '${worktreePath}' -c user.name='squads-run[bot]' -c user.email='squads-run@agents-squads.local' commit --no-verify -m 'squads run: auto-save uncommitted deliverables on cleanup (#875)'`,
+            { stdio: 'pipe' }
+          );
+          writeLine(
+            `  ${colors.yellow}saved uncommitted work to branch ${branchName} before cleanup (#875). Recover: git -C '${repoDir}' checkout ${branchName}${RESET}`
+          );
+          // Best-effort push so the deliverable is recoverable off-machine too.
+          // Never block or fail cleanup on this (no remote / no auth / offline);
+          // the local commit on the branch already guarantees no loss.
+          // GIT_TERMINAL_PROMPT=0 + timeout prevent a credential prompt hanging
+          // the run's exit path.
+          try {
+            execSync(`git -C '${worktreePath}' push -u origin '${branchName}'`, {
+              stdio: 'pipe',
+              timeout: 30_000,
+              env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+            });
+          } catch {
+            // Local branch commit already preserves the work.
+          }
+        } catch (e) {
+          // Could not preserve the work — DO NOT delete it. Leave the worktree
+          // in place and tell the operator exactly where the deliverable is.
+          writeLine(
+            `  ${colors.red}WARN: could not auto-save uncommitted work in ${worktreePath} (#875) — leaving worktree in place to avoid data loss: ${e instanceof Error ? e.message : String(e)}${RESET}`
+          );
+          return;
+        }
+      }
+
+      // Safe now: the tree is clean (or its changes were committed to the run
+      // branch above). --force is fine — there is nothing left to lose.
       execSync(`git -C '${repoDir}' worktree remove '${worktreePath}' --force`, {
         stdio: 'pipe',
       });

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -123,4 +123,53 @@ describe('createRunWorktree (#440)', () => {
     expect(branch).toMatch(/^squads\/run-my-squad-name-/);
     cleanup();
   });
+
+  // ── No silent data loss (#875) ──────────────────────────────────────────
+  // A blocked lead leaves its deliverable uncommitted in the worktree. Cleanup
+  // must preserve it (commit to the run branch) — never --force it away.
+
+  it('preserves uncommitted (tracked) changes to the run branch before removal', () => {
+    initRepo(repoDir);
+    const { cwd, cleanup } = createRunWorktree(repoDir, 'product');
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf-8' }).trim();
+
+    // Modify a tracked file but do NOT commit (simulates a blocked agent).
+    writeFileSync(join(cwd, 'README.md'), '# deliverable the lead could not commit\n');
+
+    cleanup();
+
+    // Worktree directory is gone...
+    expect(existsSync(cwd)).toBe(false);
+    // ...but the work is recoverable from the run branch in the shared .git.
+    const recovered = execSync(`git -C '${repoDir}' show ${branch}:README.md`, { encoding: 'utf-8' });
+    expect(recovered).toContain('deliverable the lead could not commit');
+  });
+
+  it('preserves untracked deliverables to the run branch before removal', () => {
+    initRepo(repoDir);
+    const { cwd, cleanup } = createRunWorktree(repoDir, 'product');
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf-8' }).trim();
+
+    // Brand-new file the agent wrote but never `git add`ed.
+    writeFileSync(join(cwd, 'redteam-memo.md'), 'STATUS: BLOCKED — run these 5 commands\n');
+
+    cleanup();
+
+    expect(existsSync(cwd)).toBe(false);
+    const recovered = execSync(`git -C '${repoDir}' show ${branch}:redteam-memo.md`, { encoding: 'utf-8' });
+    expect(recovered).toContain('STATUS: BLOCKED');
+  });
+
+  it('removes a clean worktree without creating an auto-save commit', () => {
+    initRepo(repoDir);
+    const { cwd, cleanup } = createRunWorktree(repoDir, 'product');
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf-8' }).trim();
+    const tipBefore = execSync(`git -C '${repoDir}' rev-parse ${branch}`, { encoding: 'utf-8' }).trim();
+
+    cleanup(); // nothing dirty → no commit, just removal
+
+    expect(existsSync(cwd)).toBe(false);
+    const tipAfter = execSync(`git -C '${repoDir}' rev-parse ${branch}`, { encoding: 'utf-8' }).trim();
+    expect(tipAfter).toBe(tipBefore); // no auto-save commit added
+  });
 });


### PR DESCRIPTION
## What & why

A `squads run` whose lead ended `## STATUS: BLOCKED` on git/gh write-approval left its deliverable **uncommitted in the per-run worktree**. `cleanup()` then ran `git worktree remove --force`, destroying it — the work was recoverable only by parsing Write tool calls out of session logs. This is the data-loss defect in #875, and it directly undermines the run-verification guarantee (nothing a squad produces should ever be silently lost).

## Fix

`cleanup()` now **preserves before it removes** (single chokepoint in `worktree.ts`, so every exit path — DONE, BLOCKED, early-return, throw — is covered):

1. Detect a dirty tree via `git status --porcelain` (tracked **and** untracked).
2. Auto-commit it to the run branch `squads/run-<squad>-<id>`. That ref lives in the shared `.git` object store, so the commit survives worktree removal and is recoverable with `git checkout <branch>`. Commit uses an inline `-c` identity (works without a configured git user) and `--no-verify`.
3. Best-effort `push` (`GIT_TERMINAL_PROMPT=0` + 30s timeout so a credential prompt can't hang the run's exit). The local commit already guarantees no loss; the push just makes it recoverable off-machine.
4. **Only then** `worktree remove --force` — there is nothing left to lose.
5. If preservation fails for any reason, the worktree is **left in place** (logged loudly) rather than deleted.

## Test plan

New tests in `test/worktree.test.ts`:
- tracked uncommitted change → recoverable from the run branch after cleanup
- untracked new file → recoverable from the run branch after cleanup
- clean worktree → removed with **no** auto-save commit (no churn)

`npm run build` ✓ · `typecheck` ✓ · `lint` ✓ · full suite 1969 passing (infra integration test excluded — requires `squads` on PATH, unrelated, green in CI).

## Scope

Closes the **data-loss** defect of #875. The **convergence** half (route a lead's blocked writes to a worker for one more cycle, instead of ending BLOCKED) is tracked separately in #890.

Closes #875