### PR TITLE
docs(skill): seed SKILL.md teaches the loop, not the command list

### DIFF
--- a/templates/seed/skills/squads-cli/SKILL.md
+++ b/templates/seed/skills/squads-cli/SKILL.md
@@ -1,12 +1,39 @@
 ---
 name: squads-cli
-description: Squads CLI reference for autonomous agents — run squads, manage memory, check status, set goals, and operate the AI workforce. TRIGGER when using squads commands, dispatching agents, reading/writing memory, checking squad status, or operating the autonomous loop.
+description: Squads CLI — operate your AI workforce through the loop; intent in, reviewed work out. TRIGGER when running squads, dispatching agents, triaging the inbox, reading/writing memory, recording feedback, or checking status/usage.
 context: fork
 ---
 
 # Squads CLI
 
-The `squads` CLI is the operating system for your AI workforce. Agents are the primary users — they call these commands during execution to understand context, persist learnings, and coordinate with other squads.
+`squads` runs a business loop, not just commands: you (or an agent) express **intent**, squads **execute** it as bounded runs that end in reviewable artifacts, a human **decides** in the inbox, and the outcome feeds **learning** that shapes the next cycle.
+
+```
+        INTENT                     EXECUTE                     DECIDE
+  ┌─────────────────┐      ┌──────────────────────┐      ┌──────────────┐
+  │ goal set        │      │ run <squad> --task   │      │ inbox        │
+  │ propose (CLI    │  →   │  bounded, PR-gated   │  →   │  approve /   │ → feedback → memory
+  │  drafts work)   │      │ watch · kill         │      │  reject /    │    (LEARN — shapes
+  └─────────────────┘      └──────────────────────┘      │  defer       │     the next cycle)
+                                                          └──────────────┘
+        always-on instruments: status · dash · usage · doctor
+```
+
+Every run is **bounded** (timeout, budget), **contained** (its own git worktree), and ends in an **artifact** (a PR, a proposal branch, an inbox card) — never loose changes to your working tree.
+
+## Who types what
+
+**Humans need five commands.** Everything else is called by agents and automation.
+
+| Command | When you use it |
+|---------|-----------------|
+| `squads status` | "What's the state of my workforce?" |
+| `squads dash` | Deeper view — per-squad detail, `--ceo` for the executive summary |
+| `squads inbox` | Everything waiting on YOUR decision — `approve / reject / defer <id>` |
+| `squads usage` | What today cost (`--all-claude` for machine-wide across projects) |
+| `squads login` | Connect cloud features (optional — everything works local-first) |
+
+**Agents use the working verbs** — the rest of this file.
 
 ## Core Concepts
 
@@ -14,9 +41,10 @@ The `squads` CLI is the operating system for your AI workforce. Agents are the p
 |---------|-------------|
 | **Squad** | A team of agents in `.agents/squads/{name}/` — defined by `SQUAD.md` |
 | **Agent** | A markdown file (`{agent}.md`) inside a squad directory |
-| **Memory** | Persistent state in `.agents/memory/{squad}/{agent}/` — survives across runs |
+| **Memory** | Persistent state in `.agents/memory/` — plain markdown, survives runs, **portable to any provider** (claude, gemini, opencode, …: memory is files, not vendor state) |
 | **Target** | `squad/agent` notation (e.g., `engineering/issue-solver`) |
-| **Context cascade** | Layered context injection: SYSTEM → strategy → goals → agent → state |
+| **Context cascade** | Layered injection: SYSTEM → strategy → goals → agent → state |
+| **Inbox** | The decision surface: run outcomes, proposals, and stranded work wait there; decisions land in an append-only `reviewed.jsonl` ledger with `by:` attribution |
 
 ## File Structure
 
@@ -28,293 +56,125 @@ The `squads` CLI is the operating system for your AI workforce. Agents are the p
 │   └── {agent}.md                # Agent definition
 └── memory/
     ├── {squad}/
