### PR TITLE
fix(inbox): truthful attribution + stale-row reconcile

### DIFF
--- a/src/lib/inbox-decisions.ts
+++ b/src/lib/inbox-decisions.ts
@@ -68,6 +68,15 @@ export function reviewedLedgerPath(obsRoot: string): string {
 /** Local operator identity: `squads login` email when a session exists, else
  *  the OS user. Never throws — attribution must not block a decision. */
 export function operatorIdentity(): string {
+  // #1021: headless/autonomous invocations must stamp themselves. Every
+  // ledger decision to 2026-07-07 was made by the autonomous tick but
+  // stamped with the founder's login email via this fallback — the ledger
+  // must never claim a human decided what they never saw. `--by` remains
+  // the explicit override for bridges acting on a real decider's behalf.
+  if (!process.stdin.isTTY) {
+    const agent = process.env.SQUADS_AGENT;
+    return agent ? `agent:${agent}` : 'agent:headless';
+  }
   try {
     const email = loadSession()?.email;
     if (email) return email;

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -161,12 +161,34 @@ export function scanStrandedBranches(repoRoot: string): InboxItem[] {
   return items;
 }
 
+/** Injectable shell for tests (mirrors inbox-decisions' CommandRunner). */
+export type ShRunner = (cmd: string, cwd: string) => string;
+
+/**
+ * Live PR state for an artifact pointer (#1021 stale-row reconcile). A run
+ * item is only "waiting on a human" while at least one of its PRs is still
+ * open — 4 of 6 items in the 2026-07-07 audit were already-merged PRs shown
+ * as waiting. Fail-open: if gh can't answer (offline, no gh), the item stays
+ * visible — a stale row beats a hidden one.
+ */
+function prStillOpen(ref: string, run: ShRunner): boolean {
+  try {
+    const state = run(`gh pr view ${ref} --json state --jq .state`, process.cwd()).trim();
+    return state !== 'MERGED' && state !== 'CLOSED';
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Recent runs whose event stream recorded PR artifacts — output that exists
- * and may not have landed. Without live resolution this lists them for a
- * human `squads runs --outcome <id>`; the caller can resolve live (capped).
+ * and may not have landed. Landed (merged/closed) PRs are reconciled away at
+ * read time (#1021); liveness checks are skipped under VITEST /
+ * SQUADS_INBOX_NO_FETCH unless a runner is injected.
  */
-export function scanRunsWithArtifacts(obsRoot: string, limit = 15): InboxItem[] {
+export function scanRunsWithArtifacts(obsRoot: string, limit = 15, opts?: { run?: ShRunner }): InboxItem[] {
+  const liveness: ShRunner | null =
+    opts?.run ?? (process.env.VITEST || process.env.SQUADS_INBOX_NO_FETCH === '1' ? null : sh);
   const eventsDir = join(obsRoot, '.agents', 'observability', 'events');
   if (!existsSync(eventsDir)) return [];
   let files: Array<{ id: string; path: string; mtime: number }>;
@@ -197,14 +219,16 @@ export function scanRunsWithArtifacts(obsRoot: string, limit = 15): InboxItem[] 
       }
     } catch { continue; }
     if (prRefs.length === 0) continue;
+    const openRefs = liveness ? prRefs.filter((ref) => prStillOpen(ref, liveness)) : prRefs;
+    if (openRefs.length === 0) continue; // every PR landed — resolved, not waiting (#1021)
     items.push({
       id: `run-${f.id}`,
       kind: 'run_artifacts',
       ref: f.id,
-      title: `${squad || 'run'} produced ${prRefs.length} PR${prRefs.length > 1 ? 's' : ''}`,
+      title: `${squad || 'run'} produced ${openRefs.length} PR${openRefs.length > 1 ? 's' : ''}`,
       ageDays: ageDaysFrom(f.mtime),
       approveSemantics: `check landed state: squads runs --outcome ${f.id}`,
-      detail: prRefs[0],
+      detail: openRefs[0],
     });
   }
   return items;

--- a/test/inbox-decisions.test.ts
+++ b/test/inbox-decisions.test.ts
@@ -98,6 +98,20 @@ describe('decision attribution (by, C1a)', () => {
   it('operatorIdentity never returns empty', () => {
     expect(operatorIdentity().length).toBeGreaterThan(0);
   });
+
+  describe('headless attribution (#1021)', () => {
+    // Under vitest stdin is not a TTY — exactly the headless condition.
+    it('stamps agent:headless instead of a login identity when stdin is not a TTY', () => {
+      delete process.env.SQUADS_AGENT;
+      expect(operatorIdentity()).toBe('agent:headless');
+    });
+
+    it('names the agent when SQUADS_AGENT is set', () => {
+      process.env.SQUADS_AGENT = 'coo-tick';
+      expect(operatorIdentity()).toBe('agent:coo-tick');
+      delete process.env.SQUADS_AGENT;
+    });
+  });
 });
 
 describe('defer', () => {

--- a/test/inbox.test.ts
+++ b/test/inbox.test.ts
@@ -84,6 +84,46 @@ describe('scanRunsWithArtifacts (#924)', () => {
   it('missing events dir yields empty', () => {
     expect(scanRunsWithArtifacts(dir)).toEqual([]);
   });
+
+  describe('stale-row reconcile (#1021)', () => {
+    const seed = (execId: string, refs: string[]) => {
+      const eventsDir = join(dir, '.agents', 'observability', 'events');
+      mkdirSync(eventsDir, { recursive: true });
+      const line = (event: unknown, seq: number) =>
+        JSON.stringify({ v: 1, runId: execId, seq, ts: '2026-07-04T00:00:00Z', event });
+      writeFileSync(join(eventsDir, `${execId}.jsonl`), [
+        line({ type: 'run_start', squad: 'cli', mode: 'background', model: '', role: '', startedAt: 'x' }, 0),
+        ...refs.map((ref, i) => line({ type: 'artifact', kind: 'pr', ref }, i + 1)),
+      ].join('\n'));
+    };
+
+    it('drops items whose every PR already landed', () => {
+      seed('exec_merged', ['https://github.com/o/r/pull/1']);
+      const run = () => 'MERGED\n';
+      expect(scanRunsWithArtifacts(dir, 15, { run })).toEqual([]);
+    });
+
+    it('keeps items with an open PR and points detail at the open ref', () => {
+      seed('exec_mixed', ['https://github.com/o/r/pull/1', 'https://github.com/o/r/pull/2']);
+      const run = (cmd: string) => (cmd.includes('/pull/1') ? 'MERGED\n' : 'OPEN\n');
+      const items = scanRunsWithArtifacts(dir, 15, { run });
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toContain('produced 1 PR');
+      expect(items[0].detail).toBe('https://github.com/o/r/pull/2');
+    });
+
+    it('fails open: gh errors keep the item visible', () => {
+      seed('exec_offline', ['https://github.com/o/r/pull/9']);
+      const run = () => { throw new Error('gh: not logged in'); };
+      const items = scanRunsWithArtifacts(dir, 15, { run });
+      expect(items).toHaveLength(1);
+    });
+
+    it('skips liveness entirely under VITEST when no runner injected', () => {
+      seed('exec_default', ['https://github.com/o/r/pull/3']);
+      expect(scanRunsWithArtifacts(dir)).toHaveLength(1);
+    });
+  });
 });
 
 describe('buildInbox ordering', () => {


### PR DESCRIPTION
0.9 loop release, part 3 of 3 (#1019 skill ✓, #1020 aliases pending).

**Attribution**: every ledger decision to date was made by the autonomous tick but stamped `by: <founder login email>` via the operatorIdentity fallback. Headless invocations (stdin not a TTY) now stamp `agent:<SQUADS_AGENT>` / `agent:headless`. `--by` remains the explicit bridge override. The ledger never again claims a human decided what they never saw.

**Reconcile**: run-artifact items now verify PR liveness at read time — items whose every PR merged/closed are resolved, not shown as waiting. Fail-open (offline/no-gh keeps rows visible). VITEST/NO_FETCH skip unless a runner is injected.

**Live receipt**: hq's inbox went from 6 items (4 stale) → 1 genuinely-waiting item → that item exposed a superseded duplicate PR (#1013, now closed) → inbox zero.

Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)