### PR TITLE
feat(watch): live activity feed + run replay — observable execution Child A

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1187,6 +1187,7 @@ program
   .description('List live background agent runs (pid-file inventory)')
   .option('--json', 'Output as JSON')
   .option('--clean', 'Remove stale pid files; salvage crashed runs (harvest + record)')
+  .option('--replay <execId>', 'Re-render a finished run\'s activity feed from its recorded events')
   .action(async (options) => {
     const { runsCommand } = await import('./commands/runs.js');
     return runsCommand(options);

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -3,6 +3,8 @@
  * (hq#450 D4). Completes the containment loop: spool records what happened,
  * the watchdog bounds it, this surfaces it.
  */
+import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
 import { getProjectRoot } from '../lib/run-utils.js';
 import {
   listDetachedRuns,
@@ -11,6 +13,8 @@ import {
   type DetachedRun,
 } from '../lib/runs-inventory.js';
 import { reconcileDetachedRuns } from '../lib/spool.js';
+import { execEventsFile } from '../lib/exec-events.js';
+import { renderPersistedEvent, parsePersistedLine } from '../lib/event-render.js';
 import { colors, RESET, bold, writeLine } from '../lib/terminal.js';
 
 function elapsed(startedAt: number): string {
@@ -20,8 +24,66 @@ function elapsed(startedAt: number): string {
   return `${(ms / 3_600_000).toFixed(1)}h`;
 }
 
-export async function runsCommand(options: { json?: boolean; clean?: boolean }): Promise<void> {
+/**
+ * `squads runs --replay <execId>` — re-render a finished run's activity feed
+ * from its persisted events file (#903). Consumer of the #902 event stream:
+ * the same feed watch mode shows live, replayable after the fact.
+ */
+export function replayRun(execId: string, projectRoot: string): void {
+  const eventsDir = join(projectRoot, '.agents', 'observability', 'events');
+  const file = execEventsFile(projectRoot, execId);
+
+  if (!existsSync(file)) {
+    writeLine();
+    writeLine(`  ${colors.red}No events recorded for '${execId}'${RESET}`);
+    // Help the user find a replayable run: most recent events files.
+    try {
+      const available = readdirSync(eventsDir)
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) => ({ id: f.replace(/\.jsonl$/, ''), mtime: statSync(join(eventsDir, f)).mtimeMs }))
+        .sort((a, b) => b.mtime - a.mtime)
+        .slice(0, 10);
+      if (available.length > 0) {
+        writeLine(`  ${colors.dim}Recent runs with events:${RESET}`);
+        for (const a of available) {
+          writeLine(`    ${colors.cyan}${a.id}${RESET}`);
+        }
+      } else {
+        writeLine(`  ${colors.dim}No runs have recorded events yet (events land in ${eventsDir}).${RESET}`);
+      }
+    } catch {
+      writeLine(`  ${colors.dim}No events directory yet (${eventsDir}).${RESET}`);
+    }
+    writeLine();
+    return;
+  }
+
+  const lines = readFileSync(file, 'utf8').split('\n');
+  const parsed = lines.map(parsePersistedLine).filter((l): l is NonNullable<typeof l> => l !== null);
+  if (parsed.length === 0) {
+    writeLine(`  ${colors.dim}Events file for '${execId}' is empty or unreadable.${RESET}`);
+    return;
+  }
+
+  const t0 = Date.parse(parsed[0].ts);
+  writeLine();
+  writeLine(`  ${bold}Replay: ${execId}${RESET} ${colors.dim}(${parsed.length} events)${RESET}`);
+  writeLine();
+  for (const line of parsed) {
+    const rendered = renderPersistedEvent(line, t0);
+    if (rendered !== null) writeLine(rendered);
+  }
+  writeLine();
+}
+
+export async function runsCommand(options: { json?: boolean; clean?: boolean; replay?: string }): Promise<void> {
   const projectRoot = getProjectRoot();
+
+  if (options.replay) {
+    replayRun(options.replay, projectRoot);
+    return;
+  }
+
   const runs = listDetachedRuns(projectRoot);
   const live = runs.filter((r) => r.alive);
   const stale = runs.filter((r) => !r.alive);

--- a/src/lib/event-follow.ts
+++ b/src/lib/event-follow.ts
@@ -1,0 +1,121 @@
+/**
+ * event-follow.ts — live follower for a detached run's stream-json log (#903).
+ *
+ * Since #902, a detached claude run's logfile is a live JSONL event stream.
+ * This follows the file as it grows (poll + append-read; no fs.watch — it is
+ * unreliable across editors/volumes on macOS), pipes each complete line
+ * through the provider adapter, and renders the human feed. Replaces the raw
+ * `tail -f` in watch mode, which since #902 would show unreadable JSON.
+ *
+ * End-of-run detection: the detached wrapper removes its pid file on exit —
+ * when the pid file is gone and no bytes remain unread, the run is over.
+ */
+
+import { existsSync, statSync, openSync, readSync, closeSync } from 'fs';
+import { createClaudeStreamJsonAdapter } from './exec-events.js';
+import { renderEvent } from './event-render.js';
+import { writeLine } from './terminal.js';
+
+const DEFAULT_POLL_MS = 400;
+
+export interface FollowHandle {
+  /** Stop following (the run itself continues). Resolves `done`. */
+  stop: () => void;
+  /** Resolves when the run ends (pid file gone, log drained) or stop() is called. */
+  done: Promise<void>;
+}
+
+/**
+ * Follow a live stream-json log, rendering events as they land.
+ * Set SQUADS_WATCH_RAW=1 to pass raw lines through instead of rendering.
+ */
+export function followProviderLog(
+  logFile: string,
+  opts: { pidFile?: string; pollMs?: number; onLine?: (rendered: string) => void } = {},
+): FollowHandle {
+  const pollMs = opts.pollMs ?? DEFAULT_POLL_MS;
+  const emit = opts.onLine ?? ((line: string) => writeLine(`  ${line}`));
+  const raw = process.env.SQUADS_WATCH_RAW === '1';
+  const adapter = createClaudeStreamJsonAdapter();
+
+  let offset = 0;
+  let buf = '';
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let resolveDone: () => void = () => {};
+  const done = new Promise<void>((resolve) => { resolveDone = resolve; });
+
+  const consumeLine = (line: string): void => {
+    if (!line.trim()) return;
+    if (raw) {
+      emit(line);
+      return;
+    }
+    let events;
+    try {
+      events = adapter.parseLine(line);
+    } catch {
+      return;
+    }
+    for (const event of events) {
+      const rendered = renderEvent(event);
+      if (rendered !== null) emit(rendered);
+    }
+  };
+
+  const readAppended = (): boolean => {
+    // Returns true when new bytes were consumed.
+    let size: number;
+    try {
+      size = statSync(logFile).size;
+    } catch {
+      return false; // not created yet — keep waiting
+    }
+    if (size < offset) offset = 0; // truncated/rotated — start over
+    if (size === offset) return false;
+    try {
+      const fd = openSync(logFile, 'r');
+      try {
+        const chunk = Buffer.alloc(size - offset);
+        const read = readSync(fd, chunk, 0, chunk.length, offset);
+        offset += read;
+        buf += chunk.toString('utf8', 0, read);
+      } finally {
+        closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+    const lines = buf.split('\n');
+    buf = lines.pop() ?? '';
+    for (const line of lines) consumeLine(line);
+    return true;
+  };
+
+  const finish = (): void => {
+    if (stopped) return;
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    // Drain whatever is left, including a final partial line.
+    readAppended();
+    if (buf) {
+      consumeLine(buf);
+      buf = '';
+    }
+    resolveDone();
+  };
+
+  const tick = (): void => {
+    if (stopped) return;
+    const gotBytes = readAppended();
+    // Run over? pid file removed by the wrapper on exit, and log fully drained.
+    if (!gotBytes && opts.pidFile && !existsSync(opts.pidFile)) {
+      finish();
+      return;
+    }
+    timer = setTimeout(tick, pollMs);
+  };
+  timer = setTimeout(tick, 0);
+
+  return { stop: finish, done };
+}

--- a/src/lib/event-render.ts
+++ b/src/lib/event-render.ts
@@ -1,0 +1,117 @@
+/**
+ * event-render.ts — human-legible rendering of the exec-event stream (#903).
+ *
+ * Child A of the observable-execution RFC (#898): turn the typed events the
+ * #902 substrate persists into the activity feed a human can watch —
+ * "reading X… searched web for Y… spawned profiler… wrote Z." Used by both
+ * the live `--watch` follower (raw provider lines → adapter → render) and
+ * `squads runs --replay <execId>` (persisted events file → render).
+ *
+ * Rendering rules:
+ * - Specialized events (file_read/file_write/web_fetch/subagent_*) replace
+ *   their generic tool_call line — the adapter emits both, we render one.
+ * - tool_result is noise when ok; only failures render.
+ * - Multi-agent runs (conversation cycles) prefix each line with the agent
+ *   lane, and subagent_spawn/done mark the fan-out tree.
+ */
+
+import { colors, RESET } from './terminal.js';
+import type { ExecEvent, PersistedExecEvent } from './exec-events.js';
+
+/** Tools whose specialized event carries the line — skip their generic tool_call. */
+const SPECIALIZED_TOOLS = new Set([
+  'read', 'write', 'edit', 'notebookedit', 'webfetch', 'websearch', 'agent', 'task',
+]);
+
+function fmtBytes(n: number): string {
+  if (n <= 0) return '';
+  if (n < 1024) return ` (${n}b)`;
+  return ` (${(n / 1024).toFixed(1)}kb)`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m`;
+  return `${(ms / 3_600_000).toFixed(1)}h`;
+}
+
+/**
+ * Render one event as a single feed line, or null when the event is noise
+ * (ok tool_results, tool_calls covered by a specialization).
+ */
+export function renderEvent(event: ExecEvent): string | null {
+  switch (event.type) {
+    case 'run_start':
+      return `${colors.cyan}▶${RESET} ${event.squad}${event.agent ? `/${event.agent}` : ''} ${colors.dim}(${event.mode}${event.model ? `, ${event.model}` : ''}${event.role ? `, ${event.role}` : ''})${RESET}`;
+    case 'context_assembled': {
+      const evicted = event.layers.filter((l) => l.evicted).length;
+      return `${colors.dim}⧉ context: ${event.layers.length - evicted} layers, ~${fmtTokens(event.totalTokensEst)} tokens (budget ${fmtTokens(event.budgetTokens)})${evicted ? ` · ${evicted} evicted` : ''}${RESET}`;
+    }
+    case 'tool_call':
+      if (SPECIALIZED_TOOLS.has(event.tool.toLowerCase())) return null;
+      return `${colors.dim}⋯${RESET} ${event.tool}${event.inputSummary ? ` ${colors.dim}${event.inputSummary}${RESET}` : ''}`;
+    case 'tool_result':
+      if (event.ok) return null;
+      return `${colors.red}✗ ${event.tool} failed${RESET}${event.summary ? ` ${colors.dim}${event.summary}${RESET}` : ''}`;
+    case 'file_read':
+      return `${colors.dim}read ${event.path}${RESET}`;
+    case 'file_write':
+      return `${colors.green}wrote${RESET} ${event.path}${colors.dim}${fmtBytes(event.bytes)}${RESET}`;
+    case 'web_fetch':
+      return `${colors.cyan}web${RESET} ${colors.dim}${event.url}${RESET}`;
+    case 'subagent_spawn':
+      return `${colors.purple}⇒ spawned ${event.agent}${RESET}${event.task ? ` ${colors.dim}— ${event.task}${RESET}` : ''}`;
+    case 'subagent_done':
+      return `${colors.purple}⇐ ${event.agent}${RESET} ${event.ok ? `${colors.green}done${RESET}` : `${colors.red}failed${RESET}`}`;
+    case 'artifact':
+      return `${colors.green}✚ ${event.kind}${RESET} ${colors.dim}${event.ref}${RESET}`;
+    case 'token_usage':
+      return `${colors.dim}Σ ${fmtTokens(event.input)} in / ${fmtTokens(event.output)} out · cache ${fmtTokens(event.cacheRead)}r/${fmtTokens(event.cacheWrite)}w${event.costEst ? ` · $${event.costEst.toFixed(4)}` : ''}${RESET}`;
+    case 'run_end': {
+      const o = event.outcomes;
+      const made: string[] = [];
+      if (o.commits) made.push(`${o.commits} commit${o.commits > 1 ? 's' : ''}`);
+      if (o.prs_created) made.push(`${o.prs_created} PR${o.prs_created > 1 ? 's' : ''}`);
+      if (o.issues_created) made.push(`${o.issues_created} issue${o.issues_created > 1 ? 's' : ''}`);
+      if (o.files_edited) made.push(`${o.files_edited} file${o.files_edited > 1 ? 's' : ''} edited`);
+      const status = event.ok ? `${colors.green}completed${RESET}` : `${colors.red}failed${RESET}`;
+      return `${colors.cyan}■${RESET} ${status} ${colors.dim}in ${fmtDuration(event.durationMs)}${event.totalUsage.costEst ? ` · $${event.totalUsage.costEst.toFixed(4)}` : ''}${made.length ? ` · ${made.join(', ')}` : ''}${RESET}`;
+    }
+    case 'truncated':
+      return `${colors.yellow}… ${event.droppedCount} events dropped${RESET} ${colors.dim}(${event.reason})${RESET}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Render a persisted (enveloped) event with agent-lane prefix and a relative
+ * timestamp — the replay view. `t0` is the run's first event timestamp.
+ */
+export function renderPersistedEvent(line: PersistedExecEvent, t0: number): string | null {
+  const body = renderEvent(line.event);
+  if (body === null) return null;
+  const dtMs = Date.parse(line.ts) - t0;
+  const stamp = Number.isFinite(dtMs) && dtMs >= 0 ? `+${(dtMs / 1000).toFixed(1)}s` : '      ';
+  const lane = line.agent ? `${colors.dim}${line.agent} │${RESET} ` : '';
+  return `  ${colors.dim}${stamp.padStart(8)}${RESET}  ${lane}${body}`;
+}
+
+/** Parse a raw events-file JSONL line; null when malformed. */
+export function parsePersistedLine(raw: string): PersistedExecEvent | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const obj = JSON.parse(trimmed) as PersistedExecEvent;
+    if (!obj || obj.v !== 1 || !obj.event || typeof obj.event.type !== 'string') return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -770,11 +770,17 @@ export function executeForeground(config: {
   });
 }
 
-/** Execute Claude in watch mode (background + tail log) */
+/**
+ * Execute Claude in watch mode: background run + LIVE event feed (#903).
+ * Since #902 the detached log is a stream-json event stream, so watch renders
+ * the human activity feed through the provider adapter instead of raw
+ * `tail -f` (which would show JSON). SQUADS_WATCH_RAW=1 restores raw lines.
+ */
 export async function executeWatch(config: {
   projectRoot: string;
   agentEnv: Record<string, string>;
   logFile: string;
+  pidFile?: string;
   wrapperScript: string;
 }): Promise<string> {
   const child = spawn('sh', ['-c', config.wrapperScript], {
@@ -787,24 +793,23 @@ export async function executeWatch(config: {
 
   await new Promise(resolve => setTimeout(resolve, LOG_FILE_INIT_DELAY_MS));
 
-  writeLine(`  ${colors.dim}Tailing log (Ctrl+C to stop watching, agent continues)...${RESET}`);
+  writeLine(`  ${colors.dim}Watching live (Ctrl+C to stop watching, agent continues)...${RESET}`);
   writeLine();
 
-  const tail = spawn('tail', ['-f', config.logFile], { stdio: 'inherit' });
+  const { followProviderLog } = await import('./event-follow.js');
+  const follower = followProviderLog(config.logFile, { pidFile: config.pidFile });
 
   process.on('SIGINT', () => {
-    tail.kill();
+    follower.stop();
     writeLine();
     writeLine(`  ${colors.dim}Stopped watching. Agent continues in background.${RESET}`);
-    writeLine(`  ${colors.dim}Resume: tail -f ${config.logFile}${RESET}`);
+    writeLine(`  ${colors.dim}Raw log: ${config.logFile}${RESET}`);
     process.exit(0);
   });
 
-  return new Promise((resolve) => {
-    tail.on('close', () => {
-      resolve(`Agent running in background. Log: ${config.logFile}`);
-    });
-  });
+  await follower.done;
+  writeLine();
+  return `Run finished. Log: ${config.logFile}`;
 }
 
 // ── Main execution functions ─────────────────────────────────────────
@@ -1024,7 +1029,7 @@ export async function executeWithClaude(
       });
     }
 
-    return executeWatch({ projectRoot: targetRepoRoot, agentEnv, logFile, wrapperScript });
+    return executeWatch({ projectRoot: targetRepoRoot, agentEnv, logFile, pidFile, wrapperScript });
   }
 
   // ── Background mode ──────────────────────────────────────────────────

--- a/test/event-render.test.ts
+++ b/test/event-render.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { renderEvent, renderPersistedEvent, parsePersistedLine } from '../src/lib/event-render.js';
+import { followProviderLog } from '../src/lib/event-follow.js';
+import type { ExecEvent, PersistedExecEvent } from '../src/lib/exec-events.js';
+
+// Strip ANSI codes so assertions read the words, not the palette.
+// eslint-disable-next-line no-control-regex
+const strip = (s: string | null) => (s === null ? null : s.replace(/\x1b\[[0-9;]*m/g, ''));
+
+describe('renderEvent — the activity feed lines (#903)', () => {
+  it('renders run lifecycle, files, web, and artifacts as human lines', () => {
+    expect(strip(renderEvent({ type: 'run_start', squad: 'demo', agent: 'hello', mode: 'background', model: 'haiku', role: 'worker', startedAt: 'x' })))
+      .toContain('demo/hello');
+    expect(strip(renderEvent({ type: 'file_read', path: 'src/a.ts' }))).toBe('read src/a.ts');
+    expect(strip(renderEvent({ type: 'file_write', path: 'src/b.ts', bytes: 2048 }))).toContain('wrote src/b.ts (2.0kb)');
+    expect(strip(renderEvent({ type: 'web_fetch', url: 'duckdb upsert' }))).toContain('web duckdb upsert');
+    expect(strip(renderEvent({ type: 'artifact', kind: 'pr', ref: 'gh pr create --base develop' }))).toContain('✚ pr');
+    expect(strip(renderEvent({ type: 'subagent_spawn', childRunId: 'a1', squad: '', agent: 'profiler', task: 'research' }))).toContain('spawned profiler — research');
+    expect(strip(renderEvent({ type: 'subagent_done', childRunId: 'a1', agent: 'profiler', ok: true }))).toContain('profiler done');
+  });
+
+  it('suppresses noise: specialized tool_calls and ok tool_results render null', () => {
+    expect(renderEvent({ type: 'tool_call', tool: 'Read', inputSummary: 'a.ts' })).toBeNull();
+    expect(renderEvent({ type: 'tool_call', tool: 'WebSearch', inputSummary: 'q' })).toBeNull();
+    expect(renderEvent({ type: 'tool_result', tool: 'Bash', ok: true, summary: 'fine' })).toBeNull();
+    // Generic tools and failures DO render.
+    expect(strip(renderEvent({ type: 'tool_call', tool: 'Bash', inputSummary: 'npm test' }))).toContain('Bash npm test');
+    expect(strip(renderEvent({ type: 'tool_result', tool: 'Bash', ok: false, summary: 'exit 1' }))).toContain('Bash failed');
+  });
+
+  it('summarizes context, usage, run_end, and truncation', () => {
+    expect(strip(renderEvent({
+      type: 'context_assembled',
+      layers: [
+        { layer: 3, name: 'Goals', chars: 400, tokensEst: 100, evicted: false },
+        { layer: 7, name: 'Briefing', chars: 0, tokensEst: 0, evicted: true },
+      ],
+      totalTokensEst: 100, budgetTokens: 15000,
+    }))).toContain('1 layers, ~100 tokens (budget 15.0k) · 1 evicted');
+    expect(strip(renderEvent({ type: 'token_usage', input: 1500, output: 80, cacheRead: 33152, cacheWrite: 0, costEst: 0.0179, model: 'haiku' })))
+      .toContain('1.5k in / 80 out');
+    expect(strip(renderEvent({
+      type: 'run_end', ok: true, durationMs: 4000,
+      totalUsage: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0, costEst: 0.02 },
+      outcomes: { actions: 3, files_edited: 1, commits: 2, prs_created: 1, issues_created: 0 },
+    }))).toContain('completed in 4s · $0.0200 · 2 commits, 1 PR, 1 file edited');
+    expect(strip(renderEvent({ type: 'truncated', droppedCount: 8, reason: 'cap' }))).toContain('8 events dropped');
+  });
+});
+
+describe('renderPersistedEvent — replay view with lanes + relative time', () => {
+  const persisted = (event: ExecEvent, ts: string, agent?: string): PersistedExecEvent =>
+    ({ v: 1, runId: 'exec_x', seq: 0, ts, ...(agent ? { agent } : {}), event });
+
+  it('prefixes the agent lane and a +Ns stamp', () => {
+    const t0 = Date.parse('2026-07-01T00:00:00.000Z');
+    const line = strip(renderPersistedEvent(
+      persisted({ type: 'file_read', path: 'a.ts' }, '2026-07-01T00:00:02.300Z', 'builder'), t0,
+    ));
+    expect(line).toContain('+2.3s');
+    expect(line).toContain('builder │');
+    expect(line).toContain('read a.ts');
+  });
+
+  it('returns null for noise events so replay stays legible', () => {
+    const t0 = Date.parse('2026-07-01T00:00:00.000Z');
+    expect(renderPersistedEvent(
+      persisted({ type: 'tool_result', tool: 'Read', ok: true, summary: '' }, '2026-07-01T00:00:01Z'), t0,
+    )).toBeNull();
+  });
+});
+
+describe('parsePersistedLine', () => {
+  it('parses valid envelope lines and rejects malformed ones', () => {
+    const good = JSON.stringify({ v: 1, runId: 'r', seq: 0, ts: '2026-07-01T00:00:00Z', event: { type: 'file_read', path: 'a' } });
+    expect(parsePersistedLine(good)?.event.type).toBe('file_read');
+    expect(parsePersistedLine('')).toBeNull();
+    expect(parsePersistedLine('not json')).toBeNull();
+    expect(parsePersistedLine(JSON.stringify({ v: 2, event: { type: 'x' } }))).toBeNull();
+    expect(parsePersistedLine(JSON.stringify({ v: 1, runId: 'r', seq: 0, ts: 'x' }))).toBeNull();
+  });
+});
+
+describe('followProviderLog — live feed from a growing stream-json log', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'squads-follow-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const assistantToolUse = JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/repo/a.ts' } }] },
+  });
+  const resultLine = JSON.stringify({
+    type: 'result', subtype: 'success', result: 'ok', is_error: false, total_cost_usd: 0.01,
+    usage: { input_tokens: 5, output_tokens: 3 }, num_turns: 1,
+  });
+
+  it('renders appended lines as they land and ends when the pid file disappears', async () => {
+    const logFile = join(dir, 'run.log');
+    const pidFile = join(dir, 'run.pid');
+    writeFileSync(logFile, '');
+    writeFileSync(pidFile, '123');
+
+    const seen: string[] = [];
+    const follower = followProviderLog(logFile, {
+      pidFile, pollMs: 20, onLine: (l) => seen.push(strip(l)!),
+    });
+
+    appendFileSync(logFile, assistantToolUse + '\n');
+    await new Promise((r) => setTimeout(r, 80));
+    expect(seen.some((l) => l.includes('read /repo/a.ts'))).toBe(true);
+
+    // Run ends: result line + wrapper removes the pid file.
+    appendFileSync(logFile, resultLine + '\n');
+    unlinkSync(pidFile);
+    await follower.done;
+    expect(seen.some((l) => l.includes('5 in / 3 out'))).toBe(true);
+  });
+
+  it('handles a log that does not exist yet, then appears', async () => {
+    const logFile = join(dir, 'late.log');
+    const pidFile = join(dir, 'late.pid');
+    writeFileSync(pidFile, '123');
+
+    const seen: string[] = [];
+    const follower = followProviderLog(logFile, {
+      pidFile, pollMs: 20, onLine: (l) => seen.push(strip(l)!),
+    });
+
+    await new Promise((r) => setTimeout(r, 50)); // file not there yet — no crash
+    writeFileSync(logFile, assistantToolUse + '\n');
+    await new Promise((r) => setTimeout(r, 80));
+    expect(seen.some((l) => l.includes('read /repo/a.ts'))).toBe(true);
+
+    follower.stop();
+    await follower.done;
+  });
+
+  it('stop() drains a trailing partial line before resolving', async () => {
+    const logFile = join(dir, 'partial.log');
+    writeFileSync(logFile, assistantToolUse + '\n' + resultLine); // no trailing newline
+
+    const seen: string[] = [];
+    const follower = followProviderLog(logFile, { pollMs: 20, onLine: (l) => seen.push(strip(l)!) });
+    await new Promise((r) => setTimeout(r, 60));
+    follower.stop();
+    await follower.done;
+    expect(seen.some((l) => l.includes('5 in / 3 out'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #903 (Child A of RFC #898). Consumer of the #902 substrate — no new event types.

## What

- **`--watch` is now a live activity feed.** Since #902 the detached log is a stream-json event stream; raw `tail -f` showed JSON. The new follower (`event-follow.ts`) reads appended bytes, normalizes through the provider adapter, and renders human lines as they happen: `read src/a.ts` → `wrote pong.txt (4b)` → `Σ 23 in / 529 out · $0.0254`. Run end detected via pid-file removal. `SQUADS_WATCH_RAW=1` restores raw lines.
- **`squads runs --replay <execId>`** re-renders a finished run from its persisted events file, with agent lanes + relative timestamps (`+58.0s  hello │ Σ …`) — the sub-agent fan-out reads as an indented lane per agent. Unknown id → lists recent replayable runs.
- **Renderer** (`event-render.ts`): one line per event type; noise suppressed (ok `tool_result`s, `tool_call`s covered by a specialization); `run_end` summarizes duration/cost/artifacts; `truncated` renders the drop count so a capped stream is never mistaken for complete.

Note: went with `squads runs --replay <id>` rather than a new top-level command (command-sprawl, #442); trivially aliasable later if wanted.

## Verification

- 2042 tests green (9 new: renderer per event type incl. null-noise contract, replay lanes/stamps, follower live-append + late-file-creation + partial-line drain + pid-file end detection).
- **Live-verified**: real haiku `--watch` run on a fixture project streamed the feed mid-run and exited cleanly on completion; `--replay` rendered a prior real run (4 events, correct `+58.0s` stamps); unknown-id UX lists available runs.

## Follow-ups (not this PR)

- Local-API SSE tee so the squads-app renders the same feed (Child A fast-follow per the spec).
- Conversation-mode (`runConversation`) inline live feed — its events persist already (#902); rendering there rides with #904's report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)