### PR TITLE
feat(providers): GLM lane — z.ai Anthropic-compatible endpoint via claude CLI

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -1158,14 +1158,20 @@ export async function executeWithProvider(
   const agentName = options.agentName || 'unknown';
   const timestamp = Date.now();
 
-  // Build clean env: remove CLAUDECODE to allow nesting, pass squad context
+  // Build clean env: remove CLAUDECODE to allow nesting, pass squad context.
+  // Provider env hooks (cliConfig.env) inject endpoint/auth overrides; a key
+  // set to undefined removes the inherited variable from the child env.
   const { CLAUDECODE: _claudeCode, ...cleanEnv } = process.env;
-  const providerEnv = {
+  const providerEnv: NodeJS.ProcessEnv = {
     ...cleanEnv,
+    ...(cliConfig.env?.() ?? {}),
     SQUADS_SQUAD: squadName,
     SQUADS_AGENT: agentName,
     SQUADS_PROVIDER: provider,
   };
+  for (const key of Object.keys(providerEnv)) {
+    if (providerEnv[key] === undefined) delete providerEnv[key];
+  }
 
   // Create isolated worktree for this agent (same pattern as executeWithClaude)
   const branchName = `agent/${squadName}/${agentName}-${timestamp}`;

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -33,6 +33,13 @@ export interface CLIConfig {
    * prints it. Enables observability records for non-anthropic runs (#824).
    */
   parseUsage?: (output: string) => ProviderUsage | null;
+
+  /**
+   * Extra environment for the spawned CLI (e.g. pointing the claude CLI at an
+   * Anthropic-compatible endpoint). A key set to undefined is REMOVED from the
+   * child env — needed when an inherited variable would shadow the injected one.
+   */
+  env?: () => Record<string, string | undefined>;
 }
 
 export interface RunOptions {
@@ -156,6 +163,28 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
       ...aiderMapTokensArgs(),
     ],
     parseUsage: parseAiderUsage,
+  },
+
+  // GLM (z.ai) serves an Anthropic-compatible endpoint, so the claude CLI is
+  // the agentic harness: point it at z.ai and auth with GLM_API_KEY.
+  // ANTHROPIC_API_KEY is removed so an inherited key can't shadow the token.
+  glm: {
+    provider: 'glm',
+    displayName: 'GLM (z.ai via claude)',
+    command: 'claude',
+    install: 'npm i -g @anthropic-ai/claude-code, then set GLM_API_KEY',
+    buildArgs: (prompt, opts) => [
+      '--print',
+      '--model',
+      opts?.model || process.env.GLM_MODEL || 'glm-4.7',
+      prompt,
+    ],
+    env: () => ({
+      ANTHROPIC_BASE_URL: process.env.GLM_BASE_URL || 'https://api.z.ai/api/anthropic',
+      ANTHROPIC_AUTH_TOKEN: process.env.GLM_API_KEY,
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_MODEL: undefined,
+    }),
   },
 
   mistral: {

--- a/test/llm-usage.test.ts
+++ b/test/llm-usage.test.ts
@@ -56,3 +56,41 @@ describe('aider map-tokens knob (#845)', () => {
     expect(LLM_CLIS.deepseek.buildArgs('hi')).not.toContain('--map-tokens');
   });
 });
+
+describe('glm lane (#926 — z.ai Anthropic-compatible endpoint via claude CLI)', () => {
+  afterEach(() => {
+    delete process.env.GLM_API_KEY;
+    delete process.env.GLM_BASE_URL;
+    delete process.env.GLM_MODEL;
+  });
+
+  it('delegates to the claude CLI in non-interactive print mode', () => {
+    expect(LLM_CLIS.glm.command).toBe('claude');
+    const args = LLM_CLIS.glm.buildArgs('do the thing');
+    expect(args[0]).toBe('--print');
+    expect(args).toContain('do the thing');
+  });
+
+  it('defaults the model and honors override precedence (opts > GLM_MODEL)', () => {
+    expect(LLM_CLIS.glm.buildArgs('hi')).toContain('glm-4.7');
+    process.env.GLM_MODEL = 'glm-4.6';
+    expect(LLM_CLIS.glm.buildArgs('hi')).toContain('glm-4.6');
+    expect(LLM_CLIS.glm.buildArgs('hi', { model: 'glm-4.7-air' })).toContain('glm-4.7-air');
+  });
+
+  it('maps GLM_API_KEY to ANTHROPIC_AUTH_TOKEN and removes shadowing vars', () => {
+    process.env.GLM_API_KEY = 'zai-test-key';
+    const env = LLM_CLIS.glm.env!();
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://api.z.ai/api/anthropic');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('zai-test-key');
+    // undefined = the runner must DELETE these from the child env, or an
+    // inherited ANTHROPIC_API_KEY silently routes the run to Anthropic
+    expect(env).toHaveProperty('ANTHROPIC_API_KEY', undefined);
+    expect(env).toHaveProperty('ANTHROPIC_MODEL', undefined);
+  });
+
+  it('honors GLM_BASE_URL override', () => {
+    process.env.GLM_BASE_URL = 'https://proxy.example/anthropic';
+    expect(LLM_CLIS.glm.env!().ANTHROPIC_BASE_URL).toBe('https://proxy.example/anthropic');
+  });
+});


### PR DESCRIPTION
## Summary
Registers a `glm` executor lane: the `claude` CLI acts as the agentic harness for GLM models by pointing at z.ai's Anthropic-compatible endpoint. Third fallback engine alongside the Anthropic and DeepSeek lanes; the scoreboard already maps `glm` model strings to this lane.

## Changes
- `CLIConfig.env?()` — optional per-provider environment hook; a key set to `undefined` is **deleted** from the child env (needed so an inherited `ANTHROPIC_API_KEY` can't silently route a GLM run back to Anthropic).
- `glm` registry entry — `claude --print` with `ANTHROPIC_BASE_URL` (default `https://api.z.ai/api/anthropic`, override `GLM_BASE_URL`) + `ANTHROPIC_AUTH_TOKEN` from `GLM_API_KEY`; model default `glm-4.7`, override via `--model`/`GLM_MODEL`.
- `executeWithProvider` spreads the hook into `providerEnv` and strips `undefined` keys — covers both foreground and background spawn paths.
- 4 new tests (entry shape, model precedence, env mapping/removal, base-URL override).

## Testing
- [x] `npx tsc --noEmit` + `npm run build` pass
- [x] `test/llm-usage.test.ts` 12/12 pass (8 existing + 4 new)
- [x] Endpoint + auth verified live with a direct request (reached z.ai, got its balance response)
- [ ] Full agentic smoke dispatch pending account credit — note: z.ai encodes insufficient balance as `rate_limit_error`, which the claude CLI retries with backoff, so an unfunded run hangs until the watchdog rather than failing fast

Closes #926