### PR TITLE
feat(runs): context-economy report — observable execution Child B

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1188,6 +1188,7 @@ program
   .option('--json', 'Output as JSON')
   .option('--clean', 'Remove stale pid files; salvage crashed runs (harvest + record)')
   .option('--replay <execId>', 'Re-render a finished run\'s activity feed from its recorded events')
+  .option('--report <execId>', 'Context-economy report for a finished run (per-agent cost, cache hits, per-layer)')
   .action(async (options) => {
     const { runsCommand } = await import('./commands/runs.js');
     return runsCommand(options);

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -13,8 +13,9 @@ import {
   type DetachedRun,
 } from '../lib/runs-inventory.js';
 import { reconcileDetachedRuns } from '../lib/spool.js';
-import { execEventsFile } from '../lib/exec-events.js';
+import { execEventsFile, type PersistedExecEvent } from '../lib/exec-events.js';
 import { renderPersistedEvent, parsePersistedLine } from '../lib/event-render.js';
+import { buildContextReport, renderContextReport } from '../lib/context-report.js';
 import { colors, RESET, bold, writeLine } from '../lib/terminal.js';
 
 function elapsed(startedAt: number): string {
@@ -25,11 +26,10 @@ function elapsed(startedAt: number): string {
 }
 
 /**
- * `squads runs --replay <execId>` — re-render a finished run's activity feed
- * from its persisted events file (#903). Consumer of the #902 event stream:
- * the same feed watch mode shows live, replayable after the fact.
+ * Load a run's persisted events; on a missing file, print help (recent
+ * replayable runs) and return null. Shared by --replay and --report.
  */
-export function replayRun(execId: string, projectRoot: string): void {
+function loadRunEvents(execId: string, projectRoot: string): PersistedExecEvent[] | null {
   const eventsDir = join(projectRoot, '.agents', 'observability', 'events');
   const file = execEventsFile(projectRoot, execId);
 
@@ -55,15 +55,26 @@ export function replayRun(execId: string, projectRoot: string): void {
       writeLine(`  ${colors.dim}No events directory yet (${eventsDir}).${RESET}`);
     }
     writeLine();
-    return;
+    return null;
   }
 
   const lines = readFileSync(file, 'utf8').split('\n');
   const parsed = lines.map(parsePersistedLine).filter((l): l is NonNullable<typeof l> => l !== null);
   if (parsed.length === 0) {
     writeLine(`  ${colors.dim}Events file for '${execId}' is empty or unreadable.${RESET}`);
-    return;
+    return null;
   }
+  return parsed;
+}
+
+/**
+ * `squads runs --replay <execId>` — re-render a finished run's activity feed
+ * from its persisted events file (#903). Consumer of the #902 event stream:
+ * the same feed watch mode shows live, replayable after the fact.
+ */
+export function replayRun(execId: string, projectRoot: string): void {
+  const parsed = loadRunEvents(execId, projectRoot);
+  if (!parsed) return;
 
   const t0 = Date.parse(parsed[0].ts);
   writeLine();
@@ -76,11 +87,27 @@ export function replayRun(execId: string, projectRoot: string): void {
   writeLine();
 }
 
-export async function runsCommand(options: { json?: boolean; clean?: boolean; replay?: string }): Promise<void> {
+/**
+ * `squads runs --report <execId>` — context-economy report (#904): per-agent
+ * tokens/cost + cache-hit ratio (exact), per-tool activity, per-layer
+ * assembly cost (estimated). Where did the context go?
+ */
+export function reportRun(execId: string, projectRoot: string): void {
+  const parsed = loadRunEvents(execId, projectRoot);
+  if (!parsed) return;
+  const report = buildContextReport(parsed);
+  for (const line of renderContextReport(report)) writeLine(line);
+}
+
+export async function runsCommand(options: { json?: boolean; clean?: boolean; replay?: string; report?: string }): Promise<void> {
   const projectRoot = getProjectRoot();
 
   if (options.replay) {
     replayRun(options.replay, projectRoot);
+    return;
+  }
+  if (options.report) {
+    reportRun(options.report, projectRoot);
     return;
   }
 

--- a/src/lib/context-report.ts
+++ b/src/lib/context-report.ts
@@ -1,0 +1,203 @@
+/**
+ * context-report.ts — per-run context economy report (#904).
+ *
+ * Child B of the observable-execution RFC (#898): aggregate a run's persisted
+ * event stream into "where did tokens/context go?" — the data basis for the
+ * isolate-vs-inline decision, budget caps (#702), cache-friendly layout
+ * (#703), and spotting context bloat (#889).
+ *
+ * Honest v1 (per the spec): two attribution qualities, labeled as such —
+ * - EXACT from the provider stream: per-agent tokens/cost (each agent spawn
+ *   has its own terminal result → token_usage event) and cache-hit ratio.
+ * - ESTIMATED at assembly time: per-layer chars/tokensEst from the
+ *   context_assembled event. No provider exposes per-layer billing; this is
+ *   the only per-layer truth that exists.
+ * Per-tool attribution is ACTIVITY counts (calls), not tokens — the provider
+ * stream does not attribute tokens to individual tool calls.
+ */
+
+import type { PersistedExecEvent, ContextLayerStat } from './exec-events.js';
+import { colors, RESET, bold } from './terminal.js';
+
+// ── Aggregation (pure, testable) ──────────────────────────────────────
+
+export interface AgentUsageRow {
+  agent: string;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  costEst: number;
+  /** cacheRead / (input + cacheRead) — how much of the prompt was cache-served. */
+  cacheHitPct: number;
+  /** tool_call count attributed to this agent (activity, not tokens). */
+  toolCalls: number;
+}
+
+export interface ContextReport {
+  runId: string;
+  /** Per-agent usage from token_usage events (EXACT — provider-reported). */
+  agents: AgentUsageRow[];
+  /** Per-tool call counts across the run (activity proxy). */
+  toolCounts: Array<{ tool: string; calls: number }>;
+  /** Per-layer assembly stats from context_assembled (ESTIMATED at assembly). */
+  layers: ContextLayerStat[];
+  /** Budget the layers were assembled under (tokens, estimated). */
+  budgetTokens: number;
+  totals: { input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number; cacheHitPct: number };
+  /** Events dropped by the writer cap, if any — the report is then partial. */
+  droppedEvents: number;
+}
+
+function pct(numerator: number, denominator: number): number {
+  return denominator > 0 ? Math.round((numerator / denominator) * 100) : 0;
+}
+
+/** Aggregate a run's persisted events into the context-economy report. */
+export function buildContextReport(events: PersistedExecEvent[]): ContextReport {
+  const agents = new Map<string, AgentUsageRow>();
+  const tools = new Map<string, number>();
+  let layers: ContextLayerStat[] = [];
+  let budgetTokens = 0;
+  let droppedEvents = 0;
+  const runId = events[0]?.runId ?? '';
+
+  const agentRow = (name: string): AgentUsageRow => {
+    let row = agents.get(name);
+    if (!row) {
+      row = { agent: name, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costEst: 0, cacheHitPct: 0, toolCalls: 0 };
+      agents.set(name, row);
+    }
+    return row;
+  };
+
+  for (const line of events) {
+    const ev = line.event;
+    const agent = line.agent || '(run)';
+    switch (ev.type) {
+      case 'token_usage': {
+        const row = agentRow(agent);
+        row.input += ev.input;
+        row.output += ev.output;
+        row.cacheRead += ev.cacheRead;
+        row.cacheWrite += ev.cacheWrite;
+        row.costEst += ev.costEst;
+        break;
+      }
+      case 'tool_call': {
+        agentRow(agent).toolCalls += 1;
+        tools.set(ev.tool, (tools.get(ev.tool) ?? 0) + 1);
+        break;
+      }
+      case 'context_assembled':
+        // Last one wins (single-assembly runs have exactly one).
+        layers = ev.layers;
+        budgetTokens = ev.budgetTokens;
+        break;
+      case 'truncated':
+        droppedEvents += ev.droppedCount;
+        break;
+      default:
+        break;
+    }
+  }
+
+  const rows = [...agents.values()]
+    .map((r) => ({ ...r, cacheHitPct: pct(r.cacheRead, r.input + r.cacheRead) }))
+    // Biggest spender first — the report is about finding where context goes.
+    .sort((a, b) => (b.costEst - a.costEst) || (b.output - a.output));
+
+  const totals = rows.reduce(
+    (t, r) => ({
+      input: t.input + r.input,
+      output: t.output + r.output,
+      cacheRead: t.cacheRead + r.cacheRead,
+      cacheWrite: t.cacheWrite + r.cacheWrite,
+      costEst: t.costEst + r.costEst,
+      cacheHitPct: 0,
+    }),
+    { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costEst: 0, cacheHitPct: 0 },
+  );
+  totals.cacheHitPct = pct(totals.cacheRead, totals.input + totals.cacheRead);
+
+  return {
+    runId,
+    agents: rows,
+    toolCounts: [...tools.entries()].map(([tool, calls]) => ({ tool, calls })).sort((a, b) => b.calls - a.calls),
+    layers,
+    budgetTokens,
+    totals,
+    droppedEvents,
+  };
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+/** Render the report as terminal lines (caller writes them). */
+export function renderContextReport(report: ContextReport): string[] {
+  const out: string[] = [];
+  const dim = (s: string) => `${colors.dim}${s}${RESET}`;
+
+  out.push('');
+  out.push(`  ${bold}Context economy — ${report.runId}${RESET}`);
+  out.push('');
+
+  // Per-agent (exact)
+  out.push(`  ${bold}Per agent${RESET} ${dim('(provider-reported — exact)')}`);
+  if (report.agents.length === 0) {
+    out.push(dim('    no token_usage events recorded'));
+  }
+  for (const a of report.agents) {
+    out.push(
+      `    ${colors.cyan}${a.agent}${RESET}  ` +
+      dim(`${fmtTokens(a.input)} in / ${fmtTokens(a.output)} out · cache ${fmtTokens(a.cacheRead)}r (${a.cacheHitPct}% hit) / ${fmtTokens(a.cacheWrite)}w`) +
+      (a.costEst ? ` ${colors.green}$${a.costEst.toFixed(4)}${RESET}` : '') +
+      (a.toolCalls ? dim(` · ${a.toolCalls} tool calls`) : ''),
+    );
+  }
+  out.push(
+    `    ${bold}total${RESET}  ` +
+    dim(`${fmtTokens(report.totals.input)} in / ${fmtTokens(report.totals.output)} out · cache hit ${report.totals.cacheHitPct}%`) +
+    (report.totals.costEst ? ` ${colors.green}$${report.totals.costEst.toFixed(4)}${RESET}` : ''),
+  );
+  out.push('');
+
+  // Per-tool activity
+  if (report.toolCounts.length > 0) {
+    out.push(`  ${bold}Tool activity${RESET} ${dim('(call counts — tokens are not tool-attributable)')}`);
+    for (const t of report.toolCounts.slice(0, 10)) {
+      out.push(`    ${t.tool.padEnd(14)} ${dim(`${t.calls} call${t.calls > 1 ? 's' : ''}`)}`);
+    }
+    out.push('');
+  }
+
+  // Per-layer (estimated)
+  if (report.layers.length > 0) {
+    out.push(`  ${bold}Context layers${RESET} ${dim(`(assembly-time estimate · budget ~${fmtTokens(report.budgetTokens)} tokens)`)}`);
+    const injected = report.layers.filter((l) => !l.evicted);
+    const totalTokens = injected.reduce((s, l) => s + l.tokensEst, 0);
+    for (const l of report.layers) {
+      if (l.evicted) {
+        out.push(`    ${colors.yellow}L${l.layer} ${l.name}${RESET} ${dim('— EVICTED (budget)')}`);
+      } else {
+        const share = pct(l.tokensEst, totalTokens);
+        const bar = '█'.repeat(Math.max(1, Math.round(share / 5)));
+        out.push(`    L${l.layer} ${l.name.padEnd(28).slice(0, 28)} ${dim(`~${fmtTokens(l.tokensEst).padStart(6)} tok ${String(share).padStart(3)}%`)} ${colors.purple}${bar}${RESET}`);
+      }
+    }
+    out.push('');
+  }
+
+  if (report.droppedEvents > 0) {
+    out.push(`  ${colors.yellow}⚠ ${report.droppedEvents} events were dropped by the size cap — this report is partial.${RESET}`);
+    out.push('');
+  }
+
+  return out;
+}

--- a/test/context-report.test.ts
+++ b/test/context-report.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { buildContextReport, renderContextReport } from '../src/lib/context-report.js';
+import type { ExecEvent, PersistedExecEvent } from '../src/lib/exec-events.js';
+
+// eslint-disable-next-line no-control-regex
+const strip = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+let seq = 0;
+const ev = (event: ExecEvent, agent?: string): PersistedExecEvent =>
+  ({ v: 1, runId: 'exec_report_1', seq: seq++, ts: '2026-07-01T00:00:00Z', ...(agent ? { agent } : {}), event });
+
+const usage = (agent: string, input: number, output: number, cacheRead: number, cost: number): PersistedExecEvent =>
+  ev({ type: 'token_usage', input, output, cacheRead, cacheWrite: 100, costEst: cost, model: 'sonnet' }, agent);
+
+describe('buildContextReport (#904)', () => {
+  it('aggregates per-agent usage with cache-hit ratio, sorted by cost', () => {
+    const report = buildContextReport([
+      usage('scanner', 100, 50, 900, 0.01),     // 90% cache hit
+      usage('worker', 4000, 2000, 4000, 0.30),  // 50% cache hit — biggest spender
+      usage('worker', 1000, 500, 1000, 0.10),   // accumulates onto worker
+    ]);
+
+    expect(report.runId).toBe('exec_report_1');
+    expect(report.agents.map((a) => a.agent)).toEqual(['worker', 'scanner']); // cost-sorted
+    const worker = report.agents[0];
+    expect(worker.input).toBe(5000);
+    expect(worker.output).toBe(2500);
+    expect(worker.cacheHitPct).toBe(50); // 5000 read / (5000 in + 5000 read)
+    expect(report.agents[1].cacheHitPct).toBe(90);
+    expect(report.totals.costEst).toBeCloseTo(0.41);
+    expect(report.totals.input).toBe(5100);
+  });
+
+  it('counts tool activity per tool and per agent', () => {
+    const report = buildContextReport([
+      ev({ type: 'tool_call', tool: 'Bash', inputSummary: 'x' }, 'worker'),
+      ev({ type: 'tool_call', tool: 'Bash', inputSummary: 'y' }, 'worker'),
+      ev({ type: 'tool_call', tool: 'Read', inputSummary: 'z' }, 'scanner'),
+      usage('worker', 10, 5, 0, 0.01),
+    ]);
+    expect(report.toolCounts).toEqual([
+      { tool: 'Bash', calls: 2 },
+      { tool: 'Read', calls: 1 },
+    ]);
+    expect(report.agents.find((a) => a.agent === 'worker')?.toolCalls).toBe(2);
+  });
+
+  it('carries per-layer assembly stats including evictions and the budget', () => {
+    const report = buildContextReport([
+      ev({
+        type: 'context_assembled',
+        layers: [
+          { layer: 9, name: 'Founder Context', chars: 8000, tokensEst: 2000, evicted: false },
+          { layer: 3, name: 'Goals', chars: 400, tokensEst: 100, evicted: false },
+          { layer: 7, name: 'Daily Briefing', chars: 0, tokensEst: 0, evicted: true },
+        ],
+        totalTokensEst: 2100,
+        budgetTokens: 15000,
+      }, 'lead'),
+    ]);
+    expect(report.layers).toHaveLength(3);
+    expect(report.budgetTokens).toBe(15000);
+    expect(report.layers.filter((l) => l.evicted)).toHaveLength(1);
+  });
+
+  it('surfaces dropped events so a partial report is never silent', () => {
+    const report = buildContextReport([
+      ev({ type: 'truncated', droppedCount: 42, reason: 'cap' }),
+    ]);
+    expect(report.droppedEvents).toBe(42);
+    const rendered = renderContextReport(report).map(strip).join('\n');
+    expect(rendered).toContain('42 events were dropped');
+    expect(rendered).toContain('partial');
+  });
+
+  it('renders attribution-quality labels (exact vs estimate) and layer bars', () => {
+    const rendered = renderContextReport(buildContextReport([
+      usage('lead', 1000, 500, 3000, 0.05),
+      ev({
+        type: 'context_assembled',
+        layers: [{ layer: 1, name: 'Company', chars: 2000, tokensEst: 500, evicted: false }],
+        totalTokensEst: 500, budgetTokens: 20000,
+      }, 'lead'),
+    ])).map(strip).join('\n');
+
+    expect(rendered).toContain('provider-reported — exact');
+    expect(rendered).toContain('assembly-time estimate');
+    expect(rendered).toContain('75% hit'); // 3000/(1000+3000)
+    expect(rendered).toContain('L1 Company');
+    expect(rendered).toContain('100%');
+  });
+
+  it('handles an empty event list without crashing', () => {
+    const report = buildContextReport([]);
+    expect(report.agents).toEqual([]);
+    expect(renderContextReport(report).map(strip).join('\n')).toContain('no token_usage events');
+  });
+});


### PR DESCRIPTION
Closes #904 (Child B of RFC #898). Consumer of the #902 substrate — aggregation/report layer only, no new event types.

## What

`squads runs --report <execId>` renders the context-economy report from a run's persisted events:

- **Per agent** (labeled *provider-reported — exact*): input/output tokens, cache read/write, **cache-hit ratio** (`cacheRead / (input+cacheRead)`), cost, tool-call count — sorted biggest spender first. Multi-agent conversation cycles attribute each agent's spawn via the event envelope.
- **Tool activity**: call counts per tool (honestly labeled — the provider stream does not attribute tokens to individual tool calls).
- **Context layers** (labeled *assembly-time estimate*): per-layer tokens + share bars from the `context_assembled` event, with budget and **EVICTED** layers surfaced — the isolate-vs-inline decision data.
- **Partial-report guard**: if the writer cap dropped events, the report says so instead of reading as complete.

Shares the events-file loader with `--replay` (#907) — unknown ids list recent runs.

## Verification

- 2048 tests green (6 new: per-agent aggregation + cache-hit math + cost sort, tool counts, layer/eviction carry, dropped-events surfacing, exact/estimate labels, empty-input).
- **Live-verified** on a real run's events file: exact usage row (100% cache hit on a warm haiku run) + 3-layer breakdown with share bars.

## Wires into (no code here)

#702 budget caps / #703 cache-friendly layout / #889 zombie context bloat — this report is their sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)