-    │   ├── goals.md               # Measurable targets (primary squad context)
-    │   ├── feedback.md            # Last cycle evaluation
-    │   ├── active-work.md         # Open PRs/issues
-    │   └── {agent}/
-    │       ├── state.md           # Agent's persistent state
-    │       └── learnings.md       # Accumulated insights
-    ├── company/strategy.md        # Company strategic context (primary L1)
-    └── daily-briefing.md          # Cross-squad context
+    │   ├── goals.md              # Measurable targets (primary squad context)
+    │   ├── feedback.md           # Last cycle evaluation
+    │   └── {agent}/state.md      # Agent's persistent state
+    ├── company/strategy.md       # Company strategic context (L1)
+    └── daily-briefing.md         # Cross-squad context
 ```
 
 ---
 
-## Running Agents
-
-### Single Agent
-
-```bash
-# Run specific agent (two equivalent notations)
-squads run engineering/issue-solver
-squads run engineering -a issue-solver
-
-# With founder directive (replaces lead briefing)
-squads run engineering/issue-solver --task "Fix CI pipeline for PR #593"
-
-# Dry run — preview without executing
-squads run engineering --dry-run
-
-# Background execution
-squads run engineering/scanner -b          # Detached
-squads run engineering/scanner -w          # Detached but tail logs
-
-# Use different LLM provider
-squads run research/analyst --provider=google
-squads run research/analyst --provider=google --model=gemini-2.5-flash
-```
-
-### Squad Conversation
-
-Run an entire squad as a coordinated team. Lead briefs → workers execute → lead reviews → iterate until convergence.
-
-```bash
-squads run research                        # Sequential conversation
-squads run research --parallel             # All agents in parallel (tmux)
-squads run research --lead                 # Single orchestrator with Task tool
-squads run research --max-turns 10         # Limit conversation turns
-squads run research --cost-ceiling 15      # Budget cap in USD
-```
-
-### Autopilot (Autonomous Dispatch)
-
-No target = autopilot mode. CLI scores squads by priority, dispatches automatically.
-
-```bash
-squads run                                 # Start autopilot
-squads run --once                          # Single cycle then exit
-squads run --once --dry-run                # Preview what would dispatch
-squads run -i 15 --budget 50              # 15-min cycles, $50/day cap
-squads run --phased                        # Respect depends_on ordering
-squads run --max-parallel 3               # Up to 3 squads simultaneously
-```
-
-### Execution Options
-
-| Flag | Purpose |
-|------|---------|
-| `--verbose` | Detailed output with context sections logged |
-| `--timeout <min>` | Execution timeout (default: 30 min) |
-| `--effort <level>` | `high`, `medium`, `low` (default: from SQUAD.md or high) |
-| `--skills <ids>` | Load additional skills |
-| `--cloud` | Dispatch to cloud worker (requires `squads login`) |
-| `--no-verify` | Skip post-execution verification |
-| `--no-eval` | Skip post-run COO evaluation |
-| `--json` | Machine-readable output |
-
----
-
-## Memory Operations
-
-Memory is how agents persist knowledge across runs. Files-first — everything is markdown on disk.
-
-### Read Memory
-
-```bash
-# View all memory for a squad
-squads memory read engineering
-
-# Search across ALL squad memory
-squads memory query "CI pipeline failures"
-squads memory query "agent performance"
-```
-
-### Write Memory
-
-```bash
-# Write insight to squad memory
-squads memory write research "MCP adoption rate at 15% — up from 8% last month"
-
-# Write to specific agent
-squads memory write engineering --agent issue-solver "PR #593 blocked by flaky test"
-```
-
-### Capture Learnings
-
-```bash
-# Quick learning capture
-squads learn "Google blocks headless Chrome OAuth — use cookie injection" \
-  --squad engineering --category pattern --tags "auth,chrome,e2e"
-
-# View learnings
-squads learnings
-squads learnings --squad engineering
-```
-
-### Sync Memory
-
-```bash
-squads sync                    # Pull remote changes
-squads sync --push             # Pull + push local changes
-squads sync --postgres         # Also sync to Postgres
-```
-
----
-
-## Status & Monitoring
-
-### Squad Status
-
-```bash
-squads status                  # All squads overview
-squads status engineering      # Specific squad details
-squads status -v               # Verbose with agent details
-squads status --json           # Machine-readable
-```
-
-### Dashboards
-
-```bash
-squads dash                    # Overview dashboard
-squads dash engineering        # Squad-specific dashboard
-squads dash --ceo              # Executive summary
-squads dash --full             # Include GitHub PR/issue stats (~30s)
-squads dash --list             # List available dashboards
-```
-
-### Execution History
-
-```bash
-squads exec list               # Recent executions
-squads exec list --squad eng   # Filter by squad
-squads exec show <id>          # Execution details
-squads exec stats              # Aggregate statistics
-```
-
-### Cost Tracking
-
-```bash
-squads cost                    # Today + this week
-squads cost --squad research   # Squad-specific costs
-squads cost --json             # Machine-readable
-```
-
-### Health & Readiness
-
-```bash
-squads doctor                  # Check tools, auth, project readiness
-squads doctor -v               # Verbose with install hints
-squads eval engineering/scanner  # Agent readiness score
-```
-
----
-
-## Goals & Strategy
-
-Goals are measurable targets (in `memory/{squad}/goals.md`). Strategy is company direction (in `memory/company/strategy.md`).
-
-### Set Goals
+## INTENT — tell the system what matters
 
 ```bash
 squads goal set engineering "Zero CI failures on main branch"
