### PR TITLE
fix(sandbox): follow gitdir pointer when .git is a linked-worktree file

### DIFF
--- a/src/lib/sandbox-settings.ts
+++ b/src/lib/sandbox-settings.ts
@@ -21,8 +21,9 @@
  * managed settings — tracked for the real-run smoke.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { dirname, isAbsolute, join } from 'path';
+import { tmpdir } from 'os';
 
 export interface SandboxSettingsOptions {
   /** Worktree/project root — the agent's write root. */
@@ -108,10 +109,29 @@ export function readGuardrailPermissions(guardrailPath: string | undefined): unk
   }
 }
 
-/** Write the merged settings to a temp file and return its path (for --settings). */
+/**
+ * Write the merged settings to a temp file and return its path (for --settings).
+ *
+ * Callers pass `<repoRoot>/.git` so the file never dirties the working tree.
+ * In a LINKED WORKTREE `.git` is a file (a `gitdir:` pointer), not a directory —
+ * mkdir on it throws EEXIST and killed every conversation-mode run (#931).
+ * Follow the pointer to the real per-worktree git dir; on any failure fall
+ * back to a tmpdir rather than take the spawn down.
+ */
 export function writeSandboxSettingsFile(settings: Record<string, unknown>, dir: string): string {
-  mkdirSync(dir, { recursive: true });
-  const path = join(dir, 'squads-sandbox-settings.json');
+  let target = dir;
+  try {
+    if (existsSync(dir) && !statSync(dir).isDirectory()) {
+      const pointer = readFileSync(dir, 'utf-8').match(/^gitdir:\s*(.+)\s*$/m);
+      if (!pointer) throw new Error(`${dir} exists but is not a directory or gitdir pointer`);
+      const gitDir = pointer[1].trim();
+      target = isAbsolute(gitDir) ? gitDir : join(dirname(dir), gitDir);
+    }
+    mkdirSync(target, { recursive: true });
+  } catch {
+    target = mkdtempSync(join(tmpdir(), 'squads-sandbox-'));
+  }
+  const path = join(target, 'squads-sandbox-settings.json');
   writeFileSync(path, JSON.stringify(settings, null, 2));
   return path;
 }

--- a/test/lib/workflow.test.ts
+++ b/test/lib/workflow.test.ts
@@ -43,6 +43,10 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
   appendFileSync: vi.fn(),
+  // writeSandboxSettingsFile (#931) stats the .git target and falls back to a
+  // tmpdir on failure — treat the mocked path as a plain directory.
+  statSync: vi.fn().mockReturnValue({ isDirectory: () => true }),
+  mkdtempSync: vi.fn().mockReturnValue('/mock/tmp/squads-sandbox-x'),
 }));
 
 // Mock child_process before import — workflow.ts uses spawn for agent execution

--- a/test/sandbox-settings.test.ts
+++ b/test/sandbox-settings.test.ts
@@ -74,6 +74,30 @@ describe('file I/O (the path the ESM-require bug broke at runtime)', () => {
     expect((parsed.sandbox as { enabled: boolean }).enabled).toBe(true);
   });
 
+  it('follows the gitdir pointer when .git is a linked-worktree FILE (#931)', () => {
+    const wt = mkdtempSync(join(tmpdir(), 'sbx-wt-'));
+    const realGitDir = mkdtempSync(join(tmpdir(), 'sbx-gitdir-'));
+    writeFileSync(join(wt, '.git'), `gitdir: ${realGitDir}\n`);
+    const path = writeSandboxSettingsFile(buildSandboxSettings({ cwd: wt }), join(wt, '.git'));
+    expect(path.startsWith(realGitDir)).toBe(true);
+    expect(JSON.parse(readFileSync(path, 'utf-8'))).toBeTruthy();
+  });
+
+  it('resolves a RELATIVE gitdir pointer against the worktree root', () => {
+    const wt = mkdtempSync(join(tmpdir(), 'sbx-rel-'));
+    writeFileSync(join(wt, '.git'), 'gitdir: sub/gitdir\n');
+    const path = writeSandboxSettingsFile(buildSandboxSettings({ cwd: wt }), join(wt, '.git'));
+    expect(path.startsWith(join(wt, 'sub', 'gitdir'))).toBe(true);
+  });
+
+  it('falls back to a tmpdir instead of throwing when .git is garbage (#931)', () => {
+    const wt = mkdtempSync(join(tmpdir(), 'sbx-bad-'));
+    writeFileSync(join(wt, '.git'), 'not a pointer');
+    const path = writeSandboxSettingsFile(buildSandboxSettings({ cwd: wt }), join(wt, '.git'));
+    expect(path.includes('squads-sandbox-')).toBe(true);
+    expect(JSON.parse(readFileSync(path, 'utf-8'))).toBeTruthy();
+  });
+
   it('readGuardrailHooks pulls .hooks out of a settings file (and is safe on missing)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'gr-'));
     const p = join(dir, 'guardrail.json');


### PR DESCRIPTION
## Summary
P0 regression from #923 (sandbox default-on): every `squads run <squad> --task` died at spawn with `EEXIST: mkdir '<worktree>/.git'` because the sandbox settings file is parked inside `.git/` — a directory in the main checkout, but a **file** (gitdir pointer) in the per-run linked worktree that conversation mode creates.

## Changes
- `writeSandboxSettingsFile`: if the target `.git` exists as a file, read its `gitdir:` pointer (absolute or relative) and write into the real per-worktree git dir — same invisible-to-the-tree property; on any failure fall back to `mkdtemp` instead of throwing into the spawn.
- 3 new tests: absolute pointer, relative pointer, garbage-pointer fallback.

## Testing
- [x] `tsc --noEmit` + sandbox suite 13/13
- [x] Reproduced the failure live (first [internal] cadence dispatch), stack pointed at `sandbox-settings.ts:113`

Fixes #931