### PR TITLE
feat(events): exec-event substrate — observable execution Child 0

### DIFF
--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -39,6 +39,7 @@ import {
 } from './execution-engine.js';
 import {
   type ContextRole,
+  type ContextStats,
   parseAgentFrontmatter,
   extractMcpServersFromDefinition,
   loadSystemProtocol,
@@ -249,9 +250,13 @@ export async function runAgent(
   if (options.verbose && agentFrontmatter.max_context_tokens) {
     writeLine(`  ${colors.dim}Context budget: ${agentFrontmatter.max_context_tokens} tokens (agent override)${RESET}`);
   }
+  // Capture per-layer assembly stats — emitted as the run's `context_assembled`
+  // exec-event (#902). Only assembly knows the layers; the provider never does.
+  let contextStats: ContextStats | undefined;
   const squadContext = gatherSquadContext(squadName, agentName, {
     verbose: options.verbose, agentPath, role: contextRole,
     maxTokens: agentFrontmatter.max_context_tokens,
+    onStats: (stats) => { contextStats = stats; },
   });
 
   // Fetch cognition beliefs for prompt injection (Reflexion pattern)
@@ -355,6 +360,7 @@ ${systemContext}${squadContext}${cognitionContext}${learningContext}`;
             squadName,
             agentName,
             model: options.model,
+            contextStats,
           });
         } else {
           result = await executeWithProvider(provider, currentPrompt, {

--- a/src/lib/exec-events.ts
+++ b/src/lib/exec-events.ts
@@ -1,0 +1,362 @@
+/**
+ * exec-events.ts — the observable-execution substrate (#902, RFC #898).
+ *
+ * Every run emits a typed, inspectable stream of execution events. Two
+ * consumers are built on top of this substrate (as separate child issues):
+ * live run visibility (#903) and per-run context economy (#904). #817
+ * (post-hoc outcomes) and #662 (org TUI) aggregate the same events — there
+ * is no second event path.
+ *
+ * Design constraints (from the RFC):
+ * - Provider-agnostic from line one: runner code consumes `ExecEvent[]` only.
+ *   Provider stream shapes (Claude stream-json today; deepseek/gemini as those
+ *   executors land) are normalized by a `ProviderEventAdapter` at the bottom.
+ * - `context_assembled` is the one event no provider can emit — only our own
+ *   context assembly (run-context.ts) knows the L0–L10 layers. It is the
+ *   per-layer source for the context-economy consumer.
+ * - Persistence is best-effort and NEVER throws into the run path: a broken
+ *   disk must not kill an agent. Size-capped with an explicit `truncated`
+ *   event — never a silent cap.
+ */
+
+import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+// ── Event schema ──────────────────────────────────────────────────────
+
+/** Per-layer accounting from context assembly (see run-context.ts). */
+export interface ContextLayerStat {
+  /** Layer id in the Squad Context System (1=company … 9/10=founder). */
+  layer: number;
+  name: string;
+  /** Chars actually injected (post-truncation); 0 when evicted. */
+  chars: number;
+  tokensEst: number;
+  /** True when the layer had content but the budget refused it entirely. */
+  evicted: boolean;
+}
+
+export type ExecEvent =
+  | { type: 'run_start'; squad: string; agent?: string; mode: string; model: string; role: string; startedAt: string }
+  | { type: 'context_assembled'; layers: ContextLayerStat[]; totalTokensEst: number; budgetTokens: number }
+  | { type: 'tool_call'; tool: string; inputSummary: string }
+  | { type: 'tool_result'; tool: string; ok: boolean; summary: string }
+  | { type: 'file_read'; path: string }
+  | { type: 'file_write'; path: string; bytes: number }
+  | { type: 'web_fetch'; url: string }
+  | { type: 'subagent_spawn'; childRunId: string; squad: string; agent: string; task: string }
+  | { type: 'subagent_done'; childRunId: string; agent: string; ok: boolean }
+  | { type: 'token_usage'; input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number; model: string }
+  | { type: 'artifact'; kind: 'commit' | 'pr' | 'issue' | 'file'; ref: string }
+  | { type: 'run_end'; ok: boolean; durationMs: number; totalUsage: { input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number }; outcomes: { actions: number; files_edited: number; commits: number; prs_created: number; issues_created: number } }
+  | { type: 'truncated'; droppedCount: number; reason: string };
+
+/** Envelope stamped on every persisted line. */
+export interface PersistedExecEvent {
+  v: 1;
+  runId: string;
+  seq: number;
+  ts: string;
+  /** Which agent in the run produced this event (fan-out attribution). */
+  agent?: string;
+  event: ExecEvent;
+}
+
+// ── Provider normalization ────────────────────────────────────────────
+
+/**
+ * Normalizes one provider's raw stream into ExecEvents. Instances may hold
+ * per-run state (e.g. mapping tool_use ids to tool names so results can be
+ * labeled). Create one adapter per run; never share across runs.
+ */
+export interface ProviderEventAdapter {
+  parseLine(raw: string): ExecEvent[];
+}
+
+/** Cap on the tool-id → name correlation map (defensive; ~2 entries/turn). */
+const PENDING_TOOL_MAP_MAX = 10_000;
+const INPUT_SUMMARY_MAX = 200;
+
+interface ClaudeContentBlock {
+  type?: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+function summarizeToolInput(name: string, input: Record<string, unknown> | undefined): string {
+  if (!input) return '';
+  const pick = (k: string) => (typeof input[k] === 'string' ? (input[k] as string) : '');
+  const lower = name.toLowerCase();
+  let summary = '';
+  if (lower === 'bash') summary = pick('command');
+  else if (lower === 'read' || lower === 'write' || lower === 'edit' || lower === 'notebookedit') summary = pick('file_path');
+  else if (lower === 'webfetch') summary = pick('url');
+  else if (lower === 'websearch') summary = pick('query');
+  else if (lower === 'agent' || lower === 'task') summary = pick('description') || pick('prompt');
+  else if (lower === 'glob' || lower === 'grep') summary = pick('pattern');
+  if (!summary) {
+    try { summary = JSON.stringify(input); } catch { summary = ''; }
+  }
+  return summary.slice(0, INPUT_SUMMARY_MAX);
+}
+
+/** Events derived from one `tool_use` block (call + specialization + artifacts). */
+function eventsFromToolUse(block: ClaudeContentBlock): ExecEvent[] {
+  const name = block.name || 'unknown';
+  const input = block.input;
+  const lower = name.toLowerCase();
+  const events: ExecEvent[] = [{ type: 'tool_call', tool: name, inputSummary: summarizeToolInput(name, input) }];
+
+  const str = (k: string) => (input && typeof input[k] === 'string' ? (input[k] as string) : '');
+  if (lower === 'read') {
+    if (str('file_path')) events.push({ type: 'file_read', path: str('file_path') });
+  } else if (lower === 'write' || lower === 'edit' || lower === 'notebookedit') {
+    const bytes = input && typeof input.content === 'string' ? (input.content as string).length : 0;
+    if (str('file_path')) events.push({ type: 'file_write', path: str('file_path'), bytes });
+  } else if (lower === 'webfetch' || lower === 'websearch') {
+    const target = str('url') || str('query');
+    if (target) events.push({ type: 'web_fetch', url: target });
+  } else if (lower === 'agent' || lower === 'task') {
+    events.push({
+      type: 'subagent_spawn',
+      childRunId: block.id || '',
+      squad: '',
+      agent: str('subagent_type') || name,
+      task: (str('description') || str('prompt')).slice(0, INPUT_SUMMARY_MAX),
+    });
+  } else if (lower === 'bash') {
+    const cmd = str('command');
+    if (/\bgit\b/.test(cmd) && /\bcommit\b/.test(cmd)) events.push({ type: 'artifact', kind: 'commit', ref: cmd.slice(0, INPUT_SUMMARY_MAX) });
+    if (/\bgh\b/.test(cmd) && /\bpr\s+create\b/.test(cmd)) events.push({ type: 'artifact', kind: 'pr', ref: cmd.slice(0, INPUT_SUMMARY_MAX) });
+    if (/\bgh\b/.test(cmd) && /\bissue\s+create\b/.test(cmd)) events.push({ type: 'artifact', kind: 'issue', ref: cmd.slice(0, INPUT_SUMMARY_MAX) });
+  }
+  return events;
+}
+
+/** Short human summary of a tool_result content payload. */
+function summarizeToolResult(content: unknown): string {
+  if (typeof content === 'string') return content.slice(0, INPUT_SUMMARY_MAX);
+  if (Array.isArray(content)) {
+    const text = content
+      .filter((b): b is { type: string; text: string } => !!b && typeof b === 'object' && (b as { type?: string }).type === 'text' && typeof (b as { text?: string }).text === 'string')
+      .map((b) => b.text)
+      .join(' ');
+    return text.slice(0, INPUT_SUMMARY_MAX);
+  }
+  return '';
+}
+
+/**
+ * The Claude adapter: normalizes `claude --print --output-format stream-json
+ * --verbose` JSONL lines into ExecEvents. Stateful per run: correlates
+ * `tool_result` blocks (which arrive on `user` events carrying only a
+ * tool_use_id) back to the tool name, and Agent/Task spawns to subagent_done.
+ */
+export function createClaudeStreamJsonAdapter(): ProviderEventAdapter {
+  /** tool_use id → tool name, so results can be labeled. */
+  const pendingTools = new Map<string, string>();
+
+  return {
+    parseLine(raw: string): ExecEvent[] {
+      const trimmed = raw.trim();
+      if (!trimmed) return [];
+      let ev: Record<string, unknown>;
+      try {
+        ev = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        return []; // stray non-JSON line (warning etc.) — not an event
+      }
+
+      const message = ev.message as { content?: ClaudeContentBlock[]; usage?: Record<string, number>; model?: string } | undefined;
+
+      if (ev.type === 'assistant' && Array.isArray(message?.content)) {
+        const events: ExecEvent[] = [];
+        for (const block of message.content) {
+          if (!block || block.type !== 'tool_use') continue;
+          if (block.id && block.name) {
+            if (pendingTools.size >= PENDING_TOOL_MAP_MAX) pendingTools.clear();
+            pendingTools.set(block.id, block.name);
+          }
+          events.push(...eventsFromToolUse(block));
+        }
+        return events;
+      }
+
+      if (ev.type === 'user' && Array.isArray(message?.content)) {
+        const events: ExecEvent[] = [];
+        for (const block of message.content) {
+          if (!block || block.type !== 'tool_result' || !block.tool_use_id) continue;
+          const tool = pendingTools.get(block.tool_use_id) || 'unknown';
+          pendingTools.delete(block.tool_use_id);
+          const ok = block.is_error !== true;
+          events.push({ type: 'tool_result', tool, ok, summary: summarizeToolResult(block.content) });
+          if (tool.toLowerCase() === 'agent' || tool.toLowerCase() === 'task') {
+            events.push({ type: 'subagent_done', childRunId: block.tool_use_id, agent: tool, ok });
+          }
+        }
+        return events;
+      }
+
+      if (ev.type === 'result') {
+        const u = (ev.usage as Record<string, number>) || {};
+        return [{
+          type: 'token_usage',
+          input: u.input_tokens || 0,
+          output: u.output_tokens || 0,
+          cacheRead: u.cache_read_input_tokens || 0,
+          cacheWrite: u.cache_creation_input_tokens || 0,
+          costEst: typeof ev.total_cost_usd === 'number' ? ev.total_cost_usd : 0,
+          model: typeof ev.model === 'string' ? ev.model : '',
+        }];
+      }
+
+      return [];
+    },
+  };
+}
+
+// ── Persistence ───────────────────────────────────────────────────────
+
+/** Default cap: ~5k events / ~2MB per run, then sample down to terminals. */
+const DEFAULT_MAX_EVENTS = 5000;
+const DEFAULT_MAX_BYTES = 2 * 1024 * 1024;
+
+/** Terminal/aggregate events are never dropped by the cap. */
+const UNCAPPED_TYPES = new Set<ExecEvent['type']>(['run_start', 'run_end', 'token_usage', 'truncated', 'context_assembled']);
+
+/** Canonical events file for a run, under the dispatch root's observability dir. */
+export function execEventsFile(obsRoot: string, executionId: string): string {
+  const safeId = executionId.replace(/[^A-Za-z0-9_-]/g, '');
+  return join(obsRoot, '.agents', 'observability', 'events', `${safeId}.jsonl`);
+}
+
+/**
+ * Append-only JSONL writer for a run's event stream.
+ *
+ * - Best-effort: any fs error disables the writer silently — persistence must
+ *   never take down the run it observes.
+ * - Capped (events + bytes, env-tunable via SQUADS_EVENTS_MAX /
+ *   SQUADS_EVENTS_MAX_BYTES): past the cap, detail events are counted and
+ *   dropped; terminal events still land; `close()` records an explicit
+ *   `truncated{droppedCount}` so a capped stream is never mistaken for a
+ *   complete one.
+ */
+export class ExecEventWriter {
+  private seq = 0;
+  private bytes = 0;
+  private dropped = 0;
+  private dead = false;
+  private closed = false;
+  private readonly maxEvents: number;
+  private readonly maxBytes: number;
+
+  constructor(
+    private readonly file: string,
+    private readonly runId: string,
+    opts: { maxEvents?: number; maxBytes?: number } = {},
+  ) {
+    const envMax = Number(process.env.SQUADS_EVENTS_MAX);
+    const envBytes = Number(process.env.SQUADS_EVENTS_MAX_BYTES);
+    this.maxEvents = opts.maxEvents ?? (Number.isFinite(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_EVENTS);
+    this.maxBytes = opts.maxBytes ?? (Number.isFinite(envBytes) && envBytes > 0 ? envBytes : DEFAULT_MAX_BYTES);
+    try {
+      const dir = dirname(file);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    } catch {
+      this.dead = true;
+    }
+  }
+
+  emit(event: ExecEvent, agent?: string): void {
+    if (this.dead || this.closed) return;
+    const capped = this.seq >= this.maxEvents || this.bytes >= this.maxBytes;
+    if (capped && !UNCAPPED_TYPES.has(event.type)) {
+      this.dropped++;
+      return;
+    }
+    const line: PersistedExecEvent = {
+      v: 1,
+      runId: this.runId,
+      seq: this.seq,
+      ts: new Date().toISOString(),
+      ...(agent ? { agent } : {}),
+      event,
+    };
+    try {
+      const serialized = JSON.stringify(line) + '\n';
+      appendFileSync(this.file, serialized);
+      this.seq++;
+      this.bytes += serialized.length;
+    } catch {
+      this.dead = true; // fs is broken — stop trying, never throw into the run
+    }
+  }
+
+  /** Run every event an adapter extracts from one raw provider line through emit. */
+  ingestProviderLine(adapter: ProviderEventAdapter, raw: string, agent?: string): void {
+    if (this.dead || this.closed) return;
+    let events: ExecEvent[];
+    try {
+      events = adapter.parseLine(raw);
+    } catch {
+      return; // a malformed provider line must never break the run
+    }
+    for (const event of events) this.emit(event, agent);
+  }
+
+  /** Flush the truncation marker (if any) and stop accepting events. */
+  close(): void {
+    if (this.dead || this.closed) return;
+    if (this.dropped > 0) {
+      this.emit({ type: 'truncated', droppedCount: this.dropped, reason: `event cap reached (${this.maxEvents} events / ${this.maxBytes} bytes)` });
+    }
+    this.closed = true;
+  }
+
+  /** Events dropped by the cap so far (visible for tests/diagnostics). */
+  get droppedCount(): number {
+    return this.dropped;
+  }
+
+  /** Events successfully persisted so far. */
+  get writtenCount(): number {
+    return this.seq;
+  }
+}
+
+// ── Detached-run normalization ────────────────────────────────────────
+
+/**
+ * Normalize a detached run's raw stream-json log into the run's events file.
+ * Called at reconcile time (the CLI that spawned the run is long gone). The
+ * raw log is the provider-shaped source; this writes the normalized events
+ * so consumers never touch provider lines. Appends after the run_start /
+ * context_assembled events written at spawn time; optionally closes the
+ * stream with a `run_end` synthesized from the spool's completion facts.
+ *
+ * Returns the number of events written (0 = not a stream-json log — legacy
+ * plain-text logs normalize to nothing, gracefully).
+ */
+export function normalizeDetachedLog(
+  rawLog: string,
+  obsRoot: string,
+  executionId: string,
+  agent?: string,
+  runEnd?: Extract<ExecEvent, { type: 'run_end' }>,
+): number {
+  const adapter = createClaudeStreamJsonAdapter();
+  const writer = new ExecEventWriter(execEventsFile(obsRoot, executionId), executionId);
+  for (const line of rawLog.split('\n')) {
+    writer.ingestProviderLine(adapter, line, agent);
+  }
+  // Only close a stream that actually opened: a legacy plain-text log yields
+  // zero events, and a run_end there would fabricate an event file.
+  if (runEnd && writer.writtenCount > 0) writer.emit(runEnd, agent);
+  writer.close();
+  return writer.writtenCount;
+}

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -19,7 +19,8 @@ import {
   type EffortLevel,
   type Squad,
 } from './squad-parser.js';
-import { parseAgentFrontmatter } from './run-context.js';
+import { parseAgentFrontmatter, type ContextStats } from './run-context.js';
+import { ExecEventWriter, execEventsFile } from './exec-events.js';
 import {
   type ExecutionContext,
 } from './run-types.js';
@@ -107,6 +108,8 @@ export interface ExecuteWithClaudeOptions {
   squadName: string;
   agentName: string;
   model?: string; // Model to use (Claude aliases or full model IDs like gemini-2.5-flash)
+  /** Assembly-time context stats from gatherSquadContext — emitted as the run's `context_assembled` event (#902). */
+  contextStats?: ContextStats;
 }
 
 // ── Auto-commit ──────────────────────────────────────────────────────
@@ -590,7 +593,12 @@ export function buildDetachedShellScript(config: {
         sessionId: safeSessionId,
       })
     : '';
-  const executorCmd = `claude --print --dangerously-skip-permissions --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
+  // stream-json (#902): the detached log is a LIVE event stream instead of a
+  // buffer that stays empty until exit — `--print` alone emits nothing until
+  // the run ends, which is exactly the black box this kills. `--verbose` is
+  // required for stream-json to emit events. The reconcile sweep normalizes
+  // this raw log into the run's events file (exec-events.ts).
+  const executorCmd = `claude --print --output-format stream-json --verbose --dangerously-skip-permissions --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
   const watchdogSecs = Math.max(1, Math.round((config.timeoutMinutes || 15) * 60));
   const script = `mkdir -p '${config.projectRoot}/../.worktrees'; WORK_DIR='${config.projectRoot}'; if git -C '${config.projectRoot}' worktree add '${worktreeDir}' -b '${branchName}' HEAD 2>/dev/null; then WORK_DIR='${worktreeDir}'; fi; cd "\${WORK_DIR}"; unset CLAUDECODE; ${buildWatchdogShell(executorCmd, watchdogSecs, timeoutFlag)}; ${cleanup}${spool}`;
   // pid file removed on clean wrapper exit — a surviving pid file with a dead
@@ -624,6 +632,8 @@ export function executeForeground(config: {
   execContext: ExecutionContext;
   startMs: number;
   provider?: string;
+  /** Exec-event stream (#902) — run_end/token_usage emitted here on close. */
+  events?: ExecEventWriter;
 }): Promise<string> {
   const workDir = createAgentWorktree(config.projectRoot, config.squadName, config.agentName);
 
@@ -669,6 +679,34 @@ export function executeForeground(config: {
         goals_changed: goalsChanged.length > 0 ? goalsChanged : undefined,
       };
       logObservability(obsRecord);
+
+      // Exec events (#902): foreground runs use inherited stdio (no stream to
+      // tee), so the event record is the aggregate — session usage + outcome.
+      if (config.events) {
+        config.events.emit({
+          type: 'token_usage',
+          input: sessionUsage?.input_tokens || 0,
+          output: sessionUsage?.output_tokens || 0,
+          cacheRead: sessionUsage?.cache_read_tokens || 0,
+          cacheWrite: sessionUsage?.cache_write_tokens || 0,
+          costEst: sessionUsage?.cost_usd || 0,
+          model: sessionUsage?.model || '',
+        }, config.agentName);
+        config.events.emit({
+          type: 'run_end',
+          ok: code === 0,
+          durationMs,
+          totalUsage: {
+            input: sessionUsage?.input_tokens || 0,
+            output: sessionUsage?.output_tokens || 0,
+            cacheRead: sessionUsage?.cache_read_tokens || 0,
+            cacheWrite: sessionUsage?.cache_write_tokens || 0,
+            costEst: sessionUsage?.cost_usd || 0,
+          },
+          outcomes: { actions: 0, files_edited: 0, commits: 0, prs_created: 0, issues_created: 0 },
+        });
+        config.events.close();
+      }
 
       if (code === 0) {
         updateExecutionStatus(config.squadName, config.agentName, config.execContext.executionId, 'completed', {
@@ -716,6 +754,16 @@ export function executeForeground(config: {
         error: String(err),
         durationMs,
       });
+      if (config.events) {
+        config.events.emit({
+          type: 'run_end',
+          ok: false,
+          durationMs,
+          totalUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costEst: 0 },
+          outcomes: { actions: 0, files_edited: 0, commits: 0, prs_created: 0, issues_created: 0 },
+        });
+        config.events.close();
+      }
       cleanupWorktree(workDir, config.projectRoot);
       reject(err);
     });
@@ -847,6 +895,29 @@ export async function executeWithClaude(
 
   await registerContextWithBridge(execContext);
 
+  // Exec-event stream (#902): run_start + context_assembled are written by the
+  // CLI at dispatch (only we know the layers); the run's tool activity follows —
+  // live for foreground, appended at reconcile for detached (from the raw
+  // stream-json log the executor writes).
+  const events = new ExecEventWriter(execEventsFile(projectRoot, execContext.executionId), execContext.executionId);
+  events.emit({
+    type: 'run_start',
+    squad: squadName,
+    agent: agentName,
+    mode: runInForeground ? 'foreground' : runInWatch ? 'watch' : 'background',
+    model: claudeModelAlias || resolvedModel || '',
+    role: options.contextStats?.role || '',
+    startedAt: new Date(startMs).toISOString(),
+  });
+  if (options.contextStats) {
+    events.emit({
+      type: 'context_assembled',
+      layers: options.contextStats.layers,
+      totalTokensEst: options.contextStats.totalTokensEst,
+      budgetTokens: Math.ceil(options.contextStats.budgetChars / 4),
+    }, agentName);
+  }
+
   // Get bot token so agents create PRs/issues as bot identity (not user's personal gh auth)
   let botGhToken: string | undefined;
   try {
@@ -920,7 +991,7 @@ export async function executeWithClaude(
 
     return executeForeground({
       prompt, claudeArgs, agentEnv, projectRoot: targetRepoRoot,
-      squadName, agentName, execContext, startMs, provider,
+      squadName, agentName, execContext, startMs, provider, events,
     });
   }
 
@@ -940,6 +1011,10 @@ export async function executeWithClaude(
     timeoutMinutes: watchdogMinutes,
     sessionId: randomUUID(),
   });
+
+  // Detached: run_start/context_assembled are already on disk; the run's tool
+  // events are normalized from the raw stream-json log at reconcile (spool.ts).
+  events.close();
 
   if (runInWatch) {
     if (verbose) {

--- a/src/lib/run-context.ts
+++ b/src/lib/run-context.ts
@@ -33,10 +33,24 @@ import { execSync } from 'child_process';
 import { findSquadsDir } from './squad-parser.js';
 import { findMemoryDir } from './memory.js';
 import { colors, RESET, writeLine } from './terminal.js';
+import { type ContextLayerStat } from './exec-events.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
 export type ContextRole = 'scanner' | 'worker' | 'lead' | 'coo' | 'verifier';
+
+/**
+ * Assembly-time accounting for one context build — the source of the
+ * `context_assembled` exec-event (#902). The provider stream only ever sees
+ * the final prompt; this is the one place that knows the layers.
+ */
+export interface ContextStats {
+  role: ContextRole;
+  layers: ContextLayerStat[];
+  totalChars: number;
+  totalTokensEst: number;
+  budgetChars: number;
+}
 
 // ── Token Budgets (chars, ~4 chars/token) ────────────────────────────
 
@@ -484,7 +498,11 @@ export function resolveContextRoleFromAgent(agentPath: string, agentName: string
 export function gatherSquadContext(
   squadName: string,
   agentName: string,
-  options: { verbose?: boolean; maxTokens?: number; agentPath?: string; role?: ContextRole } = {}
+  options: {
+    verbose?: boolean; maxTokens?: number; agentPath?: string; role?: ContextRole;
+    /** Receives per-layer assembly stats — the `context_assembled` event source (#902). */
+    onStats?: (stats: ContextStats) => void;
+  } = {}
 ): string {
   const squadsDir = findSquadsDir();
   if (!squadsDir) return '';
@@ -494,6 +512,7 @@ export function gatherSquadContext(
   const budget = options.maxTokens ? options.maxTokens * 4 : (ROLE_BUDGETS[role] ?? ROLE_BUDGETS.worker);
   const allowedSections = ROLE_SECTIONS[role] ?? ROLE_SECTIONS.worker;
   const sections: string[] = [];
+  const layerStats: ContextLayerStat[] = [];
   let usedChars = 0;
 
   /** Try to add a layer. Returns true if added (possibly truncated), false if no budget left. */
@@ -508,6 +527,8 @@ export function gatherSquadContext(
       if (options.verbose) {
         writeLine(`  ${colors.dim}Context budget exhausted at layer ${layerNum} (${header})${RESET}`);
       }
+      // Layer had content but the budget refused it — record the eviction.
+      layerStats.push({ layer: layerNum, name: header, chars: 0, tokensEst: 0, evicted: true });
       return false;
     }
 
@@ -523,6 +544,7 @@ export function gatherSquadContext(
 
     sections.push(`## ${header}\n${text}`);
     usedChars += text.length;
+    layerStats.push({ layer: layerNum, name: header, chars: text.length, tokensEst: Math.ceil(text.length / 4), evicted: false });
     return true;
   }
 
@@ -633,6 +655,14 @@ export function gatherSquadContext(
       addLayer(8, 'Cross-Squad Learnings', learningParts.join('\n\n'));
     }
   }
