### PR TITLE
feat(telemetry): comprehensive command telemetry via root hook — and strip PII the old events leaked

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ for (const envPath of envPaths) {
 import type { SessionSummaryData } from './commands/sessions.js';
 
 // Setup imports (must run on every invocation)
-import { registerExitHandler } from './lib/telemetry.js';
+import { registerExitHandler, installCommandTelemetry } from './lib/telemetry.js';
 import { applyStackConfig } from './lib/stack-config.js';
 
 // Register-pattern commands (must define subcommand structure before parseAsync)
@@ -186,6 +186,10 @@ function handleOutputError(str: string, write: (s: string) => void): void {
 }
 
 const program = new Command();
+
+// #1009: every command reports usage via one root hook pair — no per-command
+// wiring, privacy hard-scoped to command path + flag names in telemetry.ts.
+installCommandTelemetry(program);
 
 program
   .name('squads')

--- a/src/commands/autonomy.ts
+++ b/src/commands/autonomy.ts
@@ -46,7 +46,6 @@ export async function autonomyCommand(options: AutonomyOptions = {}): Promise<vo
   const bridgeUrl = getEnv().bridge_url;
   const period = options.period || 'today';
 
-  await track(Events.CLI_STATUS, { command: 'autonomy', period, squad: options.squad });
 
   try {
     const params = new URLSearchParams({ period });

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -25,7 +25,6 @@ export async function contextShowCommand(
   squadName: string,
   options: ContextOptions = {}
 ): Promise<void> {
-  await track(Events.CLI_CONTEXT, { squad: squadName });
   const squadsDir = findSquadsDir();
 
   if (!squadsDir) {

--- a/src/commands/cost.ts
+++ b/src/commands/cost.ts
@@ -72,7 +72,6 @@ function getBudgetStatus(
 }
 
 export async function costCommand(options: CostOptions = {}): Promise<void> {
-  await track(Events.CLI_COST, { squad: options.squad || 'all' });
 
   const stats = await fetchBridgeStats();
   const plan = detectPlan();
@@ -239,7 +238,6 @@ export async function budgetCheckCommand(
   squadName: string,
   options: { json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_COST, { action: 'budget-check', squad: squadName });
 
   const stats = await fetchBridgeStats();
   const squad = loadSquad(squadName);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -408,7 +408,6 @@ function renderDashboardFooter(): void {
 }
 
 export async function dashboardCommand(options: { verbose?: boolean; ceo?: boolean; fast?: boolean; json?: boolean } = {}): Promise<void> {
-  await track(Events.CLI_DASHBOARD, { verbose: options.verbose, ceo: options.ceo, fast: options.fast });
   const squadsDir = findSquadsDir();
   if (!squadsDir) {
     writeLine(`${colors.red}No .agents/squads directory found${RESET}`);

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -567,7 +567,6 @@ export async function evalCommand(target: string, options: {
   }
 
   await track('cli.eval', {
-    squad: squadName,
     agents: results.length,
     avgScore: Math.round(results.reduce((sum, r) => sum + r.overallScore, 0) / results.length),
   });

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -21,7 +21,6 @@ export async function goalSetCommand(
   description: string,
   options: { metric?: string[] }
 ): Promise<void> {
-  await track(Events.CLI_GOAL_SET, { squad: squadName });
   const squad = loadSquad(squadName);
   if (!squad) {
     writeLine(`  ${colors.red}Squad "${squadName}" not found${RESET}`);
@@ -53,7 +52,6 @@ export async function goalListCommand(
   squadName?: string,
   options: { all?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_GOAL_LIST, { squad: squadName || 'all' });
   const squadsDir = findSquadsDir();
   if (!squadsDir) {
     writeLine(`  ${colors.red}No .agents/squads directory found${RESET}`);
@@ -126,7 +124,6 @@ export async function goalCompleteCommand(
   squadName: string,
   goalIndex: string
 ): Promise<void> {
-  await track(Events.CLI_GOAL_COMPLETE, { squad: squadName });
   const squad = loadSquad(squadName);
   if (!squad) {
     writeLine(`  ${colors.red}Squad "${squadName}" not found${RESET}`);
@@ -161,7 +158,6 @@ export async function goalProgressCommand(
   goalIndex: string,
   progress: string
 ): Promise<void> {
-  await track(Events.CLI_GOAL_PROGRESS, { squad: squadName });
   const squad = loadSquad(squadName);
   if (!squad) {
     writeLine(`  ${colors.red}Squad "${squadName}" not found${RESET}`);

--- a/src/commands/kpi.ts
+++ b/src/commands/kpi.ts
@@ -36,7 +36,6 @@ export async function kpiShowCommand(
   squadName: string,
   options: { json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_KPI_SHOW, { squad: squadName });
 
   const squad = loadSquad(squadName);
   if (!squad) {
@@ -99,7 +98,6 @@ export async function kpiRecordCommand(
   value: string,
   options: { note?: string; json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_KPI_RECORD, { squad: squadName, kpi: kpiName });
 
   const squad = loadSquad(squadName);
   if (!squad) {
@@ -154,7 +152,6 @@ export async function kpiTrendCommand(
   kpiName: string,
   options: { periods?: string; json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_KPI_TREND, { squad: squadName, kpi: kpiName });
 
   const squad = loadSquad(squadName);
   if (!squad) {
@@ -222,7 +219,6 @@ export async function kpiInsightsCommand(
   squadName?: string,
   options: { json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_KPI_INSIGHTS, { squad: squadName || 'all' });
 
   const squadsDir = findSquadsDir();
   if (!squadsDir) {
@@ -317,7 +313,6 @@ export async function kpiInsightsCommand(
 export async function kpiListCommand(
   options: { json?: boolean } = {}
 ): Promise<void> {
-  await track(Events.CLI_KPI_LIST, {});
 
   const squadsDir = findSquadsDir();
   if (!squadsDir) {

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -161,12 +161,6 @@ export async function learnCommand(
   content += formatLearning(learning);
   writeFileSync(learningsPath, content);
 
-  // Track telemetry
-  await track(Events.CLI_LEARN, {
-    squad: squadName,
-    category,
-    tagCount: tags.length,
-  });
 
   // Display
   writeLine();
@@ -218,8 +212,6 @@ export async function learnShowCommand(
   const limit = options.limit ? parseInt(options.limit) : 10;
   const recent = filtered.slice(-limit).reverse();
 
-  // Track
-  await track(Events.CLI_LEARN_SHOW, { squad: squadName });
 
   // Display
   writeLine();
@@ -285,8 +277,6 @@ export async function learnSearchCommand(
     l.tags.some(t => t.includes(queryLower))
   );
 
-  // Track
-  await track(Events.CLI_LEARN_SEARCH, { query, matches: matches.length });
 
   // Display
   writeLine();

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -23,7 +23,6 @@ interface ListOptions {
 }
 
 export async function listCommand(options: ListOptions): Promise<void> {
-  await track('cli.list', { squads: options.squads, agents: options.agents });
   const squadsDir = findSquadsDir();
 
   if (!squadsDir) {

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -41,7 +41,6 @@ function formatCost(usd: number): string {
 }
 
 export async function logCommand(options: LogOptions = {}): Promise<void> {
-  await track(Events.CLI_LOG, { squad: options.squad, limit: options.limit });
 
   const records = queryExecutions({
     squad: options.squad,

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -149,7 +149,6 @@ export async function logoutCommand(): Promise<void> {
 
   clearSession();
   writeLine(chalk.green(`✓ Logged out from ${session.email}`));
-  await track('cli.logout');
 }
 
 export async function whoamiCommand(): Promise<void> {

--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -38,7 +38,6 @@ export async function memoryQueryCommand(
   query: string,
   options: MemoryOptions
 ): Promise<void> {
-  await track(Events.CLI_MEMORY_QUERY, { squad: options.squad, agent: options.agent });
   const memoryDir = findMemoryDir();
 
   if (!memoryDir) {
@@ -134,7 +133,6 @@ export async function memoryShowCommand(
   squadName: string,
   _options: MemoryOptions
 ): Promise<void> {
-  await track(Events.CLI_MEMORY_SHOW, { squad: squadName });
   const memoryDir = findMemoryDir();
 
   if (!memoryDir) {
@@ -187,7 +185,6 @@ export async function memoryUpdateCommand(
   content: string,
   options: MemoryOptions
 ): Promise<void> {
-  await track(Events.CLI_MEMORY_UPDATE, { squad: squadName, agent: options.agent, type: options.type });
   const agentName = options.agent || `${squadName}-lead`;
   const type = (options.type || 'learnings') as 'state' | 'output' | 'learnings' | 'feedback';
 
@@ -205,7 +202,6 @@ export async function memoryUpdateCommand(
 }
 
 export async function memoryListCommand(): Promise<void> {
-  await track(Events.CLI_MEMORY_LIST);
   const memoryDir = findMemoryDir();
 
   if (!memoryDir) {

--- a/src/commands/pause.ts
+++ b/src/commands/pause.ts
@@ -15,7 +15,6 @@ export async function pauseCommand(
   squadName: string,
   options: PauseOptions = {}
 ): Promise<void> {
-  await track(Events.CLI_STATUS, { squad: squadName, action: 'pause' });
 
   const squadsDir = findSquadsDir();
   if (!squadsDir) {
@@ -94,7 +93,6 @@ export async function resumeCommand(
   squadName: string,
   options: ResumeOptions = {}
 ): Promise<void> {
-  await track(Events.CLI_STATUS, { squad: squadName, action: 'resume' });
 
   const squadsDir = findSquadsDir();
   if (!squadsDir) {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -504,7 +504,8 @@ export async function runCommand(
       writeLine(`  ${colors.dim}   or: squads run ${squadName}/<agent> --cloud${RESET}`);
       process.exit(1);
     }
-    await track(Events.CLI_RUN, { type: 'cloud', target: `${squadName}/${agentName}` });
+    // #1009 privacy scope: run type only — squad/agent names never ship
+    await track(Events.CLI_RUN, { type: 'cloud' });
     await flushEvents();
     await runCloudDispatch(squadName, agentName, options);
     return;
@@ -561,7 +562,7 @@ export async function runCommand(
   }
 
   if (squad) {
-    await track(Events.CLI_RUN, { type: 'squad', target: squad.name });
+    await track(Events.CLI_RUN, { type: 'squad' });
     await flushEvents(); // Ensure telemetry is sent before potential exit
     const runStartMs = Date.now();
     let hadError = false;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -50,7 +50,6 @@ export async function statusCommand(
     const n = reconcileDetachedRuns(getProjectRoot());
     if (n > 0) console.log(`  reconciled ${n} detached run(s) into observability`);
   } catch { /* read paths never break on spool issues */ }
-  await track(Events.CLI_STATUS, { squad: squadName || 'all', verbose: options.verbose });
   const squadsDir = findSquadsDir();
 
   if (!squadsDir) {

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -825,7 +825,6 @@ function gitPushMemory(): { success: boolean; output: string } {
 }
 
 export async function syncCommand(options: { verbose?: boolean; push?: boolean; pull?: boolean; postgres?: boolean; dimensions?: boolean; learnings?: boolean; autoLearn?: boolean } = {}): Promise<void> {
-  await track(Events.CLI_MEMORY_SYNC, { push: options.push, pull: options.pull, postgres: options.postgres, dimensions: options.dimensions, learnings: options.learnings, autoLearn: options.autoLearn });
 
   // If --dimensions flag, sync squad/agent definitions to Postgres dim tables
   if (options.dimensions) {

--- a/src/commands/usage.ts
+++ b/src/commands/usage.ts
@@ -56,7 +56,6 @@ export async function usageCommand(options: UsageOptions = {}): Promise<void> {
     const n = reconcileDetachedRuns(getProjectRoot());
     if (n > 0) console.log(`  reconciled ${n} detached run(s) into observability`);
   } catch { /* read paths never break on spool issues */ }
-  await track(Events.CLI_COST, { action: 'usage' });
 
   const windowHours = Math.max(1, parseInt(String(options.window ?? 5), 10) || 5);
   const summary = localUsageSummary(windowHours);

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform, release } from 'os';
 import { randomUUID } from 'crypto';
+import type { Command } from 'commander';
 import { version as cliVersion } from '../version.js';
 import { loadProjectConfig } from './config.js';
 
@@ -426,6 +427,71 @@ export const Events = {
  * // ... execute command ...
  * done(); // Records duration
  */
+/**
+ * Full subcommand path of a Commander action command, dot-joined
+ * (e.g. "memory.sync", "goal.set"). Excludes the root program name.
+ */
+export function commandPath(cmd: Command): string {
+  const parts: string[] = [];
+  let c: Command | null = cmd;
+  while (c && c.parent) {
+    parts.unshift(c.name());
+    c = c.parent;
+  }
+  return parts.join('.') || cmd.name();
+}
+
+/**
+ * Names of the flags the caller explicitly passed (option source 'cli'),
+ * sorted. Names ONLY — flag values and positional args never leave the
+ * machine (#1009 privacy scope).
+ */
+export function presentFlagNames(cmd: Command): string[] {
+  const names: string[] = [];
+  for (const opt of cmd.options) {
+    try {
+      if (cmd.getOptionValueSource(opt.attributeName()) === 'cli') {
+        names.push(opt.long ?? opt.short ?? opt.attributeName());
+      }
+    } catch {
+      // telemetry must never break a command
+    }
+  }
+  return names.sort();
+}
+
+/**
+ * Root command instrumentation (#1009): one preAction/postAction pair on
+ * the program covers every command, current and future — no per-command
+ * wiring. preAction emits `cli.<path>` (the usage counter; fires even when
+ * the action later hard-exits — the local store write is synchronous).
+ * postAction emits `cli.done` with duration + success for commands that
+ * complete. Payload is hard-scoped to command path + present flag NAMES;
+ * values and positional args NEVER ship. Routes through track(), so
+ * opt-out / DO_NOT_TRACK / CI+VITEST suppression apply automatically.
+ */
+export function installCommandTelemetry(
+  program: Command,
+  trackFn: typeof track = track
+): void {
+  const startedAt = new WeakMap<Command, number>();
+  program.hook('preAction', async (_root, actionCommand) => {
+    startedAt.set(actionCommand, Date.now());
+    const flags = presentFlagNames(actionCommand).join(',');
+    await trackFn(`cli.${commandPath(actionCommand)}`, {
+      flags: flags || undefined,
+    });
+  });
+  program.hook('postAction', async (_root, actionCommand) => {
+    const start = startedAt.get(actionCommand);
+    await trackFn('cli.done', {
+      command: commandPath(actionCommand),
+      durationMs: start ? Date.now() - start : undefined,
+      success: !process.exitCode,
+    });
+  });
+}
+
 export function trackCommand(command: string): () => void {
   const start = Date.now();
 

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -235,3 +235,72 @@ describe('toMpEvent (#964 GA4 MP shape)', () => {
     expect(e.params['bad_key_name']).toHaveLength(100);
   });
 });
+
+// ─── #1009: root command hook — comprehensive, privacy-hard-scoped ──────
+import { Command } from 'commander';
+import { commandPath, presentFlagNames, installCommandTelemetry } from '../src/lib/telemetry.js';
+
+describe('commandPath (#1009)', () => {
+  it('builds the dotted path for nested subcommands, excluding the root', () => {
+    const program = new Command('squads');
+    const memory = program.command('memory');
+    const sync = memory.command('sync');
+    expect(commandPath(sync)).toBe('memory.sync');
+    expect(commandPath(memory)).toBe('memory');
+  });
+
+  it('falls back to the command name for a root-level command', () => {
+    const program = new Command('squads');
+    const run = program.command('run');
+    expect(commandPath(run)).toBe('run');
+  });
+});
+
+describe('presentFlagNames (#1009)', () => {
+  it('returns only flags the caller passed, sorted, names not values', () => {
+    const program = new Command('squads');
+    let captured: string[] = [];
+    program
+      .command('run')
+      .argument('[target]')
+      .option('-t, --timeout <min>')
+      .option('--task <text>')
+      .option('--verbose')
+      .action(function (this: Command) {
+        captured = presentFlagNames(this);
+      });
+    program.parse(['run', 'secret-squad', '--task', 'secret text', '-t', '40'], { from: 'user' });
+    expect(captured).toEqual(['--task', '--timeout']);
+    expect(captured.join(',')).not.toContain('secret');
+  });
+});
+
+describe('installCommandTelemetry (#1009)', () => {
+  it('emits cli.<path> with flag names and cli.done, never arg or flag values', async () => {
+    const events: Array<{ event: string; properties?: Record<string, unknown> }> = [];
+    const capture = async (event: string, properties?: Record<string, string | number | boolean | undefined>) => {
+      events.push({ event, properties });
+    };
+
+    const program = new Command('squads');
+    installCommandTelemetry(program, capture);
+    const goal = program.command('goal');
+    goal
+      .command('set')
+      .argument('<squad>')
+      .option('--kpi <name>')
+      .action(async () => {});
+
+    await program.parseAsync(['goal', 'set', 'client-secret', '--kpi', 'revenue'], { from: 'user' });
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain('client-secret');
+    expect(serialized).not.toContain('revenue');
+    const pre = events.find((e) => e.event === 'cli.goal.set');
+    expect(pre?.properties?.flags).toBe('--kpi');
+    const done = events.find((e) => e.event === 'cli.done');
+    expect(done?.properties?.command).toBe('goal.set');
+    expect(done?.properties?.success).toBe(true);
+    expect(typeof done?.properties?.durationMs).toBe('number');
+  });
+});


### PR DESCRIPTION
## What

One root `preAction`/`postAction` hook pair in `src/cli.ts` (installed via `installCommandTelemetry()` in telemetry.ts) replaces per-command hand-wiring:

- **`cli.<full.path>`** on preAction — full subcommand path (`memory.sync`, `goal.set`) + **flag names only**, comma-joined. Emitted before the action so the usage counter survives the 62 `process.exit()` sites.
- **`cli.done`** on postAction — command path, durationMs, success (from `process.exitCode`).

## Privacy remediation (found during the audit)

29 existing hand-wired events violated the telemetry disclosure printed at init ("command names… never personal data"): squad names in status/goal/kpi/context/pause/memory/log/cost/autonomy, run targets (`squad/agent`) in run.ts, and **the raw search query text** in `learn search`. All removed. Domain events kept (init, login/deploy lifecycle, run.complete) carry enums/counts only.

## Acceptance criteria

- [x] Root hook emits `cli.<full-command-path>` for every command incl. nested subcommands — verified live: `cli.memory.list`, `cli.status`, `cli.commands`
- [x] Payload = path + present-flag names + duration + success; no arg/flag values — unit test asserts `squads goal set <squad> --kpi <name>` ships neither value
- [x] Suppression honored — routes through `track()`/`isEnabled()` unchanged
- [x] Duplicate manual baselines removed (29), domain events kept
- [x] Previously-uninstrumented commands report automatically (hook is structural)

Verified: build green, 2213/2214 tests pass (the one failure is `test/list.test.ts` parallel-suite pollution — passes in isolation on clean develop too), live event store inspected.

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)