### PR TITLE
feat(run): role-aware default timeout — research agents 40m (#941)

### DIFF
--- a/src/lib/run-types.ts
+++ b/src/lib/run-types.ts
@@ -6,6 +6,22 @@ import type { EffortLevel } from './squad-parser.js';
 
 // ── Constants ────────────────────────────────────────────────────────
 export const DEFAULT_TIMEOUT_MINUTES = 15;
+
+/**
+ * Research-class agents (web scanners, profilers, monitors) research first and
+ * write last — a 15-minute watchdog reaps them at ANY scope before the write
+ * (6/6 company-profilers lost on 2026-07-04, #941). They get a 40m default.
+ * An explicit --timeout / -t or SQUADS_AGENT_TIMEOUT_MINUTES always wins.
+ */
+export const RESEARCH_TIMEOUT_MINUTES = 40;
+const RESEARCH_HINT = /scan|monitor|research|profil|watch|intel|market/i;
+
+export function defaultTimeoutMinutes(agent?: { name?: string; role?: string }): number {
+  if (!agent) return DEFAULT_TIMEOUT_MINUTES;
+  return RESEARCH_HINT.test(`${agent.name ?? ''} ${agent.role ?? ''}`)
+    ? RESEARCH_TIMEOUT_MINUTES
+    : DEFAULT_TIMEOUT_MINUTES;
+}
 export const SOFT_DEADLINE_RATIO = 0.7;
 
 /** Providers that support tool use (sub-agent spawning, conversation orchestration) */

--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -45,7 +45,7 @@ import {
   buildAgentEnv,
   resolveGuardrailSettings,
 } from './execution-engine.js';
-import { DEFAULT_TIMEOUT_MINUTES } from './run-types.js';
+import { defaultTimeoutMinutes } from './run-types.js';
 import { type ExecutionContext } from './run-types.js';
 import { loadProjectConfig } from './config.js';
 import { getBotGhEnv } from './github.js';
@@ -133,7 +133,7 @@ interface AgentRunConfig {
   cwd: string;
   /** Stream this agent's output live (prefixed) — set under squad-run --verbose (#791) */
   verbose?: boolean;
-  /** Per-agent execution timeout (minutes) — from --timeout. env SQUADS_AGENT_TIMEOUT_MINUTES overrides; unset → DEFAULT_TIMEOUT_MINUTES (#438) */
+  /** Per-agent execution timeout (minutes) — from --timeout. env SQUADS_AGENT_TIMEOUT_MINUTES overrides; unset → role-aware default (research agents 40m, others 15m — #941/#438) */
   timeout?: number;
   /** Cycle-level exec-event stream (#902) — this agent's tool activity is teed into it. */
   events?: ExecEventWriter;
@@ -324,7 +324,9 @@ ${squadContext}
 
     // Timeout: configurable via env var, defaults from run-types.ts
     const envTimeout = process.env.SQUADS_AGENT_TIMEOUT_MINUTES;
-    const timeoutMinutes = envTimeout ? parseInt(envTimeout, 10) : (config.timeout ?? DEFAULT_TIMEOUT_MINUTES);
+    const timeoutMinutes = envTimeout
+      ? parseInt(envTimeout, 10)
+      : (config.timeout ?? defaultTimeoutMinutes({ name: config.agentName, role: config.role }));
     let timedOut = false;
     let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
     const timeout = setTimeout(() => {

--- a/test/run-types-timeout.test.ts
+++ b/test/run-types-timeout.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { defaultTimeoutMinutes, DEFAULT_TIMEOUT_MINUTES, RESEARCH_TIMEOUT_MINUTES } from '../src/lib/run-types.js';
+
+describe('defaultTimeoutMinutes (#941 — research agents need 40m, not 15m)', () => {
+  it('gives research-class agents the long watchdog', () => {
+    expect(defaultTimeoutMinutes({ name: 'company-profiler', role: 'worker' })).toBe(RESEARCH_TIMEOUT_MINUTES);
+    expect(defaultTimeoutMinutes({ name: 'world-watch', role: 'worker' })).toBe(RESEARCH_TIMEOUT_MINUTES);
+    expect(defaultTimeoutMinutes({ name: 'aws-monitor', role: 'scanner' })).toBe(RESEARCH_TIMEOUT_MINUTES);
+    expect(defaultTimeoutMinutes({ name: 'x', role: 'market research' })).toBe(RESEARCH_TIMEOUT_MINUTES);
+  });
+  it('keeps mechanical/lead agents on the short default', () => {
+    expect(defaultTimeoutMinutes({ name: 'docs-writer', role: 'worker' })).toBe(DEFAULT_TIMEOUT_MINUTES);
+    expect(defaultTimeoutMinutes({ name: 'cli-lead', role: 'lead' })).toBe(DEFAULT_TIMEOUT_MINUTES);
+    expect(defaultTimeoutMinutes(undefined)).toBe(DEFAULT_TIMEOUT_MINUTES);
+  });
+});


### PR DESCRIPTION
Company OS §P-A A1, root-caused by the coo-tick's own dispatch (flat `DEFAULT_TIMEOUT_MINUTES=15`). Research-class agents (name/role matching scan|monitor|research|profil|watch|intel|market) default to 40m in conversation-mode spawns; everything else stays 15m; explicit `-t`/env always wins. New `defaultTimeoutMinutes()` in run-types + 2 test groups; workflow tests untouched-green. Fixes #941