+
+  options.onStats?.({
+    role,
+    layers: layerStats,
+    totalChars: usedChars,
+    totalTokensEst: Math.ceil(usedChars / 4),
+    budgetChars: budget,
+  });
 
   if (sections.length === 0) return '';
 

--- a/src/lib/spool.ts
+++ b/src/lib/spool.ts
@@ -24,9 +24,19 @@ import {
   type ObservabilityRecord,
 } from './observability.js';
 import { updateExecutionStatus } from './execution-log.js';
+import { parseStreamJson } from './stream-json.js';
+import { normalizeDetachedLog } from './exec-events.js';
 
 /** Tail cap when parsing executor logs — matches the #826 live-stream buffer. */
 const LOG_TAIL_CAP_BYTES = 256 * 1024;
+
+/**
+ * Read cap for a detached claude run's raw stream-json log (#902). Larger than
+ * the provider tail cap because the event stream's early lines carry the run's
+ * tool activity; the terminal `result` event sits at the end, so tail-reading
+ * keeps it when a log exceeds the cap.
+ */
+const STREAM_LOG_CAP_BYTES = 16 * 1024 * 1024;
 
 export interface SpoolRecord {
   execId: string;
@@ -135,10 +145,10 @@ export function buildWatchdogShell(executorCmd: string, timeoutSecs: number, tim
   );
 }
 
