### PR TITLE
fix(providers): exit-0 API failures fail loud (#936)

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -47,6 +47,7 @@ import { detectProviderFromModel } from './providers.js';
 import { getBridgeUrl } from './env-config.js';
 import { getBotGitEnv, getBotPushUrl, getCoAuthorTrailer, getBotGhEnv } from './github.js';
 import { scanDiff, loadForbiddenStrings, summarizeFindings } from './secret-scan.js';
+import { detectProviderFatalError } from './llm-clis.js';
 import {
   buildSandboxSettings, readGuardrailHooks, readGuardrailPermissions, writeSandboxSettingsFile, sandboxEnabled, sandboxStrict,
 } from './sandbox-settings.js';
@@ -1258,6 +1259,12 @@ export async function executeWithProvider(
         // Token/cost figures come from the provider's own output when parseable.
         const startMs = options.startMs || timestamp;
         const usage = captureUsage ? cliConfig.parseUsage!(outputTail) : null;
+        // #936: providers can exit 0 after printing a fatal API error — detect
+        // from output so the ledger never credits a failed run as completed.
+        const fatal = detectProviderFatalError(outputTail);
+        if (fatal) {
+          writeLine(`  ${colors.red}provider API failure (run marked failed): ${fatal}${RESET}`);
+        }
         logObservability({
           ts: new Date().toISOString(),
           id: options.executionId || generateExecutionId(),
@@ -1266,7 +1273,7 @@ export async function executeWithProvider(
           provider,
           model: options.model || 'unknown',
           trigger: (options.trigger || 'manual') as ObservabilityRecord['trigger'],
-          status: code === 0 ? 'completed' : 'failed',
+          status: code === 0 && !fatal ? 'completed' : 'failed',
           duration_ms: Date.now() - startMs,
           input_tokens: usage?.input_tokens || 0,
           output_tokens: usage?.output_tokens || 0,
@@ -1274,7 +1281,7 @@ export async function executeWithProvider(
           cache_write_tokens: 0,
           cost_usd: usage?.cost_usd || 0,
           context_tokens: 0,
-          error: code !== 0 ? `${cliConfig.command} exited with code ${code}` : undefined,
+          error: fatal ?? (code !== 0 ? `${cliConfig.command} exited with code ${code}` : undefined),
         });
         if (usage && options.verbose) {
           writeLine(`  ${colors.dim}Usage: ${usage.input_tokens} in / ${usage.output_tokens} out, $${usage.cost_usd.toFixed(4)}${RESET}`);

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -91,6 +91,34 @@ export function parseAiderUsage(output: string): ProviderUsage | null {
 }
 
 /**
+ * Fatal provider-API failure signatures (#936). Providers like aider exit 0
+ * after printing an API error, so the run was reported \u2713 completed with an
+ * empty harvest. Output-based detection is the only reliable signal. These are
+ * NON-transient failures — config/credit problems that must fail LOUD, never
+ * retried (the transient class is handled per-turn in workflow.ts, #944).
+ */
+const PROVIDER_FATAL = [
+  /litellm\.\w*Error/i,
+  /BadRequestError|AuthenticationError|PermissionDeniedError|NotFoundError/,
+  /invalid_request_error|authentication_error/,
+  /insufficient balance|please recharge|insufficient_quota|exceeded your current quota/i,
+  /The supported API model names are/,
+  /invalid api key|incorrect api key/i,
+];
+
+/** Returns the matched failure line for logging, or null when output looks healthy. */
+export function detectProviderFatalError(output: string): string | null {
+  for (const re of PROVIDER_FATAL) {
+    const m = output.match(re);
+    if (m) {
+      const line = output.split('\n').find((l) => re.test(l)) ?? m[0];
+      return line.trim().slice(0, 300);
+    }
+  }
+  return null;
+}
+
+/**
  * Check if a command exists in PATH
  */
 export function commandExists(command: string): boolean {

--- a/src/lib/spool.ts
+++ b/src/lib/spool.ts
@@ -16,7 +16,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, openSync, readSync, closeSync } from 'fs';
 import { join } from 'path';
-import { getCLIConfig } from './llm-clis.js';
+import { getCLIConfig, detectProviderFatalError } from './llm-clis.js';
 import {
   logObservability,
   captureSessionUsage,
@@ -166,18 +166,27 @@ function toRecord(spool: SpoolRecord, obsRoot: string): ObservabilityRecord {
   const durationMs = spool.endEpoch > spool.startEpoch && spool.startEpoch > 0
     ? (spool.endEpoch - spool.startEpoch) * 1000
     : 0;
-  const status: ObservabilityRecord['status'] = spool.timedOut
+  let status: ObservabilityRecord['status'] = spool.timedOut
     ? 'timeout'
     : spool.exitCode === 0 ? 'completed' : 'failed';
+  let fatalError: string | undefined;
 
   let input = 0, output = 0, cost = 0, cacheRead = 0, cacheWrite = 0;
   let model = spool.model || 'unknown';
   let outcomes: ReturnType<typeof parseStreamJson>['outcomes'] | undefined;
 
   if (spool.provider && spool.provider !== 'anthropic') {
+    const tail = spool.logFile ? readLogTail(spool.logFile) : '';
+    // #936: providers exit 0 after printing fatal API errors — never credit
+    // a failed run as completed in the ledger the scoreboard reads.
+    const fatal = tail ? detectProviderFatalError(tail) : null;
+    if (fatal && status === 'completed') {
+      status = 'failed';
+      fatalError = fatal;
+    }
     const parse = getCLIConfig(spool.provider)?.parseUsage;
-    if (parse && spool.logFile) {
-      const usage = parse(readLogTail(spool.logFile));
+    if (parse && tail) {
+      const usage = parse(tail);
       if (usage) {
         input = usage.input_tokens;
         output = usage.output_tokens;
@@ -263,7 +272,7 @@ function toRecord(spool: SpoolRecord, obsRoot: string): ObservabilityRecord {
     } : {}),
     error: spool.timedOut
       ? `detached run reaped by watchdog after ${Math.round(durationMs / 60000)} min`
-      : spool.exitCode !== 0 ? `detached run exited with code ${spool.exitCode}` : undefined,
+      : fatalError ?? (spool.exitCode !== 0 ? `detached run exited with code ${spool.exitCode}` : undefined),
   };
 }
 

--- a/test/llm-usage.test.ts
+++ b/test/llm-usage.test.ts
@@ -109,3 +109,19 @@ describe('glm lane (#926 — z.ai Anthropic-compatible endpoint via claude CLI)'
     expect(LLM_CLIS.glm.env!().ANTHROPIC_BASE_URL).toBe('https://proxy.example/anthropic');
   });
 });
+
+describe('detectProviderFatalError (#936 — exit-0 API failures must fail loud)', () => {
+  it('catches the real failure classes seen in production', async () => {
+    const { detectProviderFatalError } = await import('../src/lib/llm-clis.js');
+    expect(detectProviderFatalError('litellm.BadRequestError: DeepseekException - {"error":...}')).toContain('litellm.BadRequestError');
+    expect(detectProviderFatalError('The supported API model names are deepseek-v4-pro')).toBeTruthy();
+    expect(detectProviderFatalError('[1113][Insufficient balance or no resource package. Please recharge.]')).toBeTruthy();
+    expect(detectProviderFatalError('You exceeded your current quota, please check your plan')).toBeTruthy();
+    expect(detectProviderFatalError('Error: invalid api key provided')).toBeTruthy();
+  });
+  it('stays quiet on healthy output', async () => {
+    const { detectProviderFatalError } = await import('../src/lib/llm-clis.js');
+    expect(detectProviderFatalError('Applied edit to docs/commands.md\nTokens: 57k sent, 1.7k received.')).toBeNull();
+    expect(detectProviderFatalError('discussed error handling in the docs')).toBeNull();
+  });
+});


### PR DESCRIPTION
Providers (aider et al) exit 0 after printing fatal API errors — tonight's DeepSeek dispatch was harvested and reported ✓ completed in 6.8s after a litellm BadRequestError. New `detectProviderFatalError` (production-observed signatures: litellm errors, invalid model, no-balance/recharge, quota-exceeded, bad api key) wired into BOTH provider result paths (foreground close + spool reconcile): status→failed, matched line→error field. Scoreboard stops crediting failed runs. 7 new tests; spool suite green. Fixes #936