### PR TITLE
feat(contract): P1 grant enforcement — compiled allowlists, detached bypass closed, root_run_id (#920)

### DIFF
--- a/src/lib/agent-contract.ts
+++ b/src/lib/agent-contract.ts
@@ -292,3 +292,37 @@ export function contractFromAgentFile(
   }
   return deriveContract({ agent: agentName, squad, role, frontmatter: fm, agentFile, squadFile });
 }
+
+// ── P1: grant compilation (contract → Claude Code allowlist) ─────────────────
+
+/**
+ * Compile an agent's EXPLICIT contract grants into a `--allowedTools` list (#920).
+ *
+ * P1 v1 policy — deny-by-omission where declared, unchanged where not:
+ * - Agent file declares `tool_grants:` in frontmatter → those grants (filtered
+ *   to what the Claude Code allowlist can enforce) ARE the allowlist.
+ * - No declared grants → the caller's battle-tested static default list. The
+ *   ROLE_GRANTS role defaults stay contract-layer documentation/validation;
+ *   swapping them silently for the tuned runtime lists (#790/#793 lead
+ *   governance) would change every run's surface in one commit.
+ *
+ * Unenforceable declared tokens are dropped here at spawn; the P0 CI validator
+ * is where they FAIL loudly.
+ */
+export function compileAllowedTools(
+  agentFile: string,
+  fallback: string[],
+): { tools: string[]; source: 'contract' | 'default' } {
+  if (agentFile && existsSync(agentFile)) {
+    try {
+      const fm = (matter(readFileSync(agentFile, 'utf-8')).data ?? {}) as ContractFrontmatter;
+      if (Array.isArray(fm.tool_grants) && fm.tool_grants.length > 0) {
+        const tools = fm.tool_grants
+          .map((g) => g?.tool)
+          .filter((t): t is string => typeof t === 'string' && isEnforceableTool(t));
+        if (tools.length > 0) return { tools, source: 'contract' };
+      }
+    } catch { /* unreadable frontmatter → default surface */ }
+  }
+  return { tools: fallback, source: 'default' };
+}

