### PR TITLE
fix(deepseek): foreign-model guard + v4 default model

### DIFF
--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -153,15 +153,24 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     displayName: 'DeepSeek (via aider)',
     command: 'aider',
     install: 'pip install aider-install && aider-install, then set DEEPSEEK_API_KEY',
-    buildArgs: (prompt, opts) => [
-      '--model',
-      opts?.model ? `deepseek/${opts.model.replace(/^deepseek\//, '')}` : 'deepseek/deepseek-chat',
-      '--message',
-      prompt,
-      '--yes',
-      '--no-auto-commits',
-      ...aiderMapTokensArgs(),
-    ],
+    buildArgs: (prompt, opts) => {
+      // Agents re-laned to deepseek keep their anthropic `model:` frontmatter,
+      // and DeepSeek's API rejects foreign names (#937) — only honor a model
+      // override that is actually a deepseek model; else the lane default.
+      const requested = opts?.model?.replace(/^deepseek\//, '');
+      const model = requested && /^deepseek/.test(requested)
+        ? requested
+        : process.env.DEEPSEEK_MODEL || 'deepseek-v4-flash';
+      return [
+        '--model',
+        `deepseek/${model}`,
+        '--message',
+        prompt,
+        '--yes',
+        '--no-auto-commits',
+        ...aiderMapTokensArgs(),
+      ];
+    },
     parseUsage: parseAiderUsage,
   },
 

--- a/test/llm-usage.test.ts
+++ b/test/llm-usage.test.ts
@@ -57,6 +57,21 @@ describe('aider map-tokens knob (#845)', () => {
   });
 });
 
+describe('deepseek model guard (#937 — foreign model names must not reach the API)', () => {
+  afterEach(() => { delete process.env.DEEPSEEK_MODEL; });
+
+  it('ignores anthropic frontmatter models and uses the lane default', () => {
+    const args = LLM_CLIS.deepseek.buildArgs('hi', { model: 'claude-sonnet-4-5' });
+    expect(args[args.indexOf('--model') + 1]).toBe('deepseek/deepseek-v4-flash');
+  });
+
+  it('honors real deepseek model overrides and DEEPSEEK_MODEL env', () => {
+    expect(LLM_CLIS.deepseek.buildArgs('hi', { model: 'deepseek/deepseek-v4-pro' })).toContain('deepseek/deepseek-v4-pro');
+    process.env.DEEPSEEK_MODEL = 'deepseek-v4-pro';
+    expect(LLM_CLIS.deepseek.buildArgs('hi')).toContain('deepseek/deepseek-v4-pro');
+  });
+});
+
 describe('glm lane (#926 — z.ai Anthropic-compatible endpoint via claude CLI)', () => {
   afterEach(() => {
     delete process.env.GLM_API_KEY;


### PR DESCRIPTION
Tonight's DeepSeek dispatch failed: the agent's `model: claude-sonnet-4-5` frontmatter leaked into the aider call and DeepSeek's v4 API rejects both foreign names and the stale `deepseek-chat` default. buildArgs now honors only deepseek-prefixed overrides, defaulting to `deepseek-v4-flash` (`DEEPSEEK_MODEL` env override). 2 new tests. Silent-success companion tracked in #936. Fixes #937