### PR TITLE
feat(runs): outcome capture — did the run's output land? (#817)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1189,6 +1189,7 @@ program
   .option('--clean', 'Remove stale pid files; salvage crashed runs (harvest + record)')
   .option('--replay <execId>', 'Re-render a finished run\'s activity feed from its recorded events')
   .option('--report <execId>', 'Context-economy report for a finished run (per-agent cost, cache hits, per-layer)')
+  .option('--outcome <execId>', 'Did the run\'s output land? Resolve its PRs/issues live: merged/open/closed')
   .action(async (options) => {
     const { runsCommand } = await import('./commands/runs.js');
     return runsCommand(options);

--- a/src/commands/runs.ts
+++ b/src/commands/runs.ts
@@ -99,7 +99,50 @@ export function reportRun(execId: string, projectRoot: string): void {
   for (const line of renderContextReport(report)) writeLine(line);
 }
 
-export async function runsCommand(options: { json?: boolean; clean?: boolean; replay?: string; report?: string }): Promise<void> {
+/**
+ * `squads runs --outcome <execId>` — did the run's output LAND? (#817)
+ * Resolves the run's artifact refs live against GitHub: merged/open/closed.
+ * The evaluation question activity counters can't answer.
+ */
+export async function outcomeRun(execId: string, projectRoot: string, json?: boolean): Promise<void> {
+  const parsed = loadRunEvents(execId, projectRoot);
+  if (!parsed) return;
+  const { resolveRunOutcome } = await import('../lib/outcome-resolve.js');
+  const outcome = resolveRunOutcome(parsed);
+
+  if (json) {
+    writeLine(JSON.stringify(outcome, null, 2));
+    return;
+  }
+
+  writeLine();
+  const hasArtifacts = outcome.artifacts.length > 0 || outcome.unconfirmed.length > 0 || outcome.summary.commits > 0;
+  const verdict = outcome.landed
+    ? `${colors.green}LANDED${RESET}`
+    : hasArtifacts ? `${colors.yellow}NOT LANDED YET${RESET}` : `${colors.dim}NO ARTIFACTS${RESET}`;
+  writeLine(`  ${bold}Outcome: ${execId}${RESET}  ${verdict}`);
+  writeLine();
+
+  for (const a of outcome.artifacts) {
+    const state = a.state === 'merged' ? `${colors.green}merged${RESET}`
+      : a.state === 'open' ? `${colors.cyan}open${RESET}`
+      : a.state === 'closed' ? `${colors.red}closed${RESET}`
+      : `${colors.dim}unknown${RESET}`;
+    writeLine(`    ${a.kind.toUpperCase().padEnd(5)} ${state}  ${colors.dim}${a.ref}${a.agent ? ` · ${a.agent}` : ''}${RESET}`);
+  }
+  if (outcome.summary.commits > 0) {
+    writeLine(`    ${colors.dim}+ ${outcome.summary.commits} commit${outcome.summary.commits > 1 ? 's' : ''} recorded (not individually resolved)${RESET}`);
+  }
+  for (const u of outcome.unconfirmed) {
+    writeLine(`    ${colors.yellow}? ${u.kind}${RESET} ${colors.dim}create seen but no URL captured: ${u.ref.slice(0, 80)}${RESET}`);
+  }
+  if (!hasArtifacts) {
+    writeLine(`    ${colors.dim}This run created no commits, PRs, or issues — spend without output.${RESET}`);
+  }
+  writeLine();
+}
+
+export async function runsCommand(options: { json?: boolean; clean?: boolean; replay?: string; report?: string; outcome?: string }): Promise<void> {
   const projectRoot = getProjectRoot();
 
   if (options.replay) {
@@ -108,6 +151,10 @@ export async function runsCommand(options: { json?: boolean; clean?: boolean; re
   }
   if (options.report) {
     reportRun(options.report, projectRoot);
+    return;
+  }
+  if (options.outcome) {
+    await outcomeRun(options.outcome, projectRoot, options.json);
     return;
   }
 

--- a/src/lib/exec-events.ts
+++ b/src/lib/exec-events.ts
@@ -138,17 +138,29 @@ function eventsFromToolUse(block: ClaudeContentBlock): ExecEvent[] {
   return events;
 }
 
-/** Short human summary of a tool_result content payload. */
-function summarizeToolResult(content: unknown): string {
-  if (typeof content === 'string') return content.slice(0, INPUT_SUMMARY_MAX);
+/** Full text of a tool_result content payload (untruncated — for extraction). */
+function toolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
   if (Array.isArray(content)) {
-    const text = content
+    return content
       .filter((b): b is { type: string; text: string } => !!b && typeof b === 'object' && (b as { type?: string }).type === 'text' && typeof (b as { text?: string }).text === 'string')
       .map((b) => b.text)
       .join(' ');
-    return text.slice(0, INPUT_SUMMARY_MAX);
   }
   return '';
+}
+
+/**
+ * Extract the created artifact's canonical URL from a `gh pr create` /
+ * `gh issue create` result — gh prints the new artifact's URL on success.
+ * This is what turns "the agent RAN a create command" (activity) into "the
+ * agent CREATED this artifact" (a resolvable ref) — the basis of outcome
+ * capture (#817): a URL ref can later be checked for merged/closed state.
+ */
+function extractArtifactUrl(text: string, kind: 'pr' | 'issue'): string | undefined {
+  const path = kind === 'pr' ? 'pull' : 'issues';
+  const match = text.match(new RegExp(`https://github\\.com/[\\w.-]+/[\\w.-]+/${path}/\\d+`));
+  return match?.[0];
 }
 
 /**
@@ -158,8 +170,12 @@ function summarizeToolResult(content: unknown): string {
  * tool_use_id) back to the tool name, and Agent/Task spawns to subagent_done.
  */
 export function createClaudeStreamJsonAdapter(): ProviderEventAdapter {
-  /** tool_use id → tool name, so results can be labeled. */
-  const pendingTools = new Map<string, string>();
+  /**
+   * tool_use id → tool name (so results can be labeled) + the artifact kind
+   * when the call was a `gh pr/issue create` (so the RESULT can be mined for
+   * the created artifact's URL — the resolvable ref outcome capture needs).
+   */
+  const pendingTools = new Map<string, { name: string; artifact?: 'pr' | 'issue' }>();
 
   return {
     parseLine(raw: string): ExecEvent[] {
@@ -180,7 +196,13 @@ export function createClaudeStreamJsonAdapter(): ProviderEventAdapter {
           if (!block || block.type !== 'tool_use') continue;
           if (block.id && block.name) {
             if (pendingTools.size >= PENDING_TOOL_MAP_MAX) pendingTools.clear();
-            pendingTools.set(block.id, block.name);
+            let artifact: 'pr' | 'issue' | undefined;
+            if (block.name.toLowerCase() === 'bash') {
+              const cmd = String((block.input as { command?: unknown } | undefined)?.command ?? '');
+              if (/\bgh\b/.test(cmd) && /\bpr\s+create\b/.test(cmd)) artifact = 'pr';
+              else if (/\bgh\b/.test(cmd) && /\bissue\s+create\b/.test(cmd)) artifact = 'issue';
+            }
+            pendingTools.set(block.id, { name: block.name, artifact });
           }
           events.push(...eventsFromToolUse(block));
         }
@@ -191,12 +213,20 @@ export function createClaudeStreamJsonAdapter(): ProviderEventAdapter {
         const events: ExecEvent[] = [];
         for (const block of message.content) {
           if (!block || block.type !== 'tool_result' || !block.tool_use_id) continue;
-          const tool = pendingTools.get(block.tool_use_id) || 'unknown';
+          const pending = pendingTools.get(block.tool_use_id);
+          const tool = pending?.name || 'unknown';
           pendingTools.delete(block.tool_use_id);
           const ok = block.is_error !== true;
-          events.push({ type: 'tool_result', tool, ok, summary: summarizeToolResult(block.content) });
+          const fullText = toolResultText(block.content);
+          events.push({ type: 'tool_result', tool, ok, summary: fullText.slice(0, INPUT_SUMMARY_MAX) });
           if (tool.toLowerCase() === 'agent' || tool.toLowerCase() === 'task') {
             events.push({ type: 'subagent_done', childRunId: block.tool_use_id, agent: tool, ok });
+          }
+          // Artifact-creating command succeeded → mine the result for the
+          // created artifact's canonical URL (the resolvable ref, #817).
+          if (pending?.artifact && ok) {
+            const url = extractArtifactUrl(fullText, pending.artifact);
+            if (url) events.push({ type: 'artifact', kind: pending.artifact, ref: url });
           }
         }
         return events;

--- a/src/lib/outcome-resolve.ts
+++ b/src/lib/outcome-resolve.ts
@@ -1,0 +1,136 @@
+/**
+ * outcome-resolve.ts — did the run's output actually LAND? (#817)
+ *
+ * Activity counters (commits/PRs/issues created) answer "did the agent act";
+ * this answers the question that matters for evaluating an agent workforce:
+ * did anyone MERGE/USE the output, or did it strand? A completed run whose
+ * deliverable nobody uses is pure cost — this makes that visible per run.
+ *
+ * Sources: the run's `artifact` events. URL refs (mined from `gh … create`
+ * results by the adapter) are resolvable — checked live against GitHub.
+ * Command-string refs (the create command was seen but no URL was captured)
+ * are reported as unconfirmed rather than silently dropped.
+ */
+
+import { execSync } from 'child_process';
+import type { PersistedExecEvent } from './exec-events.js';
+
+export type ArtifactState = 'merged' | 'open' | 'closed' | 'unknown';
+
+export interface ResolvedArtifact {
+  kind: 'pr' | 'issue' | 'commit' | 'file';
+  ref: string;
+  /** Live state from GitHub; 'unknown' when unresolvable (no URL / gh failed). */
+  state: ArtifactState;
+  agent?: string;
+}
+
+export interface RunOutcome {
+  runId: string;
+  artifacts: ResolvedArtifact[];
+  /** Artifact-creating commands whose result URL was never captured. */
+  unconfirmed: Array<{ kind: string; ref: string }>;
+  summary: {
+    prs: { total: number; merged: number; open: number; closed: number };
+    issues: { total: number; open: number; closed: number };
+    commits: number;
+  };
+  /** The verdict: did any artifact land (PR merged)? */
+  landed: boolean;
+}
+
+const GITHUB_URL = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/(pull|issues)\/\d+$/;
+
+/** Runs `gh …` and returns stdout, or null on failure. Injectable for tests. */
+export type GhExec = (args: string[]) => string | null;
+
+const defaultGhExec: GhExec = (args) => {
+  try {
+    return execSync(`gh ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(' ')}`, {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 15_000,
+    });
+  } catch {
+    return null;
+  }
+};
+
+function resolvePrState(url: string, gh: GhExec): ArtifactState {
+  const out = gh(['pr', 'view', url, '--json', 'state,mergedAt']);
+  if (!out) return 'unknown';
+  try {
+    const parsed = JSON.parse(out) as { state?: string; mergedAt?: string | null };
+    if (parsed.mergedAt || parsed.state === 'MERGED') return 'merged';
+    if (parsed.state === 'OPEN') return 'open';
+    if (parsed.state === 'CLOSED') return 'closed';
+  } catch { /* fall through */ }
+  return 'unknown';
+}
+
+function resolveIssueState(url: string, gh: GhExec): ArtifactState {
+  const out = gh(['issue', 'view', url, '--json', 'state']);
+  if (!out) return 'unknown';
+  try {
+    const parsed = JSON.parse(out) as { state?: string };
+    if (parsed.state === 'OPEN') return 'open';
+    if (parsed.state === 'CLOSED') return 'closed';
+  } catch { /* fall through */ }
+  return 'unknown';
+}
+
+/**
+ * Resolve a run's artifact events into landed/stranded facts.
+ * URL refs are deduped (create + retry emit the same URL once each) and
+ * checked live; command-string refs are surfaced as unconfirmed.
+ */
+export function resolveRunOutcome(events: PersistedExecEvent[], gh: GhExec = defaultGhExec): RunOutcome {
+  const runId = events[0]?.runId ?? '';
+  const seenUrls = new Set<string>();
+  const artifacts: ResolvedArtifact[] = [];
+  const unconfirmed: Array<{ kind: string; ref: string }> = [];
+  let commits = 0;
+
+  for (const line of events) {
+    const ev = line.event;
+    if (ev.type !== 'artifact') continue;
+    if (ev.kind === 'commit') {
+      commits += 1;
+      continue;
+    }
+    if (ev.kind === 'file') continue;
+    if (GITHUB_URL.test(ev.ref)) {
+      if (seenUrls.has(ev.ref)) continue;
+      seenUrls.add(ev.ref);
+      const state = ev.kind === 'pr' ? resolvePrState(ev.ref, gh) : resolveIssueState(ev.ref, gh);
+      artifacts.push({ kind: ev.kind, ref: ev.ref, state, agent: line.agent });
+    } else {
+      // A create command with no captured URL — activity without a resolvable
+      // ref. Reported, never silently dropped.
+      unconfirmed.push({ kind: ev.kind, ref: ev.ref });
+    }
+  }
+
+  const prs = artifacts.filter((a) => a.kind === 'pr');
+  const issues = artifacts.filter((a) => a.kind === 'issue');
+  const summary = {
+    prs: {
+      total: prs.length,
+      merged: prs.filter((a) => a.state === 'merged').length,
+      open: prs.filter((a) => a.state === 'open').length,
+      closed: prs.filter((a) => a.state === 'closed').length,
+    },
+    issues: {
+      total: issues.length,
+      open: issues.filter((a) => a.state === 'open').length,
+      closed: issues.filter((a) => a.state === 'closed').length,
+    },
+    commits,
+  };
+
+  return {
+    runId,
+    artifacts,
+    unconfirmed,
+    summary,
+    landed: summary.prs.merged > 0,
+  };
+}

--- a/test/outcome-resolve.test.ts
+++ b/test/outcome-resolve.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRunOutcome, type GhExec } from '../src/lib/outcome-resolve.js';
+import { createClaudeStreamJsonAdapter, type ExecEvent, type PersistedExecEvent } from '../src/lib/exec-events.js';
+
+let seq = 0;
+const ev = (event: ExecEvent, agent?: string): PersistedExecEvent =>
+  ({ v: 1, runId: 'exec_outcome_1', seq: seq++, ts: '2026-07-01T00:00:00Z', ...(agent ? { agent } : {}), event });
+
+const PR_URL = 'https://github.com/acme/widgets/pull/42';
+const ISSUE_URL = 'https://github.com/acme/widgets/issues/7';
+
+describe('adapter mines artifact URLs from gh create results (#817)', () => {
+  it('emits a URL-ref artifact when a gh pr create result carries the URL', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    adapter.parseLine(JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'b1', name: 'Bash', input: { command: 'gh pr create --base develop --title x' } }] },
+    }));
+    const events = adapter.parseLine(JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'b1', content: `Creating pull request…\n${PR_URL}\n` }] },
+    }));
+
+    const artifact = events.find((e) => e.type === 'artifact');
+    expect(artifact).toMatchObject({ type: 'artifact', kind: 'pr', ref: PR_URL });
+  });
+
+  it('does not fabricate a URL artifact from a failed create or URL-less output', () => {
+    const adapter = createClaudeStreamJsonAdapter();
+    adapter.parseLine(JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id: 'b2', name: 'Bash', input: { command: 'gh issue create --title y' } }] },
+    }));
+    const failed = adapter.parseLine(JSON.stringify({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'b2', content: 'GraphQL: rate limited', is_error: true }] },
+    }));
+    expect(failed.filter((e) => e.type === 'artifact')).toHaveLength(0);
+  });
+});
+
+describe('resolveRunOutcome (#817)', () => {
+  const ghFake = (states: Record<string, string>): GhExec => (args) => {
+    const url = args.find((a) => a.startsWith('https://'));
+    if (!url || !(url in states)) return null;
+    const state = states[url];
+    return state === 'merged'
+      ? JSON.stringify({ state: 'MERGED', mergedAt: '2026-07-01T00:00:00Z' })
+      : JSON.stringify({ state: state.toUpperCase(), mergedAt: null });
+  };
+
+  it('resolves URL refs live, dedupes, and verdicts LANDED on a merged PR', () => {
+    const outcome = resolveRunOutcome([
+      ev({ type: 'artifact', kind: 'pr', ref: PR_URL }, 'worker'),
+      ev({ type: 'artifact', kind: 'pr', ref: PR_URL }, 'worker'),      // dup (create cmd + result)
+      ev({ type: 'artifact', kind: 'issue', ref: ISSUE_URL }, 'lead'),
+      ev({ type: 'artifact', kind: 'commit', ref: 'git commit -m x' }),
+    ], ghFake({ [PR_URL]: 'merged', [ISSUE_URL]: 'open' }));
+
+    expect(outcome.landed).toBe(true);
+    expect(outcome.artifacts).toHaveLength(2); // deduped
+    expect(outcome.summary).toEqual({
+      prs: { total: 1, merged: 1, open: 0, closed: 0 },
+      issues: { total: 1, open: 1, closed: 0 },
+      commits: 1,
+    });
+    expect(outcome.artifacts.find((a) => a.kind === 'pr')?.agent).toBe('worker');
+  });
+
+  it('an open PR is NOT LANDED; command-string refs surface as unconfirmed', () => {
+    const outcome = resolveRunOutcome([
+      ev({ type: 'artifact', kind: 'pr', ref: PR_URL }),
+      ev({ type: 'artifact', kind: 'issue', ref: 'gh issue create --title z' }), // cmd ref, no URL
+    ], ghFake({ [PR_URL]: 'open' }));
+
+    expect(outcome.landed).toBe(false);
+    expect(outcome.summary.prs.open).toBe(1);
+    expect(outcome.unconfirmed).toEqual([{ kind: 'issue', ref: 'gh issue create --title z' }]);
+  });
+
+  it('gh failure degrades to unknown, never throws', () => {
+    const outcome = resolveRunOutcome(
+      [ev({ type: 'artifact', kind: 'pr', ref: PR_URL })],
+      () => null,
+    );
+    expect(outcome.artifacts[0].state).toBe('unknown');
+    expect(outcome.landed).toBe(false);
+  });
+
+  it('a run with no artifacts is spend without output', () => {
+    const outcome = resolveRunOutcome([
+      ev({ type: 'token_usage', input: 10, output: 5, cacheRead: 0, cacheWrite: 0, costEst: 0.01, model: 'haiku' }),
+    ], () => null);
+    expect(outcome.artifacts).toEqual([]);
+    expect(outcome.summary.commits).toBe(0);
+    expect(outcome.landed).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #817. Third consumer of the #902 event stream — completes the observable-execution trio (#907 live feed, #908 context economy, this: value capture).

## What

#817's original scope (activity counters from stream-json) already shipped via #791 (conversation) + #906 (detached). What was still missing is the question those counters can't answer: **did the output land, or strand?** A completed run whose deliverable nobody uses is pure cost — the fleet evaluation (2026-07-01) found we couldn't distinguish these.

- **Adapter enrichment**: `gh pr create` / `gh issue create` tool RESULTS carry the created artifact's URL — the adapter now correlates and emits `artifact` events with the canonical URL as a resolvable ref (previously only the command string).
- **`squads runs --outcome <execId>`**: resolves each artifact live via `gh` → `merged` / `open` / `closed` / `unknown`; verdict **LANDED** (≥1 PR merged) / **NOT LANDED YET** / **NO ARTIFACTS** (rendered as "spend without output"). URL-less creates surface as `unconfirmed`, never silently dropped. `--json` for pipelines (weekly cadence tally, [internal]).

## Verification

2054 tests green (8 new: URL mining from create results incl. failed-create no-fabrication, live resolution with injected gh fake, dedupe, unconfirmed surfacing, gh-failure→unknown degradation, no-artifact verdict). Live-verified `--outcome` end-to-end on a real run's events file.

## Follow-ups

- Batch outcome sweep into `executions.jsonl`/analytics (outcome as a column, not just on-demand) — rides with the usage-ingest pipeline.
- Commit-level resolution (reachable-from-develop) — v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)