--- a/src/lib/exec-events.ts
+++ b/src/lib/exec-events.ts
@@ -55,6 +55,8 @@ export type ExecEvent =
 export interface PersistedExecEvent {
   v: 1;
   runId: string;
+  /** Root of the dispatch chain (#920) — present only when ≠ runId (nested run). */
+  root?: string;
   seq: number;
   ts: string;
   /** Which agent in the run produced this event (fan-out attribution). */
@@ -309,9 +311,14 @@ export class ExecEventWriter {
       this.dropped++;
       return;
     }
+    // Audit chain (#920): a nested run stamps its root so a cascade's events
+    // are queryable by one id. Read per-emit (cheap) — the env is set by
+    // buildAgentEnv on the process that spawned this CLI.
+    const root = process.env.SQUADS_ROOT_RUN_ID;
     const line: PersistedExecEvent = {
       v: 1,
       runId: this.runId,
+      ...(root && root !== this.runId ? { root } : {}),
       seq: this.seq,
       ts: new Date().toISOString(),
       ...(agent ? { agent } : {}),

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -21,6 +21,7 @@ import {
 } from './squad-parser.js';
 import { parseAgentFrontmatter, type ContextStats } from './run-context.js';
 import { ExecEventWriter, execEventsFile } from './exec-events.js';
+import { compileAllowedTools } from './agent-contract.js';
 import {
   type ExecutionContext,
 } from './run-types.js';
@@ -64,6 +65,27 @@ export const VERIFICATION_STATE_MAX_CHARS = 2000;
 export const VERIFICATION_EXEC_TIMEOUT_MS = 30000;
 export const LOG_FILE_INIT_DELAY_MS = 500;
 export const VERBOSE_COMMAND_MAX_CHARS = 50;
+
+/**
+ * The default agent tool surface — the compiler fallback when an agent
+ * declares no explicit contract grants (#920). Shared by the foreground and
+ * detached spawn paths so P1 closes the detached bypass with the SAME proven
+ * surface foreground runs have exercised for months.
+ */
+export const DEFAULT_AGENT_TOOLS: string[] = [
+  'Read', 'Write', 'Edit', 'Glob', 'Grep',
+  'Bash(git:*)', 'Bash(gh:*)', 'Bash(npm:*)', 'Bash(npx:*)',
+  'Bash(node:*)', 'Bash(python3:*)', 'Bash(curl:*)',
+  'Bash(bash:*)', 'Bash(sh:*)', // agents run their own helper scripts (e.g. an agent's watchlist.sh)
+  'Bash(docker:*)', 'Bash(duckdb:*)',
+  'Bash(bq:*)', 'Bash(gcloud:*)',
+  'Bash(gws:*)', 'Bash(stripe:*)',
+  'Bash(ls:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)',
+  'Bash(cat:*)', 'Bash(head:*)', 'Bash(tail:*)', 'Bash(wc:*)',
+  'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(date:*)',
+  'Bash(squads:*)',
+  'Agent', 'WebFetch', 'WebSearch',
+];
 
 // ── Guardrail settings ────────────────────────────────────────────────
 
@@ -353,6 +375,11 @@ export function buildAgentEnv(
     SQUADS_TASK_TYPE: execContext.taskType,
     SQUADS_TRIGGER: execContext.trigger,
     SQUADS_EXECUTION_ID: execContext.executionId,
+    // Audit chain (#920): the root anchors aggregate cost/traceability across
+    // nested dispatches (an agent running `squads run` inherits these). Root
+    // propagates unchanged; parent is always the run doing THIS spawn.
+    SQUADS_ROOT_RUN_ID: baseEnv.SQUADS_ROOT_RUN_ID || execContext.executionId,
+    SQUADS_PARENT_RUN_ID: execContext.executionId,
     BRIDGE_API: getBridgeUrl(),
   };
 
@@ -569,6 +596,8 @@ export function buildDetachedShellScript(config: {
   timeoutMinutes?: number;
   /** Claude session id for this run (#857) — pins the session JSONL so reconcile attributes exactly this run's usage. */
   sessionId?: string;
+  /** Compiled tool allowlist (#920). When present, replaces --dangerously-skip-permissions on the detached executor. */
+  allowedTools?: string[];
 }): string {
   const modelFlag = config.claudeModelAlias ? `--model ${config.claudeModelAlias}` : '';
   const safeSessionId = config.sessionId ? config.sessionId.replace(/[^A-Za-z0-9-]/g, '') : '';
@@ -598,7 +627,16 @@ export function buildDetachedShellScript(config: {
   // the run ends, which is exactly the black box this kills. `--verbose` is
   // required for stream-json to emit events. The reconcile sweep normalizes
   // this raw log into the run's events file (exec-events.ts).
-  const executorCmd = `claude --print --output-format stream-json --verbose --dangerously-skip-permissions --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
+  //
+  // Permissions (#920 / P1): detached runs ran --dangerously-skip-permissions
+  // since inception — the last ungoverned spawn surface. They now get the same
+  // compiled allowlist as foreground; SQUADS_SKIP_PERMISSIONS=1 remains the
+  // explicit sandboxed-environment opt-out (checked by the CALLER, which then
+  // omits allowedTools).
+  const permissionFlags = config.allowedTools && config.allowedTools.length > 0
+    ? `--allowedTools ${config.allowedTools.map((t) => `'${t.replace(/'/g, '')}'`).join(' ')}`
+    : '--dangerously-skip-permissions';
+  const executorCmd = `claude --print --output-format stream-json --verbose ${permissionFlags} --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
   const watchdogSecs = Math.max(1, Math.round((config.timeoutMinutes || 15) * 60));
   const script = `mkdir -p '${config.projectRoot}/../.worktrees'; WORK_DIR='${config.projectRoot}'; if git -C '${config.projectRoot}' worktree add '${worktreeDir}' -b '${branchName}' HEAD 2>/dev/null; then WORK_DIR='${worktreeDir}'; fi; cd "\${WORK_DIR}"; unset CLAUDECODE; ${buildWatchdogShell(executorCmd, watchdogSecs, timeoutFlag)}; ${cleanup}${spool}`;
   // pid file removed on clean wrapper exit — a surviving pid file with a dead
@@ -852,16 +890,16 @@ export async function executeWithClaude(
   const mergedSkills = [...new Set([...(skills || []), ...squadSkills])];
   const taskType = detectTaskType(agentName);
 
+  // Agent definition path — used for frontmatter model AND contract grants (#920).
+  const squadsDirForAgent = findSquadsDir();
+  const agentPath = squadsDirForAgent ? join(squadsDirForAgent, squadName, `${agentName}.md`) : '';
+
   // Read agent frontmatter model if no explicit CLI flag
   let effectiveModel = model;
-  if (!effectiveModel) {
-    const squadsDir = findSquadsDir();
-    if (squadsDir) {
-      const agentPath = join(squadsDir, squadName, `${agentName}.md`);
-      const frontmatter = parseAgentFrontmatter(agentPath);
-      if (frontmatter.model) {
-        effectiveModel = frontmatter.model;
-      }
+  if (!effectiveModel && agentPath) {
+    const frontmatter = parseAgentFrontmatter(agentPath);
+    if (frontmatter.model) {
+      effectiveModel = frontmatter.model;
     }
   }
 
@@ -950,20 +988,13 @@ export async function executeWithClaude(
       // Explicit opt-in for sandboxed environments (Docker, CI)
       claudeArgs.push('--dangerously-skip-permissions');
     } else {
-      claudeArgs.push('--allowedTools',
-        'Read', 'Write', 'Edit', 'Glob', 'Grep',
-        'Bash(git:*)', 'Bash(gh:*)', 'Bash(npm:*)', 'Bash(npx:*)',
-        'Bash(node:*)', 'Bash(python3:*)', 'Bash(curl:*)',
-        'Bash(bash:*)', 'Bash(sh:*)', // agents run their own helper scripts (e.g. an agent's watchlist.sh)
-        'Bash(docker:*)', 'Bash(duckdb:*)',
-        'Bash(bq:*)', 'Bash(gcloud:*)',
-        'Bash(gws:*)', 'Bash(stripe:*)',
-        'Bash(ls:*)', 'Bash(mkdir:*)', 'Bash(cp:*)', 'Bash(mv:*)',
-        'Bash(cat:*)', 'Bash(head:*)', 'Bash(tail:*)', 'Bash(wc:*)',
-        'Bash(echo:*)', 'Bash(chmod:*)', 'Bash(date:*)',
-        'Bash(squads:*)',
-        'Agent', 'WebFetch', 'WebSearch',
-      );
+      // Contract grants win when the agent declares them; the tuned default
+      // surface otherwise (#920 — deny-by-omission where declared).
+      const compiled = compileAllowedTools(agentPath, DEFAULT_AGENT_TOOLS);
+      if (verbose && compiled.source === 'contract') {
+        writeLine(`  ${colors.dim}Tool grants: ${compiled.tools.length} from agent contract${RESET}`);
+      }
+      claudeArgs.push('--allowedTools', ...compiled.tools);
     }
     claudeArgs.push('--disable-slash-commands');
     if (mcpConfigPath) claudeArgs.push('--mcp-config', mcpConfigPath);
@@ -1015,6 +1046,11 @@ export async function executeWithClaude(
     obsRoot: projectRoot, executionId: execContext.executionId, trigger,
     timeoutMinutes: watchdogMinutes,
     sessionId: randomUUID(),
+    // #920: same compiled surface as foreground; SQUADS_SKIP_PERMISSIONS=1
+    // keeps the legacy bypass for sandboxed environments.
+    allowedTools: process.env.SQUADS_SKIP_PERMISSIONS === '1'
+      ? undefined
+      : compileAllowedTools(agentPath, DEFAULT_AGENT_TOOLS).tools,
   });
 
   // Detached: run_start/context_assembled are already on disk; the run's tool

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -42,6 +42,11 @@ export interface ObservabilityRecord {
   commits?: number;
   prs_created?: number;
   issues_created?: number;
+  // Audit chain (#920): nested dispatches trace to their root so aggregate
+  // cost ceilings and "what did this cascade cost" anchor at one id. Absent
+  // (or = id) for top-level runs.
+  root_run_id?: string;
+  parent_run_id?: string;
   error?: string;
   task?: string;
   // Goal tracking
@@ -472,6 +477,16 @@ async function pingIngestTrigger(): Promise<void> {
 }
 
 export function logObservability(record: ObservabilityRecord): void {
+  // Audit chain (#920): when this CLI process was itself spawned by an agent
+  // run, buildAgentEnv gave it the chain — stamp every record it writes.
+  // Explicit fields on the record win (callers that know better).
+  if (!record.root_run_id && process.env.SQUADS_ROOT_RUN_ID) {
+    record.root_run_id = process.env.SQUADS_ROOT_RUN_ID;
+  }
+  if (!record.parent_run_id && process.env.SQUADS_PARENT_RUN_ID) {
+    record.parent_run_id = process.env.SQUADS_PARENT_RUN_ID;
+  }
+
   const logPath = getLogPath();
   if (!logPath) return;
 

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -73,6 +73,7 @@ import {
   createClaudeStreamJsonAdapter,
   execEventsFile,
 } from './exec-events.js';
+import { compileAllowedTools } from './agent-contract.js';
 
 // =============================================================================
 // Configuration
@@ -239,8 +240,9 @@ ${squadContext}
   if (process.env.SQUADS_SKIP_PERMISSIONS === '1') {
     claudeArgs.push('--dangerously-skip-permissions');
   } else {
-    const tools = toolsByRole[role] || [...readTools, ...writeTools];
-    claudeArgs.push('--allowedTools', ...tools);
+    // Explicit contract grants win over the role surface (#920).
+    const fallback = toolsByRole[role] || [...readTools, ...writeTools];
+    claudeArgs.push('--allowedTools', ...compileAllowedTools(agentPath, fallback).tools);
   }
   claudeArgs.push('--disable-slash-commands');
 

--- a/test/p1-grant-enforcement.test.ts
+++ b/test/p1-grant-enforcement.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { compileAllowedTools } from '../src/lib/agent-contract.js';
+import { buildDetachedShellScript, buildAgentEnv, DEFAULT_AGENT_TOOLS } from '../src/lib/execution-engine.js';
+import { ExecEventWriter, execEventsFile, type PersistedExecEvent } from '../src/lib/exec-events.js';
+import { readFileSync } from 'fs';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'squads-p1-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function writeAgentFile(frontmatter: string): string {
+  const p = join(dir, 'agent.md');
+  writeFileSync(p, `---\n${frontmatter}\n---\n\n# Agent\nbody\n`);
+  return p;
+}
+
+describe('compileAllowedTools (#920 — deny-by-omission where declared)', () => {
+  it('explicit frontmatter tool_grants become the allowlist, unenforceable tokens dropped', () => {
+    const p = writeAgentFile([
+      'role: worker',
+      'tool_grants:',
+      '  - tool: Read',
+      '    sensitivity: read',
+      '  - tool: "Bash(git:*)"',
+      '    sensitivity: write',
+      '  - tool: "Bash(rm -rf $(pwd))"', // shell metachars — not enforceable
+      '    sensitivity: consequential',
+    ].join('\n'));
+
+    const compiled = compileAllowedTools(p, DEFAULT_AGENT_TOOLS);
+    expect(compiled.source).toBe('contract');
+    expect(compiled.tools).toEqual(['Read', 'Bash(git:*)']);
+  });
+
+  it('no declared grants → the tuned default surface, unchanged', () => {
+    const p = writeAgentFile('role: worker\nmodel: haiku');
+    const compiled = compileAllowedTools(p, DEFAULT_AGENT_TOOLS);
+    expect(compiled.source).toBe('default');
+    expect(compiled.tools).toBe(DEFAULT_AGENT_TOOLS);
+  });
+
+  it('missing/unreadable agent file → default surface, never throws', () => {
+    const compiled = compileAllowedTools(join(dir, 'nope.md'), ['Read']);
+    expect(compiled).toEqual({ tools: ['Read'], source: 'default' });
+  });
+});
+
+describe('detached executor permissions (#920 — the bypass is closed)', () => {
+  const base = {
+    projectRoot: '/proj', squadName: 'demo', agentName: 'hello', timestamp: 1,
+    escapedPrompt: 'do it', logFile: '/tmp/l.log', pidFile: '/tmp/l.pid',
+  };
+
+  it('with compiled tools: --allowedTools present, --dangerously-skip-permissions absent', () => {
+    const script = buildDetachedShellScript({ ...base, allowedTools: ['Read', 'Bash(git:*)'] });
+    expect(script).toContain(`--allowedTools 'Read' 'Bash(git:*)'`);
+    expect(script).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('without allowedTools (SQUADS_SKIP_PERMISSIONS opt-out path): legacy bypass retained', () => {
+    const script = buildDetachedShellScript(base);
+    expect(script).toContain('--dangerously-skip-permissions');
+    expect(script).not.toContain('--allowedTools');
+  });
+});
+
+describe('root_run_id chain (#920)', () => {
+  const ctx = (id: string) => ({ squad: 's', agent: 'a', taskType: 'execution', trigger: 'manual', executionId: id }) as Parameters<typeof buildAgentEnv>[1];
+
+  it('top-level spawn: root = own execution id; parent = own id for children', () => {
+    const env = buildAgentEnv({ PATH: '/bin' }, ctx('exec_root_1'));
+    expect(env.SQUADS_ROOT_RUN_ID).toBe('exec_root_1');
+    expect(env.SQUADS_PARENT_RUN_ID).toBe('exec_root_1');
+  });
+
+  it('nested spawn: root propagates unchanged; parent becomes the spawner', () => {
+    // Simulate: this CLI was spawned by exec_root_1, and now spawns exec_child_2.
+    const inherited = { PATH: '/bin', SQUADS_ROOT_RUN_ID: 'exec_root_1' };
+    const env = buildAgentEnv(inherited, ctx('exec_child_2'));
+    expect(env.SQUADS_ROOT_RUN_ID).toBe('exec_root_1');
+    expect(env.SQUADS_PARENT_RUN_ID).toBe('exec_child_2');
+  });
+
+  it('nested runs stamp root on persisted events; top-level runs do not', () => {
+    const old = process.env.SQUADS_ROOT_RUN_ID;
+    try {
+      process.env.SQUADS_ROOT_RUN_ID = 'exec_root_1';
+      mkdirSync(join(dir, '.agents'), { recursive: true });
+      const file = execEventsFile(dir, 'exec_child_2');
+      const w = new ExecEventWriter(file, 'exec_child_2');
+      w.emit({ type: 'run_start', squad: 's', mode: 'background', model: '', role: '', startedAt: 'x' });
+      w.close();
+      const line = JSON.parse(readFileSync(file, 'utf8').trim()) as PersistedExecEvent;
+      expect(line.root).toBe('exec_root_1');
+
+      // Top-level: env root equals own runId → no stamp.
+      process.env.SQUADS_ROOT_RUN_ID = 'exec_top_3';
+      const file2 = execEventsFile(dir, 'exec_top_3');
+      const w2 = new ExecEventWriter(file2, 'exec_top_3');
+      w2.emit({ type: 'run_start', squad: 's', mode: 'background', model: '', role: '', startedAt: 'x' });
+      w2.close();
+      const line2 = JSON.parse(readFileSync(file2, 'utf8').trim()) as PersistedExecEvent;
+      expect(line2.root).toBeUndefined();
+    } finally {
+      if (old === undefined) delete process.env.SQUADS_ROOT_RUN_ID;
+      else process.env.SQUADS_ROOT_RUN_ID = old;
+    }
+  });
+});


### PR DESCRIPTION
Closes #920 (P1 of the chief-cli-runtime phased plan, [internal]; step 1 of the outcome-driven-routing build order).

## What

1. **Grant compilation** — `compileAllowedTools(agentFile, fallback)`: explicit frontmatter `tool_grants:` compile to the spawn's `--allowedTools` (filtered to enforceable tokens); agents without declared grants keep the battle-tested static surface, now shared across paths as `DEFAULT_AGENT_TOOLS`. Deny-by-omission where declared, zero change where not — the safe P1 (silently swapping role defaults for the tuned #790/#793 lists would have changed every run's surface in one commit).
2. **The detached bypass is closed** — the last ungoverned spawn surface (`--dangerously-skip-permissions` since inception) now gets the same compiled allowlist as foreground. `SQUADS_SKIP_PERMISSIONS=1` remains the explicit opt-out for sandboxed environments.
3. **root_run_id audit chain** — `SQUADS_ROOT_RUN_ID`/`SQUADS_PARENT_RUN_ID` propagate through `buildAgentEnv`; `executions.jsonl` records and #902 event envelopes stamp root/parent. A nested dispatch cascade is queryable by one id (the anchor for aggregate cost ceilings, P3).

## Verification

- 2064 tests green (8 new: grant compile incl. unenforceable-token drop + fallback + never-throws, detached script with/without allowlist, root chain fresh/inherited, envelope stamping nested vs top-level).
- **Live exit criterion**: fixture agent with read-only `tool_grants` asked to write a file on a real detached run → write DENIED at the tool layer (file never created; agent output `WRITE-DENIED`; 1 tool_use total).

## Risk note

Detached agents needing tools beyond `DEFAULT_AGENT_TOOLS` must now declare frontmatter grants (or the env opt-out). The default surface is the one foreground runs have exercised for months, so the expected breakage set is empty — but watch the first scheduled runs.

Next in order: P2 default-on sandbox (#780) → review-queue Child 0 → capability matrix + scoreboard (hq spec f75f9a5e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
