### PR TITLE
chore(gitignore): ignore .aider* droppings from the deepseek lane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docker/
 
 # squads-cli (per-user config)
 .squads/config.yml
+.aider*


### PR DESCRIPTION
One-line ignore the aider executor added during tonight's deepseek dispatch (harvested to local develop by the runner; re-landed properly). Same fix as the intelligence repo. Refs #937