### PR TITLE
feat(inbox): squads inbox — everything waiting on a human, one screen (#924)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1195,6 +1195,16 @@ program
     return runsCommand(options);
   });
 
+// Review queue Child 0 (#924): everything waiting on a human, one screen.
+program
+  .command('inbox')
+  .description('Everything waiting on a human decision: open PRs, stranded run branches, unreviewed run output')
+  .option('--json', 'Output as JSON')
+  .action(async (options) => {
+    const { inboxCommand } = await import('./commands/inbox.js');
+    return inboxCommand(options);
+  });
+
 // Executor referee (outcome-driven routing §3.2): quality-per-cost per
 // task class × provider × model, from the execution ledger. Read-only.
 program

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,0 +1,40 @@
+/**
+ * `squads inbox` — everything waiting on a human, in one screen (#924).
+ * Review-queue Child 0: list only; approve/reject/defer land in Child A.
+ */
+import { getProjectRoot } from '../lib/run-utils.js';
+import { buildInbox, type InboxItem } from '../lib/inbox.js';
+import { colors, RESET, bold, writeLine } from '../lib/terminal.js';
+
+const KIND_LABEL: Record<InboxItem['kind'], string> = {
+  pr: 'PR',
+  run_branch: 'BRANCH',
+  run_artifacts: 'RUN',
+};
+
+export async function inboxCommand(options: { json?: boolean }): Promise<void> {
+  const projectRoot = getProjectRoot();
+  const items = buildInbox(projectRoot, projectRoot);
+
+  if (options.json) {
+    writeLine(JSON.stringify({ count: items.length, items }, null, 2));
+    return;
+  }
+
+  writeLine();
+  if (items.length === 0) {
+    writeLine(`  ${colors.green}Inbox zero${RESET} ${colors.dim}— nothing is waiting on a human decision.${RESET}`);
+    writeLine();
+    return;
+  }
+
+  writeLine(`  ${bold}Inbox${RESET} ${colors.dim}— ${items.length} item${items.length > 1 ? 's' : ''} waiting on a human · approve verbs land in the next release${RESET}`);
+  writeLine();
+  for (const item of items) {
+    const age = item.ageDays === 0 ? 'today' : `${item.ageDays}d`;
+    const ageColor = item.ageDays >= 7 ? colors.red : item.ageDays >= 2 ? colors.yellow : colors.dim;
+    writeLine(`  ${colors.cyan}${KIND_LABEL[item.kind].padEnd(6)}${RESET} ${ageColor}${age.padStart(5)}${RESET}  ${item.title}`);
+    writeLine(`         ${colors.dim}yes = ${item.approveSemantics}${item.detail ? ` · ${item.detail}` : ''}${RESET}`);
+  }
+  writeLine();
+}

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -1,0 +1,158 @@
+/**
+ * inbox.ts — one list of everything waiting on a human (#924, review-queue
+ * Child 0; the approval surface of the Loop).
+ *
+ * The last-mile failure this exists to kill: runs complete, deliverables
+ * strand (a brief sat un-merged on a run branch for two weeks because nothing
+ * surfaced it). The inbox derives its items from git/gh/events AT READ TIME —
+ * scanners, not a second state store that can drift. Child 0 is list-only;
+ * the decision verbs (approve/reject/defer) are Child A.
+ */
+
+import { execSync } from 'child_process';
+import { existsSync, readdirSync, statSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { parsePersistedLine } from './event-render.js';
+
+export type InboxKind = 'pr' | 'run_branch' | 'run_artifacts';
+
+export interface InboxItem {
+  /** Stable handle for Child A's decisions: pr-12 | branch-<name> | run-<execId>. */
+  id: string;
+  kind: InboxKind;
+  /** PR url | branch name | execution id. */
+  ref: string;
+  title: string;
+  ageDays: number;
+  /** What saying "yes" concretely does — shown so approval is never a mystery. */
+  approveSemantics: string;
+  detail?: string;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function ageDaysFrom(epochMs: number): number {
+  return Math.max(0, Math.floor((Date.now() - epochMs) / DAY_MS));
+}
+
+function sh(cmd: string, cwd: string): string {
+  return execSync(cmd, { encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: 20_000 });
+}
+
+/** Open PRs to develop in the repo at `repoRoot` (needs gh; empty on failure). */
+export function scanOpenPrs(repoRoot: string): InboxItem[] {
+  try {
+    const raw = sh(`gh pr list --base develop --state open --json number,title,createdAt,url,author --limit 30`, repoRoot);
+    const prs = JSON.parse(raw) as Array<{ number: number; title: string; createdAt: string; url: string; author?: { login?: string; is_bot?: boolean } }>;
+    return prs.map((pr) => ({
+      id: `pr-${pr.number}`,
+      kind: 'pr' as const,
+      ref: pr.url,
+      title: pr.title,
+      ageDays: ageDaysFrom(Date.parse(pr.createdAt)),
+      approveSemantics: 'merge to develop (CI-gated squash)',
+      detail: pr.author?.login ? `by ${pr.author.login}` : undefined,
+    }));
+  } catch {
+    return []; // no gh / not a github repo / offline — the other scanners still run
+  }
+}
+
+/**
+ * Stranded run branches: `squads/run-*` and `agent/*` refs with commits not
+ * reachable from develop (or HEAD when develop doesn't exist) — auto-committed
+ * deliverables (#891) nobody has decided on. THE Argonne case.
+ */
+export function scanStrandedBranches(repoRoot: string): InboxItem[] {
+  const items: InboxItem[] = [];
+  let refs: string;
+  try {
+    refs = sh(`git for-each-ref 'refs/heads/squads/run-*' 'refs/heads/agent/*' --format='%(refname:short)|%(committerdate:unix)|%(subject)'`, repoRoot);
+  } catch {
+    return items;
+  }
+  const base = (() => {
+    try { sh('git rev-parse --verify develop', repoRoot); return 'develop'; } catch { return 'HEAD'; }
+  })();
+  for (const line of refs.split('\n')) {
+    if (!line.trim()) continue;
+    const [branch, epoch, ...subjectParts] = line.split('|');
+    if (!branch) continue;
+    let ahead = 0;
+    try {
+      ahead = parseInt(sh(`git rev-list --count '${branch.replace(/'/g, '')}' ^${base}`, repoRoot).trim(), 10) || 0;
+    } catch { continue; }
+    if (ahead === 0) continue;
+    items.push({
+      id: `branch-${branch}`,
+      kind: 'run_branch',
+      ref: branch,
+      title: (subjectParts.join('|') || branch).slice(0, 90),
+      ageDays: ageDaysFrom((parseInt(epoch, 10) || 0) * 1000),
+      approveSemantics: `open a PR from ${branch} (has ${ahead} unmerged commit${ahead > 1 ? 's' : ''})`,
+      detail: `${ahead} commit(s) ahead of ${base}`,
+    });
+  }
+  return items;
+}
+
+/**
+ * Recent runs whose event stream recorded PR artifacts — output that exists
+ * and may not have landed. Without live resolution this lists them for a
+ * human `squads runs --outcome <id>`; the caller can resolve live (capped).
+ */
+export function scanRunsWithArtifacts(obsRoot: string, limit = 15): InboxItem[] {
+  const eventsDir = join(obsRoot, '.agents', 'observability', 'events');
+  if (!existsSync(eventsDir)) return [];
+  let files: Array<{ id: string; path: string; mtime: number }>;
+  try {
+    files = readdirSync(eventsDir)
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => ({ id: f.replace(/\.jsonl$/, ''), path: join(eventsDir, f), mtime: statSync(join(eventsDir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, limit * 3);
+  } catch {
+    return [];
+  }
+
+  const items: InboxItem[] = [];
+  for (const f of files) {
+    if (items.length >= limit) break;
+    let prRefs: string[];
+    let squad = '';
+    try {
+      const lines = readFileSync(f.path, 'utf8').split('\n').map(parsePersistedLine);
+      prRefs = [];
+      for (const l of lines) {
+        if (!l) continue;
+        if (l.event.type === 'run_start') squad = l.event.squad;
+        if (l.event.type === 'artifact' && l.event.kind === 'pr' && l.event.ref.startsWith('https://')) {
+          if (!prRefs.includes(l.event.ref)) prRefs.push(l.event.ref);
+        }
+      }
+    } catch { continue; }
+    if (prRefs.length === 0) continue;
+    items.push({
+      id: `run-${f.id}`,
+      kind: 'run_artifacts',
+      ref: f.id,
+      title: `${squad || 'run'} produced ${prRefs.length} PR${prRefs.length > 1 ? 's' : ''}`,
+      ageDays: ageDaysFrom(f.mtime),
+      approveSemantics: `check landed state: squads runs --outcome ${f.id}`,
+      detail: prRefs[0],
+    });
+  }
+  return items;
+}
+
+/**
+ * The queue, newest-risk-first: open PRs (oldest = most overdue, first),
+ * then stranded branches (the silent-loss class), then artifact runs.
+ * Scanners are independent; one failing never empties the others.
+ */
+export function buildInbox(repoRoot: string, obsRoot: string): InboxItem[] {
+  const prs = scanOpenPrs(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
+  const branches = scanStrandedBranches(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
+  const runs = scanRunsWithArtifacts(obsRoot).sort((a, b) => b.ageDays - a.ageDays);
+  return [...prs, ...branches, ...runs];
+}

--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -114,6 +114,7 @@
 | `squads update` | Check for and install updates |
 | `squads version` | Show version information |
 | `squads runs` | List live background agent runs (pid-file inventory) |
+| `squads inbox` | Everything waiting on a human decision: open PRs, stranded run branches, unreviewed run output |
 | `squads scoreboard` | Executor quality-per-cost ranking from real runs (read-only, provenance-labeled) |
 | `squads kill [target]` | Stop a background run gracefully (pid, squad, or squad/agent) |
 | `squads commands` | List the live command tree (machine-readable with --json) |

--- a/test/inbox.test.ts
+++ b/test/inbox.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+import { scanStrandedBranches, scanRunsWithArtifacts, buildInbox } from '../src/lib/inbox.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'squads-inbox-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function git(cmd: string): string {
+  return execSync(`git ${cmd}`, { cwd: dir, encoding: 'utf8', env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' } });
+}
+
+function initRepo(): void {
+  git('init -q -b develop');
+  writeFileSync(join(dir, 'a.txt'), 'a');
+  git('add -A');
+  git('commit -qm base');
+}
+
+describe('scanStrandedBranches (#924 — the Argonne case)', () => {
+  it('surfaces squads/run-* branches with commits ahead of develop', () => {
+    initRepo();
+    git('checkout -q -b squads/run-intelligence-xyz');
+    writeFileSync(join(dir, 'briefs.md'), 'deliverable');
+    git('add -A');
+    git('commit -qm "intel brief: argonne"');
+    git('checkout -q develop');
+
+    const items = scanStrandedBranches(dir);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: 'run_branch',
+      ref: 'squads/run-intelligence-xyz',
+    });
+    expect(items[0].title).toContain('argonne');
+    expect(items[0].approveSemantics).toContain('open a PR');
+    expect(items[0].detail).toContain('1 commit(s) ahead');
+  });
+
+  it('ignores run branches already merged (0 ahead) and non-run branches', () => {
+    initRepo();
+    git('checkout -q -b squads/run-merged-1');
+    git('checkout -q develop');       // no commits ahead
+    git('checkout -q -b feature/foo'); // wrong prefix
+    writeFileSync(join(dir, 'b.txt'), 'b');
+    git('add -A');
+    git('commit -qm feat');
+    git('checkout -q develop');
+
+    expect(scanStrandedBranches(dir)).toHaveLength(0);
+  });
+
+  it('non-git directory yields empty, never throws', () => {
+    expect(scanStrandedBranches(dir)).toEqual([]);
+  });
+});
+
+describe('scanRunsWithArtifacts (#924)', () => {
+  it('lists runs whose events carry PR URL artifacts, newest first, deduped', () => {
+    const eventsDir = join(dir, '.agents', 'observability', 'events');
+    mkdirSync(eventsDir, { recursive: true });
+    const line = (runId: string, event: unknown, seq: number) =>
+      JSON.stringify({ v: 1, runId, seq, ts: '2026-07-04T00:00:00Z', event });
+    writeFileSync(join(eventsDir, 'exec_a.jsonl'), [
+      line('exec_a', { type: 'run_start', squad: 'cli', mode: 'background', model: '', role: '', startedAt: 'x' }, 0),
+      line('exec_a', { type: 'artifact', kind: 'pr', ref: 'https://github.com/o/r/pull/1' }, 1),
+      line('exec_a', { type: 'artifact', kind: 'pr', ref: 'https://github.com/o/r/pull/1' }, 2), // dup
+    ].join('\n'));
+    writeFileSync(join(eventsDir, 'exec_b.jsonl'), [
+      line('exec_b', { type: 'run_start', squad: 'demo', mode: 'background', model: '', role: '', startedAt: 'x' }, 0),
+      line('exec_b', { type: 'file_read', path: 'x' }, 1), // no artifacts → excluded
+    ].join('\n'));
+
+    const items = scanRunsWithArtifacts(dir);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ kind: 'run_artifacts', ref: 'exec_a' });
+    expect(items[0].title).toContain('cli produced 1 PR');
+    expect(items[0].approveSemantics).toContain('squads runs --outcome exec_a');
+  });
+
+  it('missing events dir yields empty', () => {
+    expect(scanRunsWithArtifacts(dir)).toEqual([]);
+  });
+});
+
+describe('buildInbox ordering', () => {
+  it('one failing scanner never empties the others', () => {
+    // dir is not a git repo (branch scan fails) and has no gh remote (pr scan
+    // fails) — but events still surface.
+    const eventsDir = join(dir, '.agents', 'observability', 'events');
+    mkdirSync(eventsDir, { recursive: true });
+    writeFileSync(join(eventsDir, 'exec_c.jsonl'), JSON.stringify({
+      v: 1, runId: 'exec_c', seq: 0, ts: '2026-07-04T00:00:00Z',
+      event: { type: 'artifact', kind: 'pr', ref: 'https://github.com/o/r/pull/9' },
+    }));
+    const items = buildInbox(dir, dir);
+    expect(items.some((i) => i.ref === 'exec_c')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #924 (review-queue Child 0 — hq spec `review-queue-2026-07-01.md`; step 3 of the outcome-driven-routing build order). Follows #921 (P1) and #923 (P2).

## What

`squads inbox [--json]` — one screen of everything waiting on a human decision:

1. **Open PRs to develop** (gh scanner; graceful empty on no-gh/offline),
2. **Stranded run branches** — `squads/run-*` / `agent/*` refs with commits ahead of develop/HEAD: the #891 auto-saved deliverables nobody has decided on (the class of silent loss that stranded a deliverable for two weeks),
3. **Runs with recorded PR artifacts** (from the #902 event streams) pointing at `squads runs --outcome <id>` for landed-state.

Each item: kind, age (yellow ≥2d, red ≥7d), title, and **what "yes" concretely does** — approval is never a mystery. Scanners derive at read time (no second state store to drift); one scanner failing never empties the others.

Child 0 is list-only by design — the decision verbs (approve = merge + `outcome: used`; reject = close + write-through to `squads feedback`; defer) are Child A, pending the founder's three open decisions in the spec.

## Live verification (exit criterion)

On the real intelligence repo, the inbox surfaced the known 19-day stranded deliverable branch (red-flagged) **and a second stranded run branch created TODAY** that nothing else had surfaced — the exact failure mode this exists to kill, caught on its first real run.

2080 tests green locally (6 new: stranded-branch detection incl. merged/wrong-prefix exclusion + non-git tolerance, artifact-run scanning with dedup, scanner-independence). CI is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
