### PR TITLE
chore(release): 0.8.2 — trustworthy execution follow-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `squads-cli` are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 Releases are also published as [GitHub Releases](https://github.com/agents-squads/squads-cli/releases).
 
-## [0.8.2] — Unreleased
+## [0.8.2] — 2026-07-01
 
 Trustworthy execution — per-squad pause/resume enforcement, no silent loss of
 deliverables, a verified context-injection layer (strategy.md as L1), and a
@@ -15,6 +15,7 @@ quota-aware org runner that survives quota walls.
 - **Per-squad pause / resume enforcement** (#877) — `squads pause <squad>` makes `run`, `--org`, and cron dispatch refuse that squad until `squads resume <squad>`; the runner prints how to resume or override with `--force`. Activation state is enforced by the runner and honored by the org planner, so a paused squad can't be dispatched by accident.
 - **Context loader: `strategy.md` is the L1 company layer** (#876) — the Squad Context System now reads `memory/company/strategy.md` as the primary "why" layer (falling back to `company.md` → `directives.md`), matching the single-strategy-file model. Context-layer docs updated.
 - **Quota-aware org runner** (#861) — `squads run --org` probes quota before dispatching; `--wait-for-quota` polls until the session window reopens instead of stopping. Pre-flight `--dry-run` prints which squads would run without spending quota.
+- **Post-run ingest ping** (#870) — after a run's execution record lands in `executions.jsonl`, the CLI fires a fire-and-forget `POST /ingest/trigger` to the local squads-api so usage analytics update immediately instead of waiting for the periodic sweep. Silent no-op when the API isn't running.
 
 ### Fixed
 - **No silent loss of run deliverables** (#875) — a squad run whose lead ended BLOCKED on git/gh write-approval left its deliverable uncommitted in the per-run worktree, which cleanup then destroyed with `git worktree remove --force`. Cleanup now auto-commits any uncommitted/untracked work to the run branch (recoverable from the shared `.git`) and best-effort pushes it before removing the directory; if the work can't be preserved, the worktree is left in place instead of deleted.
@@ -22,6 +23,7 @@ quota-aware org runner that survives quota walls.
 - **`squads run SQUAD AGENT` now routes to the agent** (#866) — passing the agent as a second positional (`squads run engineering code-review`) was silently ignored and ran the whole squad. All three notations now produce identical results: `SQUAD/AGENT`, `SQUAD AGENT`, and `SQUAD -a AGENT`.
 - **Session-limit quota variant detected** (#860) — loud failure printed when quota hits mid-conversation instead of a silent empty result.
 - **Detached runs pinned to their own session id** (#862) — background runs that escaped their session were attributed to the wrong squad's usage budget.
+- **Agents can run their own shell scripts** (#900) — `Bash(bash:*)` and `Bash(sh:*)` added to the agent tool allowlist in both spawn paths (single-agent and conversation), so an agent invoking a co-located helper script no longer stalls on a permission it can never grant.
 
 ## [0.8.1] — 2026-06-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squads-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "squads-cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squads-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Your AI workforce. Every user gets an AI manager that runs their team — finance, marketing, engineering, operations — for the cost of API calls.",
   "type": "module",
   "bin": {

--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -1,6 +1,6 @@
 # Squads CLI — Full Command Reference
 
-> GENERATED from `squads commands --json` (squads-cli v0.8.1) — do not edit.
+> GENERATED from `squads commands --json` (squads-cli v0.8.2) — do not edit.
 > Regenerate: `npm run build && npm run gen:skill`. For the live tree on any
 > installed version, run `squads commands --json` directly.
 


### PR DESCRIPTION
Version bump 0.8.1 → 0.8.2 + CHANGELOG finalized (dated 2026-07-01) for the trustworthy-execution release. Seed skill reference regenerated (`npm run gen:skill` — embeds the version, drift-guarded). No source changes — version + CHANGELOG + generated reference only.

Contents of 0.8.2: #877/#892 (pause/resume enforcement) · #876/#878 (strategy.md as L1 + docs) · #875/#891 (no silent loss of deliverables) · #893/#894 (stale-memory caveat + real loader tests) · #866 (run SQUAD AGENT routing) · #860/#861/#862 (quota detection, quota-aware org runner, session-id pinning) · #870 (post-run ingest ping) · #900 (agent shell scripts) · #887/#896/#897 (docs).

Also adds the two CHANGELOG entries the release notes were missing (#870, #900).

Next: release PR `release/v0.8.2` develop→main per RELEASING.md — founder merges + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)