### PR TITLE
feat(inbox): PARTIAL class for auto-saved run branches (A5)

### DIFF
--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -134,14 +134,19 @@ export function scanStrandedBranches(repoRoot: string): InboxItem[] {
     } catch { continue; }
     if (ahead === 0) continue;
     if (!hasUnlandedCommits(branch, base, repoRoot)) continue; // squash-landed (#929)
+    // A5 (hq#470): the #875 auto-save commit message IS the signature of a run
+    // that died before committing its own work (timeout / blocked) — surface it
+    // as a PARTIAL so salvage is a queue decision, not operator archaeology.
+    const subject = subjectParts.join('|') || branch;
+    const isPartial = /auto-save uncommitted deliverables/i.test(subject);
     items.push({
       id: `branch-${branch}`,
       kind: 'run_branch',
       ref: branch,
-      title: (subjectParts.join('|') || branch).slice(0, 90),
+      title: (isPartial ? `PARTIAL (run died before committing) — ${subject}` : subject).slice(0, 110),
       ageDays: ageDaysFrom((parseInt(epoch, 10) || 0) * 1000),
       approveSemantics: `open a PR from ${branch} (has ${ahead} unmerged commit${ahead > 1 ? 's' : ''})`,
-      detail: `${ahead} commit(s) ahead of ${base}`,
+      detail: `${ahead} commit(s) ahead of ${base}${isPartial ? ' · partial run output — inspect before approving' : ''}`,
     });
   }
   return items;

--- a/test/inbox.test.ts
+++ b/test/inbox.test.ts
@@ -129,3 +129,17 @@ describe('scanner correctness (#929)', () => {
     expect(scanStrandedBranches(dir)).toHaveLength(0); // landed → not waiting on a human
   });
 });
+
+describe('partial class (A5 — timed-out runs surface, not archaeology)', () => {
+  it('flags auto-saved (#875) branches as PARTIAL', () => {
+    initRepo();
+    git('checkout -q -b squads/run-intel-tm99x-0');
+    writeFileSync(join(dir, 'half-brief.md'), 'partial work');
+    git('add -A');
+    git('commit -qm "squads run: auto-save uncommitted deliverables on cleanup (#875)"');
+    git('checkout -q develop');
+    const [item] = scanStrandedBranches(dir);
+    expect(item.title).toContain('PARTIAL');
+    expect(item.detail).toContain('inspect before approving');
+  });
+});


### PR DESCRIPTION
Company OS §P-A A5. The #875 auto-save commit message is the exact signature of a run that died before committing its own work — those inbox items now read `PARTIAL (run died before committing)` with an inspect-before-approving note in the detail. 1 new test. Closes #948