-squads goal list                    # All squads
-squads goal list engineering        # Specific squad
-squads goal complete engineering 1  # Mark done
-squads goal progress engineering 1 "75%"
+squads goal list [squad]
+squads goal complete engineering 1
+
+# Or let the CLI draft work from repo intent (ambient):
+squads propose                     # one bounded background run → proposal branch + inbox card
 ```
 
-### Business Context
+Business context for any run comes from the cascade — inspect it with:
 
 ```bash
-squads context                           # Full business context
-squads context --squad engineering       # Squad-focused context
-squads context --topic "pricing"         # Topic-focused search
-squads context --json                    # Agent-consumable format
+squads context [--squad <name>] [--topic "pricing"] [--json]
+```
+
+## EXECUTE — bounded runs that end in artifacts
+
+```bash
+# The workhorse: scoped task, one branch, one PR, stops at the PR gate
+squads run engineering --task "Fix squads-cli#593 — spec in the issue" -t 40
+
+# Single agent / squad conversation
+squads run engineering/issue-solver
+squads run research                        # lead briefs → workers → review → converge
+squads run research --dry-run              # preview without executing
+
+# Another provider (squads is provider-agnostic)
+squads run research/analyst --provider=gemini
+```
+
+Bounds and containment:
+
+| Flag | Purpose |
+|------|---------|
+| `-t, --timeout <min>` | Hard per-agent timeout |
+| `--cost-ceiling <usd>` | Budget cap for the conversation |
+| `--max-turns <n>` | Conversation turn limit |
+| `-b` / `-w` | Detached / detached with log tail |
+
+While it runs — and if it goes wrong:
+
+```bash
+squads runs                        # live background runs
+squads kill <target>               # stop one gracefully
+```
+
+If a run dies mid-work, uncommitted deliverables are auto-saved to a `squads/run-*` branch and flagged in the inbox as PARTIAL — work is never silently lost.
+
+## DECIDE — the inbox is the human gate
+
+```bash
+squads inbox                       # everything waiting on a human, one screen
+squads inbox approve <id>          # PR items: arms CI-gated auto-merge
+squads inbox reject <id> "reason"  # branches: archive-tag then delete; reason → feedback
+squads inbox defer <id> --until <date>
+```
+
+Decisions are recorded in `reviewed.jsonl` with who decided (`--by` for bridges acting on someone's behalf). Autonomous actors must stamp themselves — never a human who didn't look.
+
+## LEARN — close the loop
+
+```bash
+# Rate what a run actually delivered (feeds provider/squad routing)
+squads feedback add engineering 4 "PR merged clean, tests included"
+
+# Persist knowledge for the next run
+squads memory write engineering "Registry pattern: commands self-describe via commands --json"
+squads memory read engineering
+squads memory query "CI pipeline failures"     # search across all squads
+squads sync --push                              # share memory across machines
+
+# Executor quality-per-cost, from real outcomes
+squads scoreboard
 ```
 
 ---
 
-## Environment & Configuration
-
-### Execution Environment
+## Instruments
 
 ```bash
-squads env show engineering              # View MCP servers, skills, model, budget
-squads env show engineering --json       # Machine-readable
-squads env prompt engineering            # Ready-to-use prompt for Claude Code
+squads status [squad] [-v] [--json]     # workforce state
+squads dash [name] [--ceo]              # dashboards
+squads usage [--all-claude]             # spend: project-scoped by default, machine-wide with the flag
+squads doctor [-v]                      # tools, auth, project readiness — run this first when anything fails
+squads providers                        # available LLM CLI lanes
+squads pause <squad> / resume <squad>   # governance: a paused squad cannot be dispatched
 ```
 
-### Provider Management
+## Agent patterns (during execution)
 
 ```bash
