### PR TITLE
fix(learnings): silent no-op when no bridge configured (#911)

### DIFF
--- a/src/lib/execution-log.ts
+++ b/src/lib/execution-log.ts
@@ -109,6 +109,11 @@ export async function checkPreflightGates(squad: string, agent: string): Promise
 export async function fetchLearnings(squad: string, limit = DEFAULT_LEARNINGS_LIMIT): Promise<Learning[]> {
   const bridgeUrl = getBridgeUrl();
 
+  // No bridge configured (the default for a fresh local-first install) →
+  // silent no-op. Warning below is reserved for a CONFIGURED bridge that
+  // fails — a bare install must not print internal endpoints on every run (#911).
+  if (!bridgeUrl) return [];
+
   try {
     const response = await fetch(
       `${bridgeUrl}/api/learnings/relevant?squad=${encodeURIComponent(squad)}&limit=${limit}`,

--- a/test/executions.test.ts
+++ b/test/executions.test.ts
@@ -303,3 +303,26 @@ describe('executions', () => {
     });
   });
 });
+
+// ── #911: no bridge configured → silent no-op, no endpoint leak ──────────
+import { fetchLearnings } from '../src/lib/execution-log.js';
+
+describe('fetchLearnings without a bridge (#911)', () => {
+  it('returns [] silently when bridge_url is unset (fresh local-first install)', async () => {
+    const oldBridge = process.env.SQUADS_BRIDGE_URL;
+    delete process.env.SQUADS_BRIDGE_URL;
+    const warnings: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    // fetchLearnings warns via writeLine(stdout) — capture to assert silence.
+    (process.stdout.write as unknown) = (chunk: string) => { warnings.push(String(chunk)); return true; };
+    try {
+      const result = await fetchLearnings('demo');
+      expect(result).toEqual([]);
+      expect(warnings.join('')).not.toContain('learnings fetch failed');
+      expect(warnings.join('')).not.toContain('/api/learnings');
+    } finally {
+      (process.stdout.write as unknown) = origWrite;
+      if (oldBridge !== undefined) process.env.SQUADS_BRIDGE_URL = oldBridge;
+    }
+  });
+});


### PR DESCRIPTION
Closes #911 (fresh-customer container QA finding #2).

`bridge_url` defaults to `''` on a local-first install, so `fetchLearnings` fed a relative URL to `fetch` → `warn: learnings fetch failed: Failed to parse URL from /api/learnings/relevant?...` printed on EVERY run, leaking an internal endpoint the customer has no backend for.

Fix: early-return `[]` when no bridge URL is configured. The dim warning remains for the case that deserves it — a configured bridge that fails. Regression test asserts silence + no endpoint string in output (fails pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
