### PR TITLE
feat(inbox): approve / reject / defer verbs + decisions ledger (review-queue Child A)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1195,14 +1195,17 @@ program
     return runsCommand(options);
   });
 
-// Review queue Child 0 (#924): everything waiting on a human, one screen.
+// Review queue (#924 list, #933 decision verbs): everything waiting on a
+// human, one screen — and the three things a human can say to each item.
 program
-  .command('inbox')
-  .description('Everything waiting on a human decision: open PRs, stranded run branches, unreviewed run output')
+  .command('inbox [action] [id]')
+  .description('Everything waiting on a human decision — list, or approve/reject/defer <id>')
   .option('--json', 'Output as JSON')
-  .action(async (options) => {
+  .option('--reason <text>', 'Why (required for reject; written through to squads feedback)')
+  .option('--days <n>', 'Defer window in days (default 7)')
+  .action(async (action, id, options) => {
     const { inboxCommand } = await import('./commands/inbox.js');
-    return inboxCommand(options);
+    return inboxCommand(action, id, options);
   });
 
 // Executor referee (outcome-driven routing §3.2): quality-per-cost per

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,9 +1,15 @@
 /**
- * `squads inbox` — everything waiting on a human, in one screen (#924).
- * Review-queue Child 0: list only; approve/reject/defer land in Child A.
+ * `squads inbox` — everything waiting on a human, in one screen (#924), and
+ * the three decision verbs (#933, review-queue Child A):
+ *
+ *   squads inbox                       list what's waiting
+ *   squads inbox approve <id>          execute the item's approve semantics
+ *   squads inbox reject <id> --reason  close/archive + write-through to feedback
+ *   squads inbox defer <id> [--days N] snooze; resurfaces automatically
  */
 import { getProjectRoot } from '../lib/run-utils.js';
 import { buildInbox, type InboxItem } from '../lib/inbox.js';
+import { approveItem, rejectItem, deferItem, type DecisionOutcome } from '../lib/inbox-decisions.js';
 import { colors, RESET, bold, writeLine } from '../lib/terminal.js';
 
 const KIND_LABEL: Record<InboxItem['kind'], string> = {
@@ -12,8 +18,68 @@ const KIND_LABEL: Record<InboxItem['kind'], string> = {
   run_artifacts: 'RUN',
 };
 
-export async function inboxCommand(options: { json?: boolean }): Promise<void> {
+const VERBS = new Set(['approve', 'reject', 'defer']);
+
+export interface InboxOptions {
+  json?: boolean;
+  reason?: string;
+  days?: string;
+}
+
+export async function inboxCommand(action?: string, id?: string, options: InboxOptions = {}): Promise<void> {
   const projectRoot = getProjectRoot();
+
+  if (!action) {
+    return listInbox(projectRoot, options);
+  }
+  if (!VERBS.has(action)) {
+    writeLine(`  ${colors.red}Unknown inbox action '${action}'${RESET} ${colors.dim}— use approve | reject | defer (or no action to list)${RESET}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!id) {
+    writeLine(`  ${colors.red}Missing item id${RESET} ${colors.dim}— run 'squads inbox' to see ids (pr-12, branch-…, run-…)${RESET}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // Verbs must see deferred items too (so a snoozed item can be decided early).
+  const items = buildInbox(projectRoot, projectRoot, { includeDeferred: true });
+  const item = items.find((i) => i.id === id);
+  if (!item) {
+    writeLine(`  ${colors.red}No inbox item '${id}'${RESET}`);
+    if (items.length > 0) {
+      writeLine(`  ${colors.dim}available: ${items.map((i) => i.id).join(', ')}${RESET}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const ctx = { repoRoot: projectRoot, obsRoot: projectRoot };
+  let outcome: DecisionOutcome;
+  if (action === 'approve') {
+    outcome = approveItem(item, ctx);
+  } else if (action === 'reject') {
+    if (!options.reason) {
+      writeLine(`  ${colors.red}reject needs --reason${RESET} ${colors.dim}— the reason writes through to squads feedback so the squad learns from it${RESET}`);
+      process.exitCode = 1;
+      return;
+    }
+    outcome = rejectItem(item, options.reason, ctx);
+  } else {
+    outcome = deferItem(item, parseInt(options.days ?? '7', 10), ctx);
+  }
+
+  if (options.json) {
+    writeLine(JSON.stringify({ id: item.id, action, ...outcome }, null, 2));
+  } else {
+    const mark = outcome.ok ? `${colors.green}✓${RESET}` : `${colors.red}✗${RESET}`;
+    writeLine(`  ${mark} ${action} ${colors.cyan}${item.id}${RESET} ${colors.dim}— ${outcome.message}${RESET}`);
+  }
+  if (!outcome.ok) process.exitCode = 1;
+}
+
+function listInbox(projectRoot: string, options: InboxOptions): void {
   const items = buildInbox(projectRoot, projectRoot);
 
   if (options.json) {
@@ -28,12 +94,12 @@ export async function inboxCommand(options: { json?: boolean }): Promise<void> {
     return;
   }
 
-  writeLine(`  ${bold}Inbox${RESET} ${colors.dim}— ${items.length} item${items.length > 1 ? 's' : ''} waiting on a human · approve verbs land in the next release${RESET}`);
+  writeLine(`  ${bold}Inbox${RESET} ${colors.dim}— ${items.length} item${items.length > 1 ? 's' : ''} waiting · squads inbox approve|reject|defer <id>${RESET}`);
   writeLine();
   for (const item of items) {
     const age = item.ageDays === 0 ? 'today' : `${item.ageDays}d`;
     const ageColor = item.ageDays >= 7 ? colors.red : item.ageDays >= 2 ? colors.yellow : colors.dim;
-    writeLine(`  ${colors.cyan}${KIND_LABEL[item.kind].padEnd(6)}${RESET} ${ageColor}${age.padStart(5)}${RESET}  ${item.title}`);
+    writeLine(`  ${colors.cyan}${KIND_LABEL[item.kind].padEnd(6)}${RESET} ${ageColor}${age.padStart(5)}${RESET}  ${colors.dim}${item.id}${RESET}  ${item.title}`);
     writeLine(`         ${colors.dim}yes = ${item.approveSemantics}${item.detail ? ` · ${item.detail}` : ''}${RESET}`);
   }
   writeLine();

--- a/src/lib/feedback-store.ts
+++ b/src/lib/feedback-store.ts
@@ -1,0 +1,42 @@
+/**
+ * feedback-store.ts — append an entry to a squad's feedback log from library
+ * code (no UI, no telemetry). Same file + format as `squads feedback add`
+ * (src/commands/feedback.ts) so the context loader picks both up identically;
+ * the command keeps its richer interactive flow.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { findMemoryDir } from './memory.js';
+import { loadSquad } from './squad-parser.js';
+
+export function feedbackPathFor(squadName: string): string | null {
+  const memoryDir = findMemoryDir();
+  if (!memoryDir) return null;
+  const squad = loadSquad(squadName);
+  const agentName = squad?.agents[0]?.name || `${squadName}-lead`;
+  return join(memoryDir, squadName, agentName, 'feedback.md');
+}
+
+/** Append one feedback entry; false when no memory dir / unknown squad. */
+export function appendFeedbackEntry(squadName: string, rating: number, feedback: string): boolean {
+  const path = feedbackPathFor(squadName);
+  if (!path) return false;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const clamped = Math.min(5, Math.max(1, Math.round(rating)));
+    const date = new Date().toISOString().split('T')[0];
+    const entry =
+      `\n---\n_Date: ${date}_\n\n` +
+      `**Execution**: squads inbox decision\n` +
+      `**Rating**: ${clamped}/5 ${'★'.repeat(clamped)}${'☆'.repeat(5 - clamped)}\n` +
+      `**Feedback**: ${feedback}\n`;
+    const existing = existsSync(path)
+      ? readFileSync(path, 'utf-8')
+      : `# ${squadName} - Feedback Log\n\n> Execution feedback and learnings\n`;
+    writeFileSync(path, existing + entry);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/inbox-decisions.ts
+++ b/src/lib/inbox-decisions.ts
@@ -1,0 +1,276 @@
+/**
+ * inbox-decisions.ts — the decision verbs of the review queue (#933, Child A).
+ *
+ * Founder decisions locked 2026-07-05 (hq spec review-queue-2026-07-01.md):
+ *   1. approve authority = the EXISTING auto-merge path (CI-gated `--auto`);
+ *      the inbox changes discovery, not authority.
+ *   2. reject on a branch = archive tag, THEN delete — refs stay clean,
+ *      nothing is unrecoverable.
+ *   3. v1 scope = PRs + run branches; run_artifacts items stay pointers.
+ *
+ * Decisions land in an append-only ledger (`reviewed.jsonl`) next to
+ * `executions.jsonl`. Sources remain scanners — the ledger records only what
+ * a human decided, never queue state that could drift.
+ */
+
+import { execSync } from 'child_process';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import type { InboxItem } from './inbox.js';
+import { appendFeedbackEntry } from './feedback-store.js';
+
+/** Injectable command runner so tests never hit gh/network. */
+export type CommandRunner = (cmd: string, cwd: string) => string;
+
+const defaultRun: CommandRunner = (cmd, cwd) =>
+  execSync(cmd, { encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'], timeout: 60_000 });
+
+export interface InboxDecisionRecord {
+  v: 1;
+  ts: string;
+  id: string;
+  kind: InboxItem['kind'];
+  ref: string;
+  decision: 'approve' | 'reject' | 'defer';
+  /** Rejection reason (written through to squads feedback) / defer note. */
+  reason?: string;
+  /** Defer expiry (ISO); the list hides the item until then. */
+  until?: string;
+  /** What concretely happened (merge queued / tag created / PR closed). */
+  result: string;
+}
+
+export interface DecisionContext {
+  repoRoot: string;
+  obsRoot: string;
+  run?: CommandRunner;
+  /** Injectable feedback write-through (defaults to squads feedback append). */
+  feedbackWriter?: (squad: string, rating: number, text: string) => boolean;
+}
+
+export interface DecisionOutcome {
+  ok: boolean;
+  message: string;
+}
+
+export function reviewedLedgerPath(obsRoot: string): string {
+  return join(obsRoot, '.agents', 'observability', 'reviewed.jsonl');
+}
+
+export function readDecisions(obsRoot: string): InboxDecisionRecord[] {
+  const path = reviewedLedgerPath(obsRoot);
+  if (!existsSync(path)) return [];
+  const records: InboxDecisionRecord[] = [];
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const rec = JSON.parse(line) as InboxDecisionRecord;
+      if (rec && rec.v === 1 && rec.id && rec.decision) records.push(rec);
+    } catch {
+      // a corrupt line never takes the ledger down
+    }
+  }
+  return records;
+}
+
+export function recordDecision(obsRoot: string, rec: InboxDecisionRecord): void {
+  const path = reviewedLedgerPath(obsRoot);
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, JSON.stringify(rec) + '\n');
+}
+
+/**
+ * Item ids currently snoozed: the LATEST decision for the id is a defer whose
+ * `until` is still in the future. An approve/reject after a defer un-snoozes.
+ */
+export function activeDeferrals(obsRoot: string, now = Date.now()): Set<string> {
+  const latest = new Map<string, InboxDecisionRecord>();
+  for (const rec of readDecisions(obsRoot)) latest.set(rec.id, rec);
+  const deferred = new Set<string>();
+  for (const [id, rec] of latest) {
+    if (rec.decision === 'defer' && rec.until && Date.parse(rec.until) > now) deferred.add(id);
+  }
+  return deferred;
+}
+
+/** `squads/run-<squad>-<runId>-<n>` or `agent/<squad>/<agent>-<ts>` → squad. */
+export function squadFromBranch(branch: string): string | undefined {
+  const agentMatch = branch.match(/^agent\/([^/]+)\//);
+  if (agentMatch) return agentMatch[1];
+  const runMatch = branch.match(/^squads\/run-(.+)-[a-z0-9]+-\d+$/);
+  if (runMatch) return runMatch[1];
+  return undefined;
+}
+
+function shq(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function remoteHasBranch(branch: string, repoRoot: string, run: CommandRunner): boolean {
+  try {
+    return run(`git ls-remote --heads origin ${shq(branch)}`, repoRoot).trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function repoHasDevelop(repoRoot: string, run: CommandRunner): boolean {
+  try {
+    run('git rev-parse --verify --quiet origin/develop', repoRoot);
+    return true;
+  } catch {
+    try {
+      run('git rev-parse --verify --quiet develop', repoRoot);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * approve — executes the item's approve semantics through the EXISTING paths:
+ *  - pr: queue the CI-gated auto-merge (`gh pr merge --squash --delete-branch
+ *    --auto`); when the repo has no auto-merge (no protection), fall back to a
+ *    plain squash merge — CI wasn't gating there anyway.
+ *  - run_branch: push if needed, open a PR from the branch, queue auto-merge.
+ *  - run_artifacts: not a v1 verb — those items are pointers to `runs --outcome`.
+ */
+export function approveItem(item: InboxItem, ctx: DecisionContext): DecisionOutcome {
+  const run = ctx.run ?? defaultRun;
+  let outcome: DecisionOutcome;
+
+  if (item.kind === 'pr') {
+    const number = item.id.replace(/^pr-/, '');
+    outcome = mergePr(number, item.ref, ctx.repoRoot, run);
+  } else if (item.kind === 'run_branch') {
+    outcome = approveBranch(item.ref, ctx.repoRoot, run);
+  } else {
+    return {
+      ok: false,
+      message: `run items are pointers, not approvables (v1 = PRs + branches) — inspect with: squads runs --outcome ${item.ref}`,
+    };
+  }
+
+  recordDecision(ctx.obsRoot, {
+    v: 1, ts: new Date().toISOString(), id: item.id, kind: item.kind, ref: item.ref,
+    decision: 'approve', result: outcome.message,
+  });
+  return outcome;
+}
+
+function mergePr(number: string, url: string, repoRoot: string, run: CommandRunner): DecisionOutcome {
+  try {
+    run(`gh pr merge ${shq(number)} --squash --delete-branch --auto`, repoRoot);
+    return { ok: true, message: `auto-merge queued (CI-gated) for ${url}` };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/auto.?merge is not allowed/i.test(msg)) {
+      try {
+        run(`gh pr merge ${shq(number)} --squash --delete-branch`, repoRoot);
+        return { ok: true, message: `merged ${url} (repo has no auto-merge; plain squash)` };
+      } catch (e2) {
+        return { ok: false, message: `merge failed: ${e2 instanceof Error ? e2.message : String(e2)}` };
+      }
+    }
+    return { ok: false, message: `merge failed: ${msg}` };
+  }
+}
+
+function approveBranch(branch: string, repoRoot: string, run: CommandRunner): DecisionOutcome {
+  try {
+    if (!remoteHasBranch(branch, repoRoot, run)) {
+      run(`git push -u origin ${shq(branch)}`, repoRoot);
+    }
+    const base = repoHasDevelop(repoRoot, run) ? 'develop' : '';
+    const baseFlag = base ? `--base ${base} ` : '';
+    const url = run(
+      `gh pr create ${baseFlag}--head ${shq(branch)} --title ${shq(`land stranded run deliverable: ${branch}`)} --body ${shq('Landed via `squads inbox approve` (review-queue Child A, #933). Auto-committed run deliverable (#875) a human decided to keep.')}`,
+      repoRoot,
+    ).trim().split('\n').pop() ?? '';
+    const prNumber = url.match(/\/pull\/(\d+)/)?.[1];
+    if (prNumber) {
+      const merge = mergePr(prNumber, url, repoRoot, run);
+      return { ok: merge.ok, message: `PR opened from ${branch}: ${url} — ${merge.message}` };
+    }
+    return { ok: true, message: `PR opened from ${branch}: ${url}` };
+  } catch (e) {
+    return { ok: false, message: `could not land ${branch}: ${e instanceof Error ? e.message : String(e)}` };
+  }
+}
+
+/**
+ * reject — closes/archives the artifact AND writes the reason through to
+ * `squads feedback`, so the squad's next context injection carries the
+ * correction (this write-through is what makes rejection cheap, not wasteful).
+ *  - pr: close with the reason as a comment, delete the head branch.
+ *  - run_branch: tag `archive/<branch>` (recoverable forever), then delete
+ *    local + best-effort remote.
+ */
+export function rejectItem(item: InboxItem, reason: string, ctx: DecisionContext): DecisionOutcome {
+  const run = ctx.run ?? defaultRun;
+  let outcome: DecisionOutcome;
+  let squad: string | undefined;
+
+  if (item.kind === 'pr') {
+    const number = item.id.replace(/^pr-/, '');
+    try {
+      run(`gh pr close ${shq(number)} --comment ${shq(`Rejected via squads inbox: ${reason}`)} --delete-branch`, ctx.repoRoot);
+      outcome = { ok: true, message: `closed ${item.ref} (reason recorded)` };
+    } catch (e) {
+      outcome = { ok: false, message: `close failed: ${e instanceof Error ? e.message : String(e)}` };
+    }
+  } else if (item.kind === 'run_branch') {
+    squad = squadFromBranch(item.ref);
+    outcome = archiveBranch(item.ref, ctx.repoRoot, run);
+  } else {
+    return {
+      ok: false,
+      message: `run items are pointers, not rejectables (v1 = PRs + branches) — inspect with: squads runs --outcome ${item.ref}`,
+    };
+  }
+
+  if (outcome.ok && squad) {
+    const writer = ctx.feedbackWriter ?? appendFeedbackEntry;
+    const wrote = writer(squad, 2, `inbox reject (${item.ref}): ${reason}`);
+    if (!wrote) outcome = { ok: true, message: `${outcome.message} · feedback write-through skipped (no memory dir for '${squad}')` };
+  }
+
+  recordDecision(ctx.obsRoot, {
+    v: 1, ts: new Date().toISOString(), id: item.id, kind: item.kind, ref: item.ref,
+    decision: 'reject', reason, result: outcome.message,
+  });
+  return outcome;
+}
+
+function archiveBranch(branch: string, repoRoot: string, run: CommandRunner): DecisionOutcome {
+  const tag = `archive/${branch}`;
+  try {
+    run(`git tag ${shq(tag)} ${shq(branch)}`, repoRoot);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (!/already exists/i.test(msg)) return { ok: false, message: `archive tag failed (branch kept): ${msg}` };
+  }
+  // Best-effort remote archive + delete — a local-only branch is fine.
+  if (remoteHasBranch(branch, repoRoot, run)) {
+    try { run(`git push origin ${shq(tag)}`, repoRoot); } catch { /* tag may exist remotely */ }
+    try { run(`git push origin --delete ${shq(branch)}`, repoRoot); } catch { /* remote delete is best-effort */ }
+  }
+  try {
+    run(`git branch -D ${shq(branch)}`, repoRoot);
+  } catch (e) {
+    return { ok: false, message: `archived as ${tag} but local delete failed: ${e instanceof Error ? e.message : String(e)}` };
+  }
+  return { ok: true, message: `archived as tag ${tag}, branch deleted (recover: git checkout -b ${branch} ${tag})` };
+}
+
+/** defer — snooze the item; it resurfaces after `days` (ledger-only, nothing mutated). */
+export function deferItem(item: InboxItem, days: number, ctx: DecisionContext): DecisionOutcome {
+  const d = Number.isFinite(days) && days > 0 ? days : 7;
+  const until = new Date(Date.now() + d * 24 * 60 * 60 * 1000).toISOString();
+  recordDecision(ctx.obsRoot, {
+    v: 1, ts: new Date().toISOString(), id: item.id, kind: item.kind, ref: item.ref,
+    decision: 'defer', until, result: `snoozed ${d}d (resurfaces ${until.slice(0, 10)})`,
+  });
+  return { ok: true, message: `deferred ${d}d — resurfaces ${until.slice(0, 10)}` };
+}

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 import { existsSync, readdirSync, statSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { parsePersistedLine } from './event-render.js';
+import { activeDeferrals } from './inbox-decisions.js';
 
 export type InboxKind = 'pr' | 'run_branch' | 'run_artifacts';
 
@@ -149,10 +150,17 @@ export function scanRunsWithArtifacts(obsRoot: string, limit = 15): InboxItem[] 
  * The queue, newest-risk-first: open PRs (oldest = most overdue, first),
  * then stranded branches (the silent-loss class), then artifact runs.
  * Scanners are independent; one failing never empties the others.
+ *
+ * Actively-deferred items (Child A, #933) are hidden until their snooze
+ * expires — approve/reject decisions are NOT filtered here: an approved PR
+ * that is somehow still open should stay in your face, not vanish.
  */
-export function buildInbox(repoRoot: string, obsRoot: string): InboxItem[] {
+export function buildInbox(repoRoot: string, obsRoot: string, opts?: { includeDeferred?: boolean }): InboxItem[] {
   const prs = scanOpenPrs(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
   const branches = scanStrandedBranches(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
   const runs = scanRunsWithArtifacts(obsRoot).sort((a, b) => b.ageDays - a.ageDays);
-  return [...prs, ...branches, ...runs];
+  const all = [...prs, ...branches, ...runs];
+  if (opts?.includeDeferred) return all;
+  const deferred = activeDeferrals(obsRoot);
+  return deferred.size === 0 ? all : all.filter((i) => !deferred.has(i.id));
 }

--- a/test/inbox-decisions.test.ts
+++ b/test/inbox-decisions.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execSync } from 'child_process';
+import { scanStrandedBranches, buildInbox, type InboxItem } from '../src/lib/inbox.js';
+import {
+  approveItem, rejectItem, deferItem, readDecisions, activeDeferrals,
+  squadFromBranch, reviewedLedgerPath, type CommandRunner,
+} from '../src/lib/inbox-decisions.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'squads-inboxdec-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+function git(cmd: string): string {
+  return execSync(`git ${cmd}`, { cwd: dir, encoding: 'utf8', env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' } });
+}
+
+function initRepoWithStrandedBranch(branch = 'squads/run-intelligence-abc123-0'): InboxItem {
+  git('init -q -b develop');
+  writeFileSync(join(dir, 'a.txt'), 'a');
+  git('add -A');
+  git('commit -qm base');
+  git(`checkout -q -b '${branch}'`);
+  writeFileSync(join(dir, 'brief.md'), 'deliverable');
+  git('add -A');
+  git('commit -qm "intel brief"');
+  git('checkout -q develop');
+  const items = scanStrandedBranches(dir);
+  expect(items).toHaveLength(1);
+  return items[0];
+}
+
+/** Runner that answers gh/ls-remote calls from a script and records everything. */
+function fakeRunner(responses: Record<string, string | Error> = {}): { run: CommandRunner; calls: string[] } {
+  const calls: string[] = [];
+  const run: CommandRunner = (cmd, cwd) => {
+    calls.push(cmd);
+    for (const [prefix, resp] of Object.entries(responses)) {
+      if (cmd.startsWith(prefix)) {
+        if (resp instanceof Error) throw resp;
+        return resp;
+      }
+    }
+    // Git commands run for real (temp repo); anything else defaults to empty.
+    if (cmd.startsWith('git ')) return execSync(cmd, { encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    return '';
+  };
+  return { run, calls };
+}
+
+describe('squadFromBranch', () => {
+  it('extracts the squad from run and agent branch shapes (hyphenated squads too)', () => {
+    expect(squadFromBranch('squads/run-intelligence-mr6ceiap-0')).toBe('intelligence');
+    expect(squadFromBranch('squads/run-design-system-xy12ab-3')).toBe('design-system');
+    expect(squadFromBranch('agent/cli/issue-solver-1772760575482')).toBe('cli');
+    expect(squadFromBranch('feature/unrelated')).toBeUndefined();
+  });
+});
+
+describe('ledger (reviewed.jsonl)', () => {
+  it('records decisions append-only and survives a corrupt line', () => {
+    const item = initRepoWithStrandedBranch();
+    deferItem(item, 3, { repoRoot: dir, obsRoot: dir });
+    writeFileSync(reviewedLedgerPath(dir), readFileSync(reviewedLedgerPath(dir), 'utf8') + 'not json\n');
+    deferItem(item, 5, { repoRoot: dir, obsRoot: dir });
+    const decisions = readDecisions(dir);
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'defer')).toBe(true);
+  });
+});
+
+describe('defer', () => {
+  it('hides the item from buildInbox until the snooze expires; verbs still see it', () => {
+    const item = initRepoWithStrandedBranch();
+    expect(buildInbox(dir, dir).map((i) => i.id)).toContain(item.id);
+
+    const out = deferItem(item, 7, { repoRoot: dir, obsRoot: dir });
+    expect(out.ok).toBe(true);
+    expect(buildInbox(dir, dir).map((i) => i.id)).not.toContain(item.id);
+    expect(buildInbox(dir, dir, { includeDeferred: true }).map((i) => i.id)).toContain(item.id);
+
+    // Expired snooze resurfaces (evaluate deferrals as-of the future).
+    expect(activeDeferrals(dir, Date.now() + 8 * 24 * 3600 * 1000).has(item.id)).toBe(false);
+  });
+
+  it('a later decision supersedes the defer', () => {
+    const item = initRepoWithStrandedBranch();
+    deferItem(item, 7, { repoRoot: dir, obsRoot: dir });
+    const { run } = fakeRunner({ 'git ls-remote': '' });
+    rejectItem(item, 'superseded', { repoRoot: dir, obsRoot: dir, run, feedbackWriter: () => true });
+    expect(activeDeferrals(dir).has(item.id)).toBe(false);
+  });
+});
+
+describe('reject (decision 2: archive tag, then delete)', () => {
+  it('tags archive/<branch>, deletes the branch, writes feedback through, records the decision', () => {
+    const item = initRepoWithStrandedBranch('squads/run-intelligence-abc123-0');
+    const feedback: string[] = [];
+    const { run } = fakeRunner({ 'git ls-remote': '' }); // no origin
+    const out = rejectItem(item, 'scratch binary, not a deliverable', {
+      repoRoot: dir, obsRoot: dir, run,
+      feedbackWriter: (squad, rating, text) => { feedback.push(`${squad}|${rating}|${text}`); return true; },
+    });
+    expect(out.ok).toBe(true);
+    expect(git('tag -l "archive/*"')).toContain('archive/squads/run-intelligence-abc123-0');
+    expect(git('branch --list "squads/*"').trim()).toBe('');
+    expect(feedback).toHaveLength(1);
+    expect(feedback[0]).toContain('intelligence|2|');
+    expect(feedback[0]).toContain('scratch binary');
+    const rec = readDecisions(dir).at(-1)!;
+    expect(rec).toMatchObject({ decision: 'reject', id: item.id, reason: 'scratch binary, not a deliverable' });
+  });
+
+  it('keeps the branch when the archive tag cannot be created', () => {
+    const item = initRepoWithStrandedBranch();
+    const { run } = fakeRunner({ 'git tag': new Error('fatal: tag failed'), 'git ls-remote': '' });
+    const out = rejectItem(item, 'x', { repoRoot: dir, obsRoot: dir, run, feedbackWriter: () => true });
+    expect(out.ok).toBe(false);
+    expect(out.message).toContain('branch kept');
+  });
+
+  it('closes a PR with the reason', () => {
+    const { run, calls } = fakeRunner({ 'gh pr close': '' });
+    const item: InboxItem = { id: 'pr-12', kind: 'pr', ref: 'https://x/pull/12', title: 't', ageDays: 1, approveSemantics: 's' };
+    const out = rejectItem(item, 'wrong approach', { repoRoot: dir, obsRoot: dir, run });
+    expect(out.ok).toBe(true);
+    expect(calls.some((c) => c.startsWith(`gh pr close '12'`) && c.includes('wrong approach') && c.includes('--delete-branch'))).toBe(true);
+  });
+});
+
+describe('approve (decision 1: existing auto-merge path)', () => {
+  it('queues the CI-gated auto-merge for a PR', () => {
+    const { run, calls } = fakeRunner({ 'gh pr merge': '' });
+    const item: InboxItem = { id: 'pr-12', kind: 'pr', ref: 'https://x/pull/12', title: 't', ageDays: 1, approveSemantics: 's' };
+    const out = approveItem(item, { repoRoot: dir, obsRoot: dir, run });
+    expect(out.ok).toBe(true);
+    expect(calls).toContain(`gh pr merge '12' --squash --delete-branch --auto`);
+    expect(readDecisions(dir).at(-1)).toMatchObject({ decision: 'approve', id: 'pr-12' });
+  });
+
+  it('falls back to a plain squash when the repo has no auto-merge', () => {
+    let first = true;
+    const run: CommandRunner = (cmd) => {
+      if (cmd.startsWith('gh pr merge') && cmd.includes('--auto') && first) {
+        first = false;
+        throw new Error('GraphQL: Auto merge is not allowed for this repository');
+      }
+      return '';
+    };
+    const item: InboxItem = { id: 'pr-9', kind: 'pr', ref: 'https://x/pull/9', title: 't', ageDays: 1, approveSemantics: 's' };
+    const out = approveItem(item, { repoRoot: dir, obsRoot: dir, run });
+    expect(out.ok).toBe(true);
+    expect(out.message).toContain('plain squash');
+  });
+
+  it('pushes + opens a PR from a stranded branch and queues its merge', () => {
+    const item = initRepoWithStrandedBranch();
+    const { run, calls } = fakeRunner({
+      'git ls-remote': '',
+      'git push': '',
+      'git rev-parse --verify --quiet origin/develop': new Error('no'),
+      'git rev-parse --verify --quiet develop': '',
+      'gh pr create': 'https://github.com/o/r/pull/77\n',
+      'gh pr merge': '',
+    });
+    const out = approveItem(item, { repoRoot: dir, obsRoot: dir, run });
+    expect(out.ok).toBe(true);
+    expect(calls.some((c) => c.startsWith('git push -u origin'))).toBe(true);
+    expect(calls.some((c) => c.startsWith('gh pr create --base develop'))).toBe(true);
+    expect(calls).toContain(`gh pr merge '77' --squash --delete-branch --auto`);
+  });
+
+  it('refuses run_artifacts items (v1 scope = PRs + branches)', () => {
+    const item: InboxItem = { id: 'run-exec_x', kind: 'run_artifacts', ref: 'exec_x', title: 't', ageDays: 0, approveSemantics: 's' };
+    const out = approveItem(item, { repoRoot: dir, obsRoot: dir, run: fakeRunner().run });
+    expect(out.ok).toBe(false);
+    expect(out.message).toContain('runs --outcome');
+    expect(existsSync(reviewedLedgerPath(dir))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Review-queue Child A — the three things a human can say to an inbox item, per the founder decisions locked 2026-07-05:

1. **approve** — PRs: queue the existing CI-gated `--squash --auto` merge (falls back to plain squash only where the repo has no auto-merge). Stranded run branches: push if local-only, open a PR (base `develop` when it exists), queue its merge. The inbox changes *discovery*, not authority.
2. **reject `--reason`** — PRs: close with the reason + delete branch. Run branches: **archive tag, then delete** (`archive/<branch>`, recovery hint printed) — local + best-effort remote. The reason **writes through to `squads feedback`** for the owning squad (parsed from the branch name), so the next context injection carries the correction.
3. **defer `--days N`** — snooze; the list hides it until expiry; verbs still see it (early decide un-snoozes).

Every decision appends to `.agents/observability/reviewed.jsonl` (v1 records, corrupt-line tolerant). Sources remain scanners — the ledger stores only human decisions, never queue state. Approve/reject are never filtered from the list: an approved-but-still-open PR stays in your face.

## Changes
- `src/lib/inbox-decisions.ts` (new) — verbs, ledger, `activeDeferrals`, `squadFromBranch`; injectable `CommandRunner` + feedback writer for tests
- `src/lib/feedback-store.ts` (new) — lib-layer feedback append (same file/format as `squads feedback add`)
- `src/lib/inbox.ts` — `buildInbox` hides actively-deferred items (`includeDeferred` escape)
- `src/commands/inbox.ts` + `src/cli.ts` — `inbox [action] [id]`, `--reason`, `--days`; list shows item ids
- `test/inbox-decisions.test.ts` — 11 tests (real temp-git-repo for branch ops; scripted runner for gh)

## Testing
- [x] `tsc --noEmit`; inbox suites 17/17
- [x] E2E on a fixture repo with the built CLI: list → defer (hidden) → reject (archive tag created, branch gone, ledger has both records, feedback write-through degrades gracefully with a message when no memory dir)

Closes #933