### PR TITLE
fix(run): let agents run their own shell scripts (Bash(bash/sh:*))

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -878,6 +878,7 @@ export async function executeWithClaude(
         'Read', 'Write', 'Edit', 'Glob', 'Grep',
         'Bash(git:*)', 'Bash(gh:*)', 'Bash(npm:*)', 'Bash(npx:*)',
         'Bash(node:*)', 'Bash(python3:*)', 'Bash(curl:*)',
+        'Bash(bash:*)', 'Bash(sh:*)', // agents run their own helper scripts (e.g. an agent's watchlist.sh)
         'Bash(docker:*)', 'Bash(duckdb:*)',
         'Bash(bq:*)', 'Bash(gcloud:*)',
         'Bash(gws:*)', 'Bash(stripe:*)',

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -210,7 +210,7 @@ ${squadContext}
   // pr-create — the lead lands workers' reviewed code but never authors/ships its own.
   const leadGitGh = ['Bash(git status:*)', 'Bash(git log:*)', 'Bash(git diff:*)', 'Bash(git show:*)', 'Bash(git branch:*)', 'Bash(git fetch:*)', 'Bash(gh pr view:*)', 'Bash(gh pr list:*)', 'Bash(gh pr checks:*)', 'Bash(gh pr merge:*)', 'Bash(gh issue view:*)', 'Bash(gh issue list:*)', 'Bash(gh issue create:*)'];
   const readTools = [...readBase, 'Bash(git:*)', 'Bash(gh:*)'];
-  const writeTools = ['Write', 'Edit', 'Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)', 'Bash(python3:*)', 'Bash(docker:*)', 'Bash(duckdb:*)', 'Bash(bq:*)', 'Bash(gcloud:*)', 'Bash(gws:*)', 'Bash(stripe:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)', 'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(squads:*)', 'Agent'];
+  const writeTools = ['Write', 'Edit', 'Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)', 'Bash(python3:*)', 'Bash(bash:*)', 'Bash(sh:*)', 'Bash(docker:*)', 'Bash(duckdb:*)', 'Bash(bq:*)', 'Bash(gcloud:*)', 'Bash(gws:*)', 'Bash(stripe:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)', 'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(squads:*)', 'Agent'];
   const buildTools = ['Bash(npm:*)', 'Bash(npx:*)', 'Bash(node:*)'];
 
   const toolsByRole: Record<string, string[]> = {


### PR DESCRIPTION
## What

Adds `Bash(bash:*)` + `Bash(sh:*)` to the agent tool allowlist in both spawn paths:
- `execution-engine.ts` — the foreground / single-`--agent` run allowlist
- `workflow.ts` — `writeTools` (conversation/worker path) for parity

## Why

Scheduled/foreground agent runs already grant `Write`, `Bash(duckdb:*)`, `WebSearch`, etc., but **not** `Bash(bash:*)`. An agent that runs its own helper script (e.g. a generated `watchlist.sh`) hits a denied tool and stalls mid-run instead of completing. This was one half of the headless-autonomy failure in #899 — the agent had the research/write tools but couldn't execute its own script.

## Safety

`bash`/`sh` are no more capable than the already-granted `Bash(node:*)`, `Bash(python3:*)`, `Bash(docker:*)`. The guardrail `PreToolUse` hooks (injected via `--settings`) still gate destructive commands, and read-only `scanner` role in the conversation path is unchanged (the addition is in `writeTools` only).

The companion prompt-side fix (telling headless agents to execute autonomously and not ask "should I proceed?") lives in hq `config/approval-instructions.md`.

Refs #899