-squads providers                         # List available LLM CLI providers
-```
-
-### Sessions
-
-```bash
-squads sessions                          # Active Claude Code sessions
-squads session start                     # Start new session
-squads session end                       # End current session
-```
-
----
-
-## Autonomous Scheduling
-
-The daemon runs agents on configured schedules without human intervention.
-
-```bash
-squads auto start                  # Start scheduling daemon
-squads auto stop                   # Stop daemon
-squads auto status                 # Show daemon status + next runs
-squads auto pause "quota exhausted"  # Pause with reason
-squads auto resume                 # Resume after pause
-```
-
----
-
-## Common Patterns
-
-### Agent Self-Context (during execution)
-
-Agents call these to understand their environment:
-
-```bash
-# What am I working with?
+# Orient: what am I working with, what do I know, what's the state?
 squads env show ${SQUAD_NAME} --json
-
-# What do I know?
 squads memory read ${SQUAD_NAME}
-
-# What's happening across the org?
 squads status --json
 
-# What's the business context?
-squads context --squad ${SQUAD_NAME} --json
-```
-
-### Post-Execution Memory Update
-
-```bash
-# Persist what you learned
+# Persist before you finish — memory is the only thing that survives you
 squads memory write ${SQUAD_NAME} "Key finding from this run"
-squads learn "Pattern discovered: X causes Y" --squad ${SQUAD_NAME} --category pattern
 
-# Sync to remote
-squads sync --push
+# Dispatch follow-up work as a bounded task, never as loose edits
+squads run engineering --task "Fix the bug found in #461 — spec in issue" -b
 ```
 
-### Dispatch Another Agent
+Before creating issues or PRs, check what already exists: `squads status <squad> -v` + `squads memory read <squad>`.
 
-```bash
-# From within an agent, trigger another
-squads run engineering/issue-solver --task "Fix the bug I found in #461" -b
-```
+## Command surface
 
-### Check Before Creating
-
-Before creating issues/PRs, check what exists:
-
-```bash
-squads status engineering -v    # See active work
-squads memory read engineering  # See known issues
-squads context --squad engineering --json  # Full context
-```
-
-## Full Command Reference
-
-See `references/commands.md` for the complete command listing (generated from the live registry). For the authoritative surface on YOUR installed version, run `squads commands --json`.
+The verbs above are the canonical surface. Older command names (`orchestrate`, `autopilot`, `autonomy`, `approval`, `learn`, `stats`, `cost`, `history`, …) are deprecated aliases that print their replacement. Full generated reference: `references/commands.md`; authoritative for YOUR installed version: `squads commands --json`.
 
 ## Troubleshooting
 
@@ -322,8 +182,8 @@ See `references/commands.md` for the complete command listing (generated from th
 |---------|-----|
 | `squads: command not found` | `npm install -g squads-cli` |
 | No squads found | Run `squads init` to create `.agents/` |
+| No AI CLI installed | Init scaffolds in planning-only mode; install a provider then `squads init --force --provider <id>` |
 | Agent not found | Check path: `.agents/squads/{squad}/{agent}.md` |
 | Memory not persisting | Check `.agents/memory/` exists, run `squads sync` |
-| Wrong provider | Set `--provider` flag or `provider:` in SQUAD.md frontmatter |
-| API quota exhausted | `squads auto pause "quota"`, switch provider, or wait |
-| Context too large | Use `--effort low` or reduce context layers |
+| API quota exhausted | Wait for the window, switch `--provider`, or `squads pause <squad>` |
+| Anything else | `squads doctor -v` |


### PR DESCRIPTION
0.9 loop release, part 1 of 3 (founder-approved design from today's command-surface audit).

The seed skill becomes the workflow spec: INTENT → EXECUTE → DECIDE → LEARN, human-five vs agent working verbs, containment guarantees stated (bounded runs, worktree isolation, PARTIAL salvage, reviewed.jsonl attribution), memory-portability note (files-first = provider-portable). Reference tier unchanged (`references/commands.md`, no drift — surface untouched).

Note: the 'deprecated aliases print their replacement' line anticipates #1020, which must land in the same 0.9 release.

Parts 2–3: #1020 (deprecation aliases), #1021 (inbox truthfulness).

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)