### PR TITLE
fix(run): validate target exists before the executor preflight (#912)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -512,6 +512,19 @@ export async function runCommand(
   // Check if target is a squad or an agent
   const squad = loadSquad(squadName);
 
+  // Validate the target EXISTS before any executor preflight (#912): a typo'd
+  // squad must report "not found" (with suggestions), not "claude CLI not
+  // found" — without claude installed the old order made typos un-diagnosable.
+  if (!squad && !listAgents(squadsDir).some(a => a.name === target)) {
+    writeLine(`  ${colors.red}Squad or agent "${target}" not found${RESET}`);
+    const similar = findSimilarSquads(target, listSquads(squadsDir));
+    if (similar.length > 0) {
+      writeLine(`  ${colors.dim}Did you mean: ${similar.join(', ')}?${RESET}`);
+    }
+    writeLine(`  ${colors.dim}Run \`squads status\` to see available squads and agents.${RESET}`);
+    process.exit(1);
+  }
+
   // Paused-squad enforcement: refuse to run a paused squad unless --force is set
   if (squad && squad.status === 'paused' && !options.force) {
     const since = squad.paused_since ? ` (paused ${new Date(squad.paused_since).toLocaleDateString()})` : '';

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -454,10 +454,27 @@ describe('runCommand', () => {
   });
 
   describe('preflight check', () => {
+    // The preflight only runs for a target that EXISTS (#912): a nonexistent
+    // squad now reports "not found" BEFORE any executor CLI check, so these
+    // tests mock a real squad to legitimately reach the provider gate.
+    function makeDemoSquad() {
+      return {
+        name: 'demo',
+        dir: 'demo',
+        mission: 'Demo things',
+        agents: [],
+        pipelines: [],
+        triggers: { scheduled: [], event: [], manual: [] },
+        goals: [],
+        status: 'active',
+        frontmatter: {},
+      };
+    }
+
     it('exits with code 1 when non-anthropic provider CLI not found', async () => {
       delete process.env.SQUADS_SKIP_CHECKS;
       mockFindSquadsDir.mockReturnValue('/project/.agents/squads');
-      mockLoadSquad.mockReturnValue(null);
+      mockLoadSquad.mockReturnValue(makeDemoSquad() as ReturnType<typeof mockLoadSquad>);
       mockIsProviderCLIAvailable.mockReturnValue(false);
 
       await expect(
@@ -470,7 +487,7 @@ describe('runCommand', () => {
     it('writes CLI not found error for missing provider', async () => {
       delete process.env.SQUADS_SKIP_CHECKS;
       mockFindSquadsDir.mockReturnValue('/project/.agents/squads');
-      mockLoadSquad.mockReturnValue(null);
+      mockLoadSquad.mockReturnValue(makeDemoSquad() as ReturnType<typeof mockLoadSquad>);
       mockIsProviderCLIAvailable.mockReturnValue(false);
 
       await expect(
@@ -479,6 +496,21 @@ describe('runCommand', () => {
 
       const calls = mockWriteLine.mock.calls.map(c => c[0]);
       expect(calls.some(msg => msg?.toString().includes('CLI not found'))).toBe(true);
+    });
+
+    it('reports "not found" (not a CLI error) for a nonexistent target (#912)', async () => {
+      delete process.env.SQUADS_SKIP_CHECKS;
+      mockFindSquadsDir.mockReturnValue('/project/.agents/squads');
+      mockLoadSquad.mockReturnValue(null);
+      mockIsProviderCLIAvailable.mockReturnValue(false);
+
+      await expect(
+        runCommand('typo-squadd', { execute: true, provider: 'ollama' })
+      ).rejects.toThrow('process.exit');
+
+      const calls = mockWriteLine.mock.calls.map(c => c[0]?.toString() ?? '');
+      expect(calls.some(msg => msg.includes('not found') && msg.includes('typo-squadd'))).toBe(true);
+      expect(calls.some(msg => msg.includes('CLI not found'))).toBe(false);
     });
 
     it('skips preflight when dryRun is true', async () => {


### PR DESCRIPTION
Closes #912 (fresh-customer container QA finding #3).

`squads run <bad-squad>` on a machine without claude reported **"claude CLI not found"** instead of **"squad not found"** — `preflightExecutorCheck` ran before target validation, making typos un-diagnosable exactly for the fresh user the QA persona simulated.

Fix: the existence check (squad OR agent, with did-you-mean suggestions + `squads status` hint) now runs before the executor preflight.

Live-verified both orderings with claude stripped from PATH:
- `run typo-squadd` → `Squad or agent "typo-squadd" not found`
- `run demo` (valid) → claude install nudge (gate still correct)

2055 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
