### PR TITLE
fix(run): turn-level retry on transient API errors (#944)

### DIFF
--- a/src/lib/workflow.ts
+++ b/src/lib/workflow.ts
@@ -173,7 +173,33 @@ function outcomeFields(o: RunOutcomes) {
  * full response text and real `total_cost_usd` + `usage`, so observability gets
  * true numbers instead of 0.
  */
+/**
+ * Transient API failures (stream cut, connection reset, 5xx/overloaded) lose
+ * the TURN in conversation mode — the verifier's verdict was cut mid-response
+ * on a real run (#944). One re-spawn with backoff recovers them. Quota,
+ * timeout, auth and invalid-model errors must stay LOUD (#936) — never retried.
+ */
+const TRANSIENT_API_ERROR =
+  /connection (closed|error|reset)|api error:.*(closed|reset|interrupted)|overloaded|status (500|502|503|529)|ECONNRESET|ETIMEDOUT|socket hang up/i;
+
+export function isTransientTurnError(text: string): boolean {
+  if (/\[QUOTA\]|timed out after|authentication|invalid.*model|insufficient/i.test(text)) return false;
+  return TRANSIENT_API_ERROR.test(text);
+}
+
 async function runIndependentAgent(config: AgentRunConfig): Promise<AgentRunResult> {
+  const maxRetries = process.env.SQUADS_TURN_RETRIES === '0' ? 0 : 1;
+  const backoffMs = parseInt(process.env.SQUADS_TURN_RETRY_BACKOFF_MS ?? '5000', 10);
+  let result = await runIndependentAgentOnce(config);
+  for (let attempt = 1; attempt <= maxRetries && isTransientTurnError(result.text); attempt++) {
+    writeLine(`  ${colors.yellow}${config.agentName}: transient API error — retrying turn (${attempt}/${maxRetries})${RESET}`);
+    await new Promise((r) => setTimeout(r, backoffMs * attempt));
+    result = await runIndependentAgentOnce(config);
+  }
+  return result;
+}
+
+async function runIndependentAgentOnce(config: AgentRunConfig): Promise<AgentRunResult> {
   const { agentName, agentPath, role, squadName, task, squadContext } = config;
 
   const prompt = `You are ${agentName} (${role}) in squad ${squadName}.

--- a/test/turn-retry.test.ts
+++ b/test/turn-retry.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { isTransientTurnError } from '../src/lib/workflow.js';
+
+describe('isTransientTurnError (#944 — retry transient, stay loud on the rest)', () => {
+  it('flags real transient signatures', () => {
+    expect(isTransientTurnError('API Error: Connection closed mid-response')).toBe(true);
+    expect(isTransientTurnError('[ERROR] intel-verifier exited with code 1: ECONNRESET')).toBe(true);
+    expect(isTransientTurnError('Request failed with status 529 overloaded')).toBe(true);
+    expect(isTransientTurnError('socket hang up')).toBe(true);
+  });
+  it('NEVER retries quota, timeout, auth, or model errors', () => {
+    expect(isTransientTurnError('[QUOTA] intel-lead: API limit reached')).toBe(false);
+    expect(isTransientTurnError('[ERROR] worker timed out after 40 minutes')).toBe(false);
+    expect(isTransientTurnError('authentication_error: invalid api key')).toBe(false);
+    expect(isTransientTurnError('The supported API model names are deepseek-v4-pro (invalid request model)')).toBe(false);
+    expect(isTransientTurnError('insufficient balance, please recharge — connection error')).toBe(false);
+    expect(isTransientTurnError('normal successful output')).toBe(false);
+  });
+});


### PR DESCRIPTION
Wraps runIndependentAgent: transient-API-shaped results (connection closed/reset, overloaded/5xx, ECONNRESET, socket hang up) get exactly one re-spawn with backoff (env-tunable; `SQUADS_TURN_RETRIES=0` opt-out). Non-transient failures — quota, timeout, auth, invalid model, insufficient balance — are excluded by guard and stay loud per #936. Detector exported + 10 signature tests; workflow suite untouched-green. Fixes #944