### PR TITLE
docs(readme): replace deprecated autopilot example with 'squads run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ reasoning model builds, a mid-tier model verifies.
 ```bash
 squads run research --parallel                  # squad conversation
 squads run intelligence --task "Scan X"         # directed run
-squads autopilot --interval 30 --budget 50      # autonomous dispatch
+squads run --interval 30 --budget 50            # autopilot: autonomous dispatch
 ```
 
 ## Documentation


### PR DESCRIPTION
The first-contact UX sim (fresh model reading only README + `--help`) flagged that the README features `squads autopilot --interval 30 --budget 50` as a primary example while `--help` marks `autopilot` **[deprecated]**. A contradiction a new user catches reads as docs lagging the CLI.

Use the supported form `squads run --interval 30 --budget 50` (run with no target = autopilot mode), which `run --help` itself documents.

One-line docs fix.

Refs #895.