### PR TITLE
feat(sandbox): P2 default-on — OS sandbox for every agent spawn path (#780)

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -47,7 +47,7 @@ import { getBridgeUrl } from './env-config.js';
 import { getBotGitEnv, getBotPushUrl, getCoAuthorTrailer, getBotGhEnv } from './github.js';
 import { scanDiff, loadForbiddenStrings, summarizeFindings } from './secret-scan.js';
 import {
-  buildSandboxSettings, readGuardrailHooks, readGuardrailPermissions, writeSandboxSettingsFile, sandboxEnabled,
+  buildSandboxSettings, readGuardrailHooks, readGuardrailPermissions, writeSandboxSettingsFile, sandboxEnabled, sandboxStrict,
 } from './sandbox-settings.js';
 import {
   colors,
@@ -598,8 +598,11 @@ export function buildDetachedShellScript(config: {
   sessionId?: string;
   /** Compiled tool allowlist (#920). When present, replaces --dangerously-skip-permissions on the detached executor. */
   allowedTools?: string[];
+  /** Settings file for the executor (#780): sandbox + guardrail hooks. Detached runs previously got NEITHER. */
+  settingsFile?: string;
 }): string {
   const modelFlag = config.claudeModelAlias ? `--model ${config.claudeModelAlias}` : '';
+  const settingsFlag = config.settingsFile ? `--settings '${config.settingsFile.replace(/'/g, '')}' ` : '';
   const safeSessionId = config.sessionId ? config.sessionId.replace(/[^A-Za-z0-9-]/g, '') : '';
   const sessionFlag = safeSessionId ? `--session-id ${safeSessionId} ` : '';
   const branchName = `agent/${config.squadName}/${config.agentName}-${config.timestamp}`;
@@ -636,7 +639,7 @@ export function buildDetachedShellScript(config: {
   const permissionFlags = config.allowedTools && config.allowedTools.length > 0
     ? `--allowedTools ${config.allowedTools.map((t) => `'${t.replace(/'/g, '')}'`).join(' ')}`
     : '--dangerously-skip-permissions';
-  const executorCmd = `claude --print --output-format stream-json --verbose ${permissionFlags} --disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
+  const executorCmd = `claude --print --output-format stream-json --verbose ${permissionFlags} ${settingsFlag}--disable-slash-commands ${sessionFlag}${modelFlag} -- '${config.escapedPrompt}' > '${config.logFile}' 2>&1`;
   const watchdogSecs = Math.max(1, Math.round((config.timeoutMinutes || 15) * 60));
   const script = `mkdir -p '${config.projectRoot}/../.worktrees'; WORK_DIR='${config.projectRoot}'; if git -C '${config.projectRoot}' worktree add '${worktreeDir}' -b '${branchName}' HEAD 2>/dev/null; then WORK_DIR='${worktreeDir}'; fi; cd "\${WORK_DIR}"; unset CLAUDECODE; ${buildWatchdogShell(executorCmd, watchdogSecs, timeoutFlag)}; ${cleanup}${spool}`;
   // pid file removed on clean wrapper exit — a surviving pid file with a dead
@@ -1010,6 +1013,7 @@ export async function executeWithClaude(
         writeScope: memDir ? [memDir] : [],
         guardrailHooks: readGuardrailHooks(guardrailPath),
         guardrailPermissions: readGuardrailPermissions(guardrailPath),
+        strict: sandboxStrict(),
       });
       const settingsPath = writeSandboxSettingsFile(settings, join(targetRepoRoot, '.git'));
       claudeArgs.push('--settings', settingsPath);
@@ -1040,6 +1044,28 @@ export async function executeWithClaude(
 
   const envTimeout = Number(process.env.SQUADS_AGENT_TIMEOUT_MINUTES);
   const watchdogMinutes = Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : _timeoutMinutes;
+
+  // Settings for the detached executor (#780): sandbox (default-on) + guardrail
+  // hooks. Detached runs previously received NEITHER — the sandbox flip also
+  // brings the governance denylist to the path that needed it most. The file
+  // lives in the repo's .git (shared across a repo's runs — same content).
+  const detachedGuardrail = resolveGuardrailSettings(targetRepoRoot);
+  let detachedSettingsFile: string | undefined;
+  if (sandboxEnabled()) {
+    const memDirDetached = findMemoryDir();
+    const settings = buildSandboxSettings({
+      cwd: targetRepoRoot,
+      writeScope: memDirDetached ? [memDirDetached] : [],
+      guardrailHooks: readGuardrailHooks(detachedGuardrail),
+      guardrailPermissions: readGuardrailPermissions(detachedGuardrail),
+      strict: sandboxStrict(),
+    });
+    detachedSettingsFile = writeSandboxSettingsFile(settings, join(targetRepoRoot, '.git'));
+    agentEnv.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = '1';
+  } else if (detachedGuardrail) {
+    detachedSettingsFile = detachedGuardrail;
+  }
+
   const wrapperScript = buildDetachedShellScript({
     projectRoot: targetRepoRoot, squadName, agentName, timestamp,
     claudeModelAlias, escapedPrompt, logFile, pidFile,
@@ -1051,6 +1077,7 @@ export async function executeWithClaude(
     allowedTools: process.env.SQUADS_SKIP_PERMISSIONS === '1'
       ? undefined
       : compileAllowedTools(agentPath, DEFAULT_AGENT_TOOLS).tools,
+    settingsFile: detachedSettingsFile,
   });
 
   // Detached: run_start/context_assembled are already on disk; the run's tool

--- a/src/lib/sandbox-settings.ts
+++ b/src/lib/sandbox-settings.ts
@@ -9,8 +9,10 @@
  * `@anthropic-ai/sandbox-runtime`. We just feed it settings (merged with the
  * existing guardrail PreToolUse hooks) via the spawn's `--settings` flag.
  *
- * Gated behind `SQUADS_SANDBOX=1` for now: when off, behavior is unchanged; when
- * on, agents run sandboxed. Flip the default after a real `squads run` smoke.
+ * DEFAULT ON since P2 default-on (#780): agents run sandboxed unless
+ * `SQUADS_SANDBOX=0` (explicit opt-out — CI images without Seatbelt/bubblewrap,
+ * debugging). `SQUADS_SANDBOX_STRICT=1` additionally hard-fails when the
+ * sandbox is unavailable and removes the unsandboxed-retry escape hatch.
  *
  * Gotchas baked in (from Anthropic's docs): `gh`/`gcloud`/`terraform` (Go TLS)
  * and `docker` are incompatible with Seatbelt → `excludedCommands` (run outside
@@ -114,7 +116,16 @@ export function writeSandboxSettingsFile(settings: Record<string, unknown>, dir:
   return path;
 }
 
-/** Whether sandboxing is opt-in enabled for spawns. */
+/**
+ * Whether spawns run inside the OS sandbox. DEFAULT ON (#780 — P2 default-on);
+ * `SQUADS_SANDBOX=0` is the explicit opt-out for environments without
+ * Seatbelt/bubblewrap or when debugging agent behavior.
+ */
 export function sandboxEnabled(): boolean {
-  return process.env.SQUADS_SANDBOX === '1';
+  return process.env.SQUADS_SANDBOX !== '0';
+}
+
+/** Strict posture: hard-fail if the sandbox is unavailable, no unsandboxed retry. */
+export function sandboxStrict(): boolean {
+  return process.env.SQUADS_SANDBOX_STRICT === '1';
 }

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -74,6 +74,11 @@ import {
   execEventsFile,
 } from './exec-events.js';
 import { compileAllowedTools } from './agent-contract.js';
+import { findMemoryDir } from './memory.js';
+import {
+  buildSandboxSettings, readGuardrailHooks, readGuardrailPermissions,
+  writeSandboxSettingsFile, sandboxEnabled, sandboxStrict,
+} from './sandbox-settings.js';
 
 // =============================================================================
 // Configuration
@@ -260,7 +265,22 @@ ${squadContext}
   }
 
   const guardrailPath = resolveGuardrailSettings(spawnCwd);
-  if (guardrailPath) claudeArgs.push('--settings', guardrailPath);
+  if (sandboxEnabled()) {
+    // P2 default-on (#780): conversation agents run inside the OS sandbox too —
+    // same settings shape as the single-agent paths, guardrail hooks merged in.
+    const memDir = findMemoryDir();
+    const settings = buildSandboxSettings({
+      cwd: spawnCwd,
+      writeScope: memDir ? [memDir] : [],
+      guardrailHooks: readGuardrailHooks(guardrailPath),
+      guardrailPermissions: readGuardrailPermissions(guardrailPath),
+      strict: sandboxStrict(),
+    });
+    claudeArgs.push('--settings', writeSandboxSettingsFile(settings, join(spawnCwd, '.git')));
+    agentEnv.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = '1';
+  } else if (guardrailPath) {
+    claudeArgs.push('--settings', guardrailPath);
+  }
   if (claudeModel) claudeArgs.push('--model', claudeModel);
 
   // Exec-event stream (#902): announce this agent as a lane in the cycle's

--- a/test/p1-grant-enforcement.test.ts
+++ b/test/p1-grant-enforcement.test.ts
@@ -110,3 +110,33 @@ describe('root_run_id chain (#920)', () => {
     }
   });
 });
+
+// ── P2 default-on (#780) ────────────────────────────────────────────────
+
+describe('sandbox default-on (#780)', () => {
+  const OLD = process.env.SQUADS_SANDBOX;
+  afterEach(() => {
+    if (OLD === undefined) delete process.env.SQUADS_SANDBOX;
+    else process.env.SQUADS_SANDBOX = OLD;
+  });
+
+  it('sandboxEnabled defaults ON; SQUADS_SANDBOX=0 is the explicit opt-out', async () => {
+    const { sandboxEnabled } = await import('../src/lib/sandbox-settings.js');
+    delete process.env.SQUADS_SANDBOX;
+    expect(sandboxEnabled()).toBe(true);
+    process.env.SQUADS_SANDBOX = '0';
+    expect(sandboxEnabled()).toBe(false);
+    process.env.SQUADS_SANDBOX = '1';
+    expect(sandboxEnabled()).toBe(true);
+  });
+
+  it('detached executor carries --settings when a settings file is provided', () => {
+    const script = buildDetachedShellScript({
+      projectRoot: '/proj', squadName: 'demo', agentName: 'hello', timestamp: 1,
+      escapedPrompt: 'x', logFile: '/tmp/l.log', pidFile: '/tmp/l.pid',
+      allowedTools: ['Read'],
+      settingsFile: '/proj/.git/squads-sandbox-settings.json',
+    });
+    expect(script).toContain(`--settings '/proj/.git/squads-sandbox-settings.json'`);
+  });
+});

--- a/test/sandbox-settings.test.ts
+++ b/test/sandbox-settings.test.ts
@@ -96,9 +96,9 @@ describe('file I/O (the path the ESM-require bug broke at runtime)', () => {
 describe('sandboxEnabled', () => {
   const prev = process.env.SQUADS_SANDBOX;
   afterEach(() => { if (prev === undefined) delete process.env.SQUADS_SANDBOX; else process.env.SQUADS_SANDBOX = prev; });
-  it('reads SQUADS_SANDBOX=1', () => {
+  it('defaults ON; SQUADS_SANDBOX=0 is the explicit opt-out (#780 default-on)', () => {
     process.env.SQUADS_SANDBOX = '1'; expect(sandboxEnabled()).toBe(true);
     process.env.SQUADS_SANDBOX = '0'; expect(sandboxEnabled()).toBe(false);
-    delete process.env.SQUADS_SANDBOX; expect(sandboxEnabled()).toBe(false);
+    delete process.env.SQUADS_SANDBOX; expect(sandboxEnabled()).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #780 (P2 of chief-cli-runtime, [internal]; step 2 of the outcome-driven-routing build order). Follows #921 (P1).

## What

- **Default ON**: `sandboxEnabled()` now defaults true — `SQUADS_SANDBOX=0` is the explicit opt-out (CI images without Seatbelt/bubblewrap, debugging); `SQUADS_SANDBOX_STRICT=1` adds the hard-fail posture (no unsandboxed retry).
- **Detached path finally governed**: it previously received NO `--settings` at all — neither sandbox nor the guardrail PreToolUse denylist. It now carries the merged sandbox+guardrail settings file (written to the repo's `.git/`, same content across a repo's runs).
- **Conversation path** (`runIndependentAgent`) wired identically; `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` rides wherever the sandbox is on.
- Known-incompatible commands stay excluded per the spec's verified gotchas (`gh`/`gcloud`/`terraform`/`docker` run outside the sandbox); credential dirs (`~/.ssh`, `~/.aws`, `~/.config/gcloud`) are denyRead.

## Live verification (the placebo check — this was the risk)

Real detached runs on macOS Seatbelt, all three exit criteria:

| Check | Result |
|---|---|
| Read `~/.ssh/config` | **DENIED** — "access denied by sandbox restrictions" |
| `curl https://example.com` (off-allowlist) | **BLOCKED** — `CONNECT tunnel failed, response 403` |
| `curl https://api.github.com/zen` + in-worktree write + run completion | **ALL WORK** |

2074 tests green (new: default-on semantics, opt-out, detached `--settings` carriage; one stale test updated — it asserted the old opt-in default).

## Risk note

Default-flip means every agent run is now sandboxed. The escape hatches are documented (`SQUADS_SANDBOX=0`), the excluded-commands list covers the known Seatbelt breakages, and non-strict mode keeps Claude Code's graceful degradation for anything unforeseen. Watch the first scheduled runs; flip to strict once a week of runs is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