-function readLogTail(logFile: string): string {
+function readLogTail(logFile: string, capBytes: number = LOG_TAIL_CAP_BYTES): string {
   try {
     const size = statSync(logFile).size;
-    const start = Math.max(0, size - LOG_TAIL_CAP_BYTES);
+    const start = Math.max(0, size - capBytes);
     const fd = openSync(logFile, 'r');
     try {
       const buf = Buffer.alloc(size - start);
@@ -152,7 +162,7 @@ function readLogTail(logFile: string): string {
   }
 }
 
-function toRecord(spool: SpoolRecord): ObservabilityRecord {
+function toRecord(spool: SpoolRecord, obsRoot: string): ObservabilityRecord {
   const durationMs = spool.endEpoch > spool.startEpoch && spool.startEpoch > 0
     ? (spool.endEpoch - spool.startEpoch) * 1000
     : 0;
@@ -160,8 +170,9 @@ function toRecord(spool: SpoolRecord): ObservabilityRecord {
     ? 'timeout'
     : spool.exitCode === 0 ? 'completed' : 'failed';
 
-  let input = 0, output = 0, cost = 0;
+  let input = 0, output = 0, cost = 0, cacheRead = 0, cacheWrite = 0;
   let model = spool.model || 'unknown';
+  let outcomes: ReturnType<typeof parseStreamJson>['outcomes'] | undefined;
 
   if (spool.provider && spool.provider !== 'anthropic') {
     const parse = getCLIConfig(spool.provider)?.parseUsage;
@@ -174,9 +185,17 @@ function toRecord(spool: SpoolRecord): ObservabilityRecord {
       }
     }
   } else {
-    // Claude run: exact session-id attribution when the wrapper recorded one
-    // (#857); legacy fallback = mtime-window scan BOUNDED by endEpoch so a
-    // session still active after this run can't absorb the attribution.
+    // Claude run: the log IS the raw stream-json event stream (#902) — parse
+    // it for what the agent actually DID (outcomes, previously always zero on
+    // detached runs) and as the usage fallback; normalize it into the run's
+    // events file so the black box stays killed after the log rotates.
+    const rawLog = spool.logFile ? readLogTail(spool.logFile, STREAM_LOG_CAP_BYTES) : '';
+    const stream = rawLog ? parseStreamJson(rawLog) : null;
+    if (stream && stream.outcomes.actions > 0) outcomes = stream.outcomes;
+
+    // Exact session-id attribution when the wrapper recorded one (#857);
+    // legacy fallback = mtime-window scan BOUNDED by endEpoch so a session
+    // still active after this run can't absorb the attribution.
     const session = spool.sessionId
       ? captureSessionUsageById(spool.sessionId)
       : spool.startEpoch > 0
@@ -186,7 +205,36 @@ function toRecord(spool: SpoolRecord): ObservabilityRecord {
       input = session.input_tokens;
       output = session.output_tokens;
       cost = session.cost_usd;
+      cacheRead = session.cache_read_tokens || 0;
+      cacheWrite = session.cache_write_tokens || 0;
       if (session.model) model = session.model;
+    } else if (stream && stream.sawResult) {
+      // No session JSONL visible — the stream's terminal result event still
+      // carries the run's canonical usage (incl. cache), so use it.
+      input = stream.usage.input_tokens;
+      output = stream.usage.output_tokens;
+      cost = stream.usage.cost_usd;
+      cacheRead = stream.usage.cache_read_tokens;
+      cacheWrite = stream.usage.cache_write_tokens;
+      if (stream.usage.model) model = stream.usage.model;
+    }
+
+    if (rawLog) {
+      try {
+        normalizeDetachedLog(rawLog, obsRoot, spool.execId, spool.agent, {
+          type: 'run_end',
+          ok: status === 'completed',
+          durationMs,
+          totalUsage: { input, output, cacheRead, cacheWrite, costEst: cost },
+          outcomes: {
+            actions: outcomes?.actions || 0,
+            files_edited: outcomes?.files_edited || 0,
+            commits: outcomes?.commits || 0,
+            prs_created: outcomes?.prs_created || 0,
+            issues_created: outcomes?.issues_created || 0,
+          },
+        });
+      } catch { /* events are best-effort; the obs record below is the source of truth */ }
     }
   }
 
@@ -202,10 +250,17 @@ function toRecord(spool: SpoolRecord): ObservabilityRecord {
     duration_ms: durationMs,
     input_tokens: input,
     output_tokens: output,
-    cache_read_tokens: 0,
-    cache_write_tokens: 0,
+    cache_read_tokens: cacheRead,
+    cache_write_tokens: cacheWrite,
     cost_usd: cost,
     context_tokens: 0,
+    ...(outcomes ? {
+      actions: outcomes.actions,
+      files_edited: outcomes.files_edited,
+      commits: outcomes.commits,
+      prs_created: outcomes.prs_created,
+      issues_created: outcomes.issues_created,
+    } : {}),
     error: spool.timedOut
       ? `detached run reaped by watchdog after ${Math.round(durationMs / 60000)} min`
       : spool.exitCode !== 0 ? `detached run exited with code ${spool.exitCode}` : undefined,
@@ -236,7 +291,7 @@ export function reconcileDetachedRuns(obsRoot: string): number {
     const path = join(dir, entry);
     try {
       const spool = JSON.parse(readFileSync(path, 'utf8')) as SpoolRecord;
-      const record = toRecord(spool);
+      const record = toRecord(spool, obsRoot);
       logObservability(record);
       try {
         updateExecutionStatus(spool.squad, spool.agent, spool.execId, record.status === 'completed' ? 'completed' : 'failed', {

--- a/src/lib/stream-json.ts
+++ b/src/lib/stream-json.ts
@@ -252,8 +252,16 @@ export class StreamJsonAccumulator {
   /** Running sum of what the agent did across the whole stream. */
   private outcomes: RunOutcomes = emptyOutcomes();
 
-  /** @param onText optional sink for live display of assistant text chunks. */
-  constructor(private readonly onText?: (text: string) => void) {}
+  /**
+   * @param onText optional sink for live display of assistant text chunks.
+   * @param onRawLine optional tee of every complete raw JSONL line — used to
+   *   feed a ProviderEventAdapter (exec-events.ts, #902) without a second
+   *   line-buffering layer. Called before the line is parsed here.
+   */
+  constructor(
+    private readonly onText?: (text: string) => void,
+    private readonly onRawLine?: (raw: string) => void,
+  ) {}
 
   /** Feed a decoded stdout chunk; processes all complete lines within it. */
   push(chunk: string): void {
@@ -272,6 +280,7 @@ export class StreamJsonAccumulator {
   }
 
   private consume(line: string): void {
+    this.onRawLine?.(line);
     const parsed = parseStreamJsonLine(line);
     if (parsed.text) {
       this.assistantText += this.assistantText ? '\n' + parsed.text : parsed.text;

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -68,6 +68,11 @@ import {
   type StreamUsage,
   type RunOutcomes,
 } from './stream-json.js';
+import {
+  ExecEventWriter,
+  createClaudeStreamJsonAdapter,
+  execEventsFile,
+} from './exec-events.js';
 
 // =============================================================================
 // Configuration
@@ -124,6 +129,8 @@ interface AgentRunConfig {
   verbose?: boolean;
   /** Per-agent execution timeout (minutes) — from --timeout. env SQUADS_AGENT_TIMEOUT_MINUTES overrides; unset → DEFAULT_TIMEOUT_MINUTES (#438) */
   timeout?: number;
+  /** Cycle-level exec-event stream (#902) — this agent's tool activity is teed into it. */
+  events?: ExecEventWriter;
 }
 
 /**
@@ -254,6 +261,18 @@ ${squadContext}
   if (guardrailPath) claudeArgs.push('--settings', guardrailPath);
   if (claudeModel) claudeArgs.push('--model', claudeModel);
 
+  // Exec-event stream (#902): announce this agent as a lane in the cycle's
+  // fan-out tree, then tee its provider stream through the Claude adapter so
+  // every tool call / file touch / web fetch lands as a normalized event.
+  config.events?.emit({
+    type: 'subagent_spawn',
+    childRunId: execContext.executionId,
+    squad: squadName,
+    agent: agentName,
+    task: task.slice(0, 200),
+  });
+  const eventAdapter = config.events ? createClaudeStreamJsonAdapter() : undefined;
+
   return new Promise<AgentRunResult>((resolve) => {
     const child = spawn('claude', claudeArgs, {
       cwd: spawnCwd, env: agentEnv,
@@ -275,7 +294,10 @@ ${squadContext}
               writeLine(`  ${colors.dim}${agentName} │${RESET} ${line}`);
             }
           }
-        : undefined
+        : undefined,
+      eventAdapter
+        ? (raw: string) => config.events?.ingestProviderLine(eventAdapter, raw, agentName)
+        : undefined,
     );
 
     // Timeout: configurable via env var, defaults from run-types.ts
@@ -317,6 +339,13 @@ ${squadContext}
         : rawUsage;
       const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim();
 
+      config.events?.emit({
+        type: 'subagent_done',
+        childRunId: execContext.executionId,
+        agent: agentName,
+        ok: !timedOut && !isError && code === 0,
+      });
+
       // Timed-out agents: return the timeout sentinel the convergence loop
       // expects, but with the salvaged assistant-event usage (real tokens; cost
       // derived above) instead of zero — cut-off cost is no longer invisible.
@@ -344,6 +373,7 @@ ${squadContext}
 
     child.on('error', (err) => {
       clearTimeout(timeout);
+      config.events?.emit({ type: 'subagent_done', childRunId: execContext.executionId, agent: agentName, ok: false });
       resolve({ text: `[ERROR] ${agentName} failed to spawn: ${err.message}`, usage: emptyUsage(), outcomes: emptyOutcomes() });
     });
   });
@@ -465,11 +495,51 @@ export async function runConversation(
 
   log(`${squad.name}: ${allAgents.length} agents (${leads.length}L ${scanners.length}S ${workers.length}W ${verifiers.length}V) budget: ${Math.round(tokenBudget / 1000)}K tokens`);
 
+  // Exec-event stream for this cycle (#902): persists to the dispatch root's
+  // observability dir (survives the per-run worktree by construction). One
+  // file per cycle; each agent's activity is attributed via the envelope.
+  const events = new ExecEventWriter(
+    execEventsFile(findProjectRoot() || process.cwd(), executionId),
+    executionId,
+  );
+  const finishEvents = (ok: boolean) => {
+    events.emit({
+      type: 'run_end',
+      ok,
+      durationMs: Date.now() - cycleStartMs,
+      totalUsage: {
+        input: cycleUsage.input_tokens,
+        output: cycleUsage.output_tokens,
+        cacheRead: cycleUsage.cache_read_tokens,
+        cacheWrite: cycleUsage.cache_write_tokens,
+        costEst: cycleUsage.cost_usd,
+      },
+      outcomes: { ...outcomeFields(cycleOutcomes) },
+    });
+    events.close();
+  };
+
   // Build squad context once (shared by all agents)
   // Resolve context role from frontmatter; leads default to 'lead', COO agents have role: coo
   const contextRole: ContextRole = resolveContextRoleFromAgent(lead.path, lead.name);
+  events.emit({
+    type: 'run_start',
+    squad: squad.name,
+    agent: lead.name,
+    mode: 'conversation',
+    model: options.model || modelForRole('lead'),
+    role: contextRole,
+    startedAt: new Date(cycleStartMs).toISOString(),
+  });
   const squadContext = gatherSquadContext(squad.name, lead.name, {
     agentPath: lead.path, role: contextRole,
+    // The one event the provider stream can never produce: per-layer cost (#902).
+    onStats: (stats) => events.emit({
+      type: 'context_assembled',
+      layers: stats.layers,
+      totalTokensEst: stats.totalTokensEst,
+      budgetTokens: Math.ceil(stats.budgetChars / 4),
+    }, lead.name),
   });
 
   // ═══════════════════════════════════════════════════════════════════
@@ -510,7 +580,7 @@ export async function runConversation(
   const planResult = await runIndependentAgent({
     agentName: lead.name, agentPath: lead.path, role: 'lead',
     squadName: squad.name, model: options.model || modelForRole('lead'),
-    task: options.task ? `${options.task}\n\n${planPrompt}` : planPrompt, squadContext: '', cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+    task: options.task ? `${options.task}\n\n${planPrompt}` : planPrompt, squadContext: '', cwd: squadCwd, verbose: options.verbose, timeout: options.timeout, events,
   });
   const planOutput = planResult.text;
   cycleUsage = addUsage(cycleUsage, planResult.usage);
@@ -539,6 +609,7 @@ export async function runConversation(
       error: 'Quota limit reached',
       task: options.task,
     });
+    finishEvents(false);
     return { transcript, turnCount: transcript.turns.length, totalCost: transcript.totalCost, converged: false, reason: 'Quota limit reached' };
   }
 
@@ -569,6 +640,7 @@ export async function runConversation(
       goals_after: Object.keys(goalsAfterEarly).length > 0 ? goalsAfterEarly : undefined,
       goals_changed: goalsChangedEarly.length > 0 ? goalsChangedEarly : undefined,
     });
+    finishEvents(true);
     return { transcript, turnCount: transcript.turns.length, totalCost: cycleUsage.cost_usd, converged: true, reason: conv.reason };
   }
 
@@ -598,7 +670,7 @@ ${planOutput.slice(0, 3000)}`;
     const retryResult = await runIndependentAgent({
       agentName: lead.name, agentPath: lead.path, role: 'lead',
       squadName: squad.name, model: options.model || modelForRole('lead'),
-      task: formatReminder, squadContext: '', cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+      task: formatReminder, squadContext: '', cwd: squadCwd, verbose: options.verbose, timeout: options.timeout, events,
     });
     cycleUsage = addUsage(cycleUsage, retryResult.usage);
     cycleOutcomes = addOutcomes(cycleOutcomes, retryResult.outcomes);
@@ -621,7 +693,7 @@ ${planOutput.slice(0, 3000)}`;
       return runIndependentAgent({
         agentName: agent.name, agentPath: agent.path, role: agent.role,
         squadName: squad.name, model: options.model || modelForRole(agent.role),
-        task, squadContext, cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+        task, squadContext, cwd: squadCwd, verbose: options.verbose, timeout: options.timeout, events,
       }).then(result => ({ agent, output: result.text, usage: result.usage, outcomes: result.outcomes }));
     });
 
@@ -660,6 +732,7 @@ ${planOutput.slice(0, 3000)}`;
         error: 'Quota limit reached',
         task: options.task,
       });
+      finishEvents(false);
       return { transcript, turnCount: transcript.turns.length, totalCost: cycleUsage.cost_usd, converged: false, reason: 'Quota limit reached' };
     }
   }
@@ -685,7 +758,7 @@ Summary: [what was achieved]`;
     agentName: lead.name, agentPath: lead.path, role: 'lead',
     squadName: squad.name, model: options.model || modelForRole('lead'),
     task: reviewPrompt, squadContext: `${squadContext}\n\n${serializeTranscript(transcript)}`,
-    cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+    cwd: squadCwd, verbose: options.verbose, timeout: options.timeout, events,
   });
   const reviewOutput = reviewResult.text;
   cycleUsage = addUsage(cycleUsage, reviewResult.usage);
@@ -715,6 +788,7 @@ Summary: [what was achieved]`;
       error: 'Quota limit reached',
       task: options.task,
     });
+    finishEvents(false);
     return { transcript, turnCount: transcript.turns.length, totalCost: cycleUsage.cost_usd, converged: false, reason: 'Quota limit reached' };
   }
 
@@ -750,7 +824,7 @@ or
       agentName: verifier.name, agentPath: verifier.path, role: 'verifier',
       squadName: squad.name, model: options.model || modelForRole('verifier'),
       task: verifyPrompt, squadContext: `${squadContext}\n\n${serializeTranscript(transcript)}`,
-      cwd: squadCwd, verbose: options.verbose, timeout: options.timeout,
+      cwd: squadCwd, verbose: options.verbose, timeout: options.timeout, events,
     });
     const verifyOutput = verifyResult.text;
     cycleUsage = addUsage(cycleUsage, verifyResult.usage);
@@ -794,6 +868,7 @@ or
   };
   logObservability(obsRecord);
 
+  finishEvents(true);
   return {
     transcript,
     turnCount: transcript.turns.length,

--- a/test/exec-events.test.ts
+++ b/test/exec-events.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  createClaudeStreamJsonAdapter,
+  ExecEventWriter,
+  execEventsFile,
+  normalizeDetachedLog,
+  type ExecEvent,
+  type PersistedExecEvent,
+} from '../src/lib/exec-events.js';
+
+// ── Fixture lines (real claude --output-format stream-json shapes) ─────────
+
+const assistantLine = (blocks: unknown[]) =>
+  JSON.stringify({ type: 'assistant', message: { content: blocks, model: 'claude-sonnet-5' } });
+
+const toolUse = (id: string, name: string, input: Record<string, unknown>) =>
+  ({ type: 'tool_use', id, name, input });
+
+const userToolResult = (toolUseId: string, content: unknown, isError = false) =>
+  JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: toolUseId, content, is_error: isError }] } });
+
+const resultLine = JSON.stringify({
+  type: 'result', subtype: 'success', result: 'done', is_error: false,
+  total_cost_usd: 0.42, num_turns: 3, model: 'claude-sonnet-5',
+  usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 1000, cache_creation_input_tokens: 200 },
+});
+
+function readEvents(file: string): PersistedExecEvent[] {
+  return readFileSync(file, 'utf8').trim().split('\n').map((l) => JSON.parse(l) as PersistedExecEvent);
+}
+
+// ── claudeStreamJsonAdapter ────────────────────────────────────────────────
+
+describe('claudeStreamJsonAdapter', () => {
+  it('normalizes tool_use blocks into tool_call + specializations', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    const events = adapter.parseLine(assistantLine([
+      toolUse('t1', 'Read', { file_path: '/repo/src/a.ts' }),
+      toolUse('t2', 'Write', { file_path: '/repo/src/b.ts', content: 'xyz' }),
+      toolUse('t3', 'WebSearch', { query: 'duckdb upsert' }),
+    ]));
+
+    expect(events.map((e) => e.type)).toEqual([
+      'tool_call', 'file_read',
+      'tool_call', 'file_write',
+      'tool_call', 'web_fetch',
+    ]);
+    expect(events[1]).toMatchObject({ type: 'file_read', path: '/repo/src/a.ts' });
+    expect(events[3]).toMatchObject({ type: 'file_write', path: '/repo/src/b.ts', bytes: 3 });
+    expect(events[5]).toMatchObject({ type: 'web_fetch', url: 'duckdb upsert' });
+    expect(events[0]).toMatchObject({ type: 'tool_call', tool: 'Read', inputSummary: '/repo/src/a.ts' });
+  });
+
+  it('derives artifact events from git/gh Bash commands', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    const events = adapter.parseLine(assistantLine([
+      toolUse('t1', 'Bash', { command: 'git add -A && git commit -m "feat: x"' }),
+      toolUse('t2', 'Bash', { command: 'gh pr create --base develop' }),
+      toolUse('t3', 'Bash', { command: 'gh issue create --title bug' }),
+      toolUse('t4', 'Bash', { command: 'ls -la' }),
+    ]));
+
+    const artifacts = events.filter((e): e is Extract<ExecEvent, { type: 'artifact' }> => e.type === 'artifact');
+    expect(artifacts.map((a) => a.kind)).toEqual(['commit', 'pr', 'issue']);
+    expect(events.filter((e) => e.type === 'tool_call')).toHaveLength(4);
+  });
+
+  it('correlates tool_result back to the tool name and detects failures', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    adapter.parseLine(assistantLine([toolUse('t9', 'Bash', { command: 'npm test' })]));
+    const events = adapter.parseLine(userToolResult('t9', 'FAIL: 1 test failed', true));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'tool_result', tool: 'Bash', ok: false });
+    expect((events[0] as Extract<ExecEvent, { type: 'tool_result' }>).summary).toContain('FAIL');
+  });
+
+  it('maps Agent tool_use to subagent_spawn and its result to subagent_done', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    const spawn = adapter.parseLine(assistantLine([
+      toolUse('a1', 'Agent', { description: 'research the schema', prompt: 'long prompt…' }),
+    ]));
+    expect(spawn.map((e) => e.type)).toEqual(['tool_call', 'subagent_spawn']);
+    expect(spawn[1]).toMatchObject({ type: 'subagent_spawn', childRunId: 'a1', task: 'research the schema' });
+
+    const done = adapter.parseLine(userToolResult('a1', [{ type: 'text', text: 'findings…' }]));
+    expect(done.map((e) => e.type)).toEqual(['tool_result', 'subagent_done']);
+    expect(done[1]).toMatchObject({ type: 'subagent_done', childRunId: 'a1', ok: true });
+  });
+
+  it('turns the terminal result event into token_usage', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    const events = adapter.parseLine(resultLine);
+    expect(events).toEqual([{
+      type: 'token_usage', input: 100, output: 50, cacheRead: 1000, cacheWrite: 200,
+      costEst: 0.42, model: 'claude-sonnet-5',
+    }]);
+  });
+
+  it('ignores non-JSON, empty, and uninteresting lines', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    expect(adapter.parseLine('')).toEqual([]);
+    expect(adapter.parseLine('warning: something')).toEqual([]);
+    expect(adapter.parseLine(JSON.stringify({ type: 'system', subtype: 'init' }))).toEqual([]);
+    // assistant text-only (no tool_use) is not an event in v1
+    expect(adapter.parseLine(assistantLine([{ type: 'text', text: 'thinking…' }]))).toEqual([]);
+  });
+});
+
+// ── ExecEventWriter ────────────────────────────────────────────────────────
+
+describe('ExecEventWriter', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'squads-events-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  const runStart: ExecEvent = { type: 'run_start', squad: 'eng', agent: 'builder', mode: 'conversation', model: 'sonnet', role: 'worker', startedAt: '2026-07-01T00:00:00Z' };
+
+  it('persists enveloped JSONL lines with runId, seq, and agent attribution', () => {
+    const file = execEventsFile(root, 'exec_abc123');
+    const writer = new ExecEventWriter(file, 'exec_abc123');
+    writer.emit(runStart);
+    writer.emit({ type: 'tool_call', tool: 'Read', inputSummary: 'a.ts' }, 'builder');
+    writer.close();
+
+    const lines = readEvents(file);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({ v: 1, runId: 'exec_abc123', seq: 0, event: { type: 'run_start' } });
+    expect(lines[1]).toMatchObject({ seq: 1, agent: 'builder', event: { type: 'tool_call', tool: 'Read' } });
+    expect(typeof lines[0].ts).toBe('string');
+  });
+
+  it('caps detail events and records an explicit truncated marker — never a silent cap', () => {
+    const file = execEventsFile(root, 'exec_cap');
+    const writer = new ExecEventWriter(file, 'exec_cap', { maxEvents: 3 });
+    writer.emit(runStart);
+    for (let i = 0; i < 10; i++) writer.emit({ type: 'tool_call', tool: 'Bash', inputSummary: `cmd ${i}` });
+    // Terminal events bypass the cap: the aggregate must always land.
+    writer.emit({ type: 'token_usage', input: 1, output: 2, cacheRead: 0, cacheWrite: 0, costEst: 0, model: 'sonnet' });
+    writer.close();
+
+    const lines = readEvents(file);
+    const types = lines.map((l) => l.event.type);
+    expect(types.filter((t) => t === 'tool_call')).toHaveLength(2); // seq 1,2 then capped
+    expect(types).toContain('token_usage');
+    expect(types[types.length - 1]).toBe('truncated');
+    const truncated = lines[lines.length - 1].event as Extract<ExecEvent, { type: 'truncated' }>;
+    expect(truncated.droppedCount).toBe(8);
+  });
+
+  it('never throws when the target path is unwritable', () => {
+    // A path whose ancestor is a FILE (mkdir fails with ENOTDIR) — the writer
+    // must go dead silently: persistence never takes down the run it observes.
+    const bogus = join(root, 'not-a-dir');
+    writeFileSync(bogus, 'i am a file');
+    const writer = new ExecEventWriter(join(bogus, 'x', 'events.jsonl'), 'exec_dead');
+    expect(() => {
+      writer.emit(runStart);
+      writer.close();
+    }).not.toThrow();
+    expect(writer.writtenCount).toBe(0);
+  });
+});
+
+// ── normalizeDetachedLog ───────────────────────────────────────────────────
+
+describe('normalizeDetachedLog', () => {
+  let root: string;
+
+  beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'squads-events-norm-')); });
+  afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+
+  const runEnd: Extract<ExecEvent, { type: 'run_end' }> = {
+    type: 'run_end', ok: true, durationMs: 1234,
+    totalUsage: { input: 100, output: 50, cacheRead: 1000, cacheWrite: 200, costEst: 0.42 },
+    outcomes: { actions: 2, files_edited: 1, commits: 1, prs_created: 0, issues_created: 0 },
+  };
+
+  it('normalizes a raw stream-json log into the events file and closes with run_end', () => {
+    const rawLog = [
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      assistantLine([toolUse('t1', 'Bash', { command: 'git commit -m x' })]),
+      resultLine,
+    ].join('\n');
+
+    const written = normalizeDetachedLog(rawLog, root, 'exec_detached1', 'profiler', runEnd);
+    expect(written).toBeGreaterThan(0);
+
+    const lines = readEvents(execEventsFile(root, 'exec_detached1'));
+    const types = lines.map((l) => l.event.type);
+    expect(types).toContain('tool_call');
+    expect(types).toContain('artifact');
+    expect(types).toContain('token_usage');
+    expect(types[types.length - 1]).toBe('run_end');
+    expect(lines.every((l) => l.runId === 'exec_detached1')).toBe(true);
+    expect(lines.find((l) => l.event.type === 'tool_call')?.agent).toBe('profiler');
+  });
+
+  it('yields zero events for a legacy plain-text log and fabricates nothing', () => {
+    const written = normalizeDetachedLog('plain claude output\nno json here', root, 'exec_legacy', 'agent', runEnd);
+    expect(written).toBe(0);
+    expect(existsSync(execEventsFile(root, 'exec_legacy'))).toBe(false);
+  });
+});

--- a/test/run-context.test.ts
+++ b/test/run-context.test.ts
@@ -303,3 +303,77 @@ describe('gatherSquadContext — injection contract', () => {
     expect(ctx).not.toContain('Last updated');
   });
 });
+
+// ── gatherSquadContext — onStats: the context_assembled source (#902) ────────
+
+describe('gatherSquadContext — onStats per-layer accounting', () => {
+  let testDir: string;
+  let originalCwd: string;
+  const SQUAD = 'eng';
+  const AGENT = 'builder';
+  let agentPath: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), 'squads-ctx-stats-test-' + Date.now());
+    const root = join(testDir, '.agents');
+    const mem = join(root, 'memory');
+    const sq = join(root, 'squads', SQUAD);
+    mkdirSync(sq, { recursive: true });
+    mkdirSync(join(mem, 'company'), { recursive: true });
+    mkdirSync(join(mem, SQUAD, AGENT), { recursive: true });
+    writeFileSync(join(sq, 'SQUAD.md'), '# Eng Squad\n');
+    agentPath = join(sq, `${AGENT}.md`);
+    writeFileSync(agentPath, '---\nrole: worker\n---\n\n# Builder\nbuild things\n');
+    writeFileSync(join(mem, 'company', 'strategy.md'), '# Strategy\n' + 'S'.repeat(400));
+    writeFileSync(join(mem, SQUAD, 'goals.md'), 'G'.repeat(600));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('reports every injected layer with chars/tokensEst and the role budget', () => {
+    let stats: import('../src/lib/run-context.js').ContextStats | undefined;
+    const ctx = gatherSquadContext(SQUAD, AGENT, {
+      agentPath, role: 'worker',
+      onStats: (s) => { stats = s; },
+    });
+
+    expect(ctx.length).toBeGreaterThan(0);
+    expect(stats).toBeDefined();
+    expect(stats!.role).toBe('worker');
+    expect(stats!.budgetChars).toBe(60000); // ROLE_BUDGETS.worker
+    // Layers present: 3 (goals), 4 (agent), 1 (company/strategy)
+    const byLayer = Object.fromEntries(stats!.layers.map((l) => [l.layer, l]));
+    expect(byLayer[3]).toMatchObject({ evicted: false });
+    expect(byLayer[3].chars).toBeGreaterThanOrEqual(600);
+    expect(byLayer[1].chars).toBeGreaterThan(0);
+    expect(byLayer[4].chars).toBeGreaterThan(0);
+    // Totals are consistent with the layers.
+    const sumChars = stats!.layers.reduce((a, l) => a + l.chars, 0);
+    expect(stats!.totalChars).toBe(sumChars);
+    expect(stats!.totalTokensEst).toBe(Math.ceil(sumChars / 4));
+  });
+
+  it('records budget-refused layers as evicted instead of dropping them silently', () => {
+    let stats: import('../src/lib/run-context.js').ContextStats | undefined;
+    // 150-char budget: goals (first layer in) consumes it; later layers evict.
+    gatherSquadContext(SQUAD, AGENT, {
+      agentPath, role: 'worker', maxTokens: 38, // ~152 chars
+      onStats: (s) => { stats = s; },
+    });
+
+    expect(stats).toBeDefined();
+    const evicted = stats!.layers.filter((l) => l.evicted);
+    const injected = stats!.layers.filter((l) => !l.evicted);
+    expect(injected.length).toBeGreaterThan(0);
+    expect(evicted.length).toBeGreaterThan(0);
+    for (const l of evicted) {
+      expect(l.chars).toBe(0);
+      expect(l.tokensEst).toBe(0);
+    }
+  });
+});

--- a/test/spool.test.ts
+++ b/test/spool.test.ts
@@ -286,3 +286,77 @@ describe('session-id attribution (#857)', () => {
     expect(rec.output_tokens).toBe(0);
   });
 });
+
+// ── #902: exec-event normalization + outcomes for detached claude runs ──
+
+describe('stream-json log normalization (#902)', () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    // Hermetic HOME so captureSessionUsage finds no session JSONL and the
+    // stream result event is exercised as the usage fallback.
+    home = mkdtempSync(join(tmpdir(), 'squads-home-'));
+    oldHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    process.env.HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeStreamJsonLog(): void {
+    const lines = [
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({ type: 'assistant', message: { content: [
+        { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'git add -A && git commit -m "feat: x"' } },
+        { type: 'tool_use', id: 't2', name: 'Write', input: { file_path: '/repo/x.ts', content: 'abc' } },
+      ], model: 'claude-haiku-4-5' } }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'done', is_error: false,
+        total_cost_usd: 0.05, num_turns: 2, model: 'claude-haiku-4-5',
+        usage: { input_tokens: 500, output_tokens: 80, cache_read_input_tokens: 2000, cache_creation_input_tokens: 100 } }),
+    ];
+    writeFileSync(join(root, 'run.log'), lines.join('\n') + '\n');
+  }
+
+  it('detached claude run gets outcomes + stream-usage fallback + a normalized events file', () => {
+    writeStreamJsonLog();
+    writeSpoolFile({ execId: 'exec_ev_1', provider: 'anthropic', model: 'haiku' });
+    const n = reconcileDetachedRuns(root);
+    expect(n).toBe(1);
+
+    const [rec] = readExecutionsJsonl();
+    // Usage fell back to the stream's terminal result event (no session JSONL).
+    expect(rec.input_tokens).toBe(500);
+    expect(rec.output_tokens).toBe(80);
+    expect(rec.cache_read_tokens).toBe(2000);
+    expect(rec.cache_write_tokens).toBe(100);
+    expect(rec.model).toBe('claude-haiku-4-5');
+    // Outcomes previously always zero on detached runs — now real.
+    expect(rec.actions).toBe(2);
+    expect(rec.files_edited).toBe(1);
+    expect(rec.commits).toBe(1);
+
+    // The raw provider log was normalized into the run's events file.
+    const eventsPath = join(root, '.agents', 'observability', 'events', 'exec_ev_1.jsonl');
+    expect(existsSync(eventsPath)).toBe(true);
+    const events = readFileSync(eventsPath, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
+    const types = events.map((e) => e.event.type);
+    expect(types).toContain('tool_call');
+    expect(types).toContain('artifact');
+    expect(types).toContain('file_write');
+    expect(types).toContain('token_usage');
+    expect(types[types.length - 1]).toBe('run_end');
+    expect(events.every((e) => e.runId === 'exec_ev_1')).toBe(true);
+  });
+
+  it('legacy plain-text logs reconcile as before — no events file fabricated', () => {
+    writeFileSync(join(root, 'run.log'), 'plain old buffered output\n');
+    writeSpoolFile({ execId: 'exec_ev_legacy', provider: 'anthropic', model: 'haiku' });
+    expect(reconcileDetachedRuns(root)).toBe(1);
+    const [rec] = readExecutionsJsonl();
+    expect(rec.input_tokens).toBe(0);
+    expect(existsSync(join(root, '.agents', 'observability', 'events', 'exec_ev_legacy.jsonl'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #902 (Child 0 of RFC #898). Post-0.8.2 — NOT a release blocker; #905 (the 0.8.2 release PR) is cut from develop's prior tip and unaffected.

## What

Every run now emits a **typed, persisted execution-event stream** at `.agents/observability/events/<execId>.jsonl` — the substrate both #903 (live visibility) and #904 (context economy) consume.

- **`src/lib/exec-events.ts`** (new): `ExecEvent` discriminated union per the RFC schema + `ExecEventWriter` (append-only JSONL, 5k-event/2MB cap with an explicit `truncated{droppedCount}` marker — never a silent cap; never throws into the run path) + `ProviderEventAdapter` interface with `createClaudeStreamJsonAdapter` (stateful per run: correlates `tool_result` → tool name, Agent spawns → `subagent_done`). Runner code consumes `ExecEvent[]` only — no Claude assumptions above the adapter.
- **Detached path de-black-boxed**: the single-agent detached executor now runs with `--output-format stream-json --verbose`, so the run log is a **live event feed** instead of a buffer that stays empty until exit. The reconcile sweep (spool.ts) normalizes the raw log into the events file and — bonus fix — detached records finally carry real **outcomes** (previously always zero) and **cache tokens** (previously hardcoded 0), with the stream's terminal result event as the usage fallback when no session JSONL is visible.
- **`context_assembled`**: `gatherSquadContext` reports per-layer assembly stats (`onStats`) — layer id, chars, tokensEst, evicted — the one event no provider stream can produce. Emitted on both the single-agent and conversation paths; budget-refused layers are recorded as `evicted` instead of vanishing.
- **Conversation path**: one event stream per cycle; every agent (plan/workers/review/verify) is announced with `subagent_spawn`/`subagent_done` and its provider stream teed through the adapter; `run_end` lands on every exit path including quota aborts.

## Verification

- 2033 tests green (28 new: adapter fixtures, writer cap/dead-path, onStats contract incl. eviction, spool normalization + legacy plain-text logs).
- **Live-verified** on a hermetic fixture project with a real haiku background run through the built CLI: events file present at spawn (`run_start` + `context_assembled`, 3 layers/worker budget), log streaming events mid-run, `token_usage` + `run_end` appended at reconcile, executions.jsonl record with cache tokens filled.

## Open decision (spec §founder decision 1)

Spec recommended `<run>.events.jsonl` in the run workspace (carried by the #875 auto-commit). I went with the **dispatch root's observability dir** instead: central, queryable, and survives worktree cleanup by construction rather than by rescue — and it keeps event files out of squad repos' run branches. Flagging for confirmation; moving is a small change if you prefer the workspace.

## Known follow-ups (Child A, #903)

- `--watch` / `tail -f` now shows raw JSONL (live but unrendered) — the human-legible feed is Child A's first deliverable.
- `seq` restarts when reconcile appends to a spawn-time file (two writer sessions); consumers should order by file position/ts.
- Provider adapters for deepseek/gemini land when those executors get stream output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)