### PR TITLE
fix(sequential): --task refuses on non-tool-use lanes; harvest never touches the trunk

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -732,6 +732,21 @@ async function runSquad(
       const squadProvider = normalizeProviderName(options.provider || squad?.providers?.default || 'anthropic');
 
       if (options.execute && !TOOL_USE_PROVIDERS.has(squadProvider)) {
+        // #966: sequential mode cannot hold a --task — it runs each agent's
+        // definition against the cwd with no conversation, no PR gate, and no
+        // way to carry the directive. The old behavior silently dropped the
+        // task, ran all agents, and reported success. REFUSE instead.
+        if (options.task) {
+          writeLine(`  ${icons.error} ${colors.red}--task needs an executor that can hold a task — ${squadProvider} runs sequential mode (no tool use).${RESET}`);
+          writeLine();
+          writeLine(`  ${colors.dim}Run the task through a single agent (task directive supported):${RESET}`);
+          writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}/<agent>${RESET} --task "..." --provider=${squadProvider}`);
+          writeLine(`  ${colors.dim}Or use a tool-use provider for the squad conversation:${RESET}`);
+          writeLine(`  ${colors.dim}$${RESET} squads run ${colors.cyan}${squad.name}${RESET} --task "..."`);
+          writeLine();
+          process.exitCode = 1;
+          return;
+        }
         // Sequential mode for providers without tool use (Ollama, Codex, etc.)
         await runSequentialMode(squad, squadsDir, squadProvider, options);
       } else if (options.execute) {

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -531,8 +531,7 @@ export function cleanupWorktree(
 export type HarvestOutcome =
   | { outcome: 'in-place' }          // ran in projectRoot directly — nothing to move
   | { outcome: 'nothing' }           // worktree clean, no commits — agent produced no file changes
-  | { outcome: 'merged' }            // committed + fast-forwarded into projectRoot
-  | { outcome: 'branch-preserved'; branch: string }  // committed but projectRoot diverged/dirty — branch kept
+  | { outcome: 'branch-preserved'; branch: string }  // committed to the agent branch — the only landing path (#966)
   | { outcome: 'blocked'; detail: string };          // secret/PII scan refused the commit — worktree kept
 
 /**
@@ -542,9 +541,12 @@ export type HarvestOutcome =
  * prompted with), so the engine historically never harvested — and provider
  * executors like aider, which only edit files, silently lost ALL output when
  * the worktree was cleaned (#823). This commits whatever the executor wrote
- * (after the same secret/PII scan autoCommitAgentWork uses) and fast-forwards
- * the project root; when that isn't safe the agent branch is preserved and
- * reported instead. Work must never evaporate behind a green run.
+ * (after the same secret/PII scan autoCommitAgentWork uses) and preserves it
+ * on the agent branch — NEVER integrated into the operator's checkout (#966:
+ * the old fast-forward path landed unrequested agent commits directly on a
+ * host repo's main). The inbox stranded-branch scanner surfaces the branch
+ * for a human decision. Work must never evaporate behind a green run — and
+ * must never land without one either.
  */
 export async function harvestProviderWork(
   workDir: string,
@@ -596,14 +598,9 @@ export async function harvestProviderWork(
   } catch { /* branch missing — treat as nothing */ }
   if (ahead === '0') return { outcome: 'nothing' };
 
-  // 3. Fast-forward the project root. --ff-only refuses on divergence and
-  //    aborts (preserving local changes) rather than producing a merge state.
-  try {
-    execSync(`git merge --ff-only '${branchName}'`, { cwd: projectRoot, stdio: 'pipe' });
-    return { outcome: 'merged' };
-  } catch {
-    return { outcome: 'branch-preserved', branch: branchName };
-  }
+  // 3. Preserve on the agent branch — integration is a human decision made
+  //    through the inbox gate, never a side effect of a run finishing (#966).
+  return { outcome: 'branch-preserved', branch: branchName };
 }
 
 // ── Detached execution helpers ───────────────────────────────────────
@@ -1332,13 +1329,9 @@ export async function executeWithProvider(
         }
 
         switch (harvest.outcome) {
-          case 'merged':
-            writeLine(`  ${colors.green}Harvested agent work${RESET} ${colors.dim}(fast-forwarded ${branchName})${RESET}`);
-            cleanupWorktree(workDir, projectRoot);
-            break;
           case 'branch-preserved':
-            writeLine(`  ${colors.yellow}Agent work preserved on branch ${harvest.branch}${RESET}`);
-            writeLine(`  ${colors.dim}Project root diverged or has conflicting changes — merge manually: git merge ${harvest.branch}${RESET}`);
+            writeLine(`  ${colors.green}Agent work preserved on branch ${harvest.branch}${RESET}`);
+            writeLine(`  ${colors.dim}Review and land it through the gate: squads inbox${RESET}`);
             cleanupWorktree(workDir, projectRoot, { keepBranch: true });
             break;
           case 'blocked':

--- a/test/harvest.test.ts
+++ b/test/harvest.test.ts
@@ -55,17 +55,21 @@ describe('harvestProviderWork (#823 — executor output must never be lost)', ()
     rmSync(workDir, { recursive: true, force: true });
   });
 
-  it('commits dirty executor output and fast-forwards the project root', async () => {
+  it('commits dirty executor output to the agent branch and NEVER touches the project trunk (#966)', async () => {
     writeFileSync(join(workDir, 'report.md'), '# Agent report\n');
+    const trunkBefore = git('rev-parse HEAD', root).trim();
 
     const result = await harvestProviderWork(workDir, root, branch, {
       squadName: 'testsquad', agentName: 'testagent', provider: 'deepseek',
     });
 
-    expect(result.outcome).toBe('merged');
-    expect(existsSync(join(root, 'report.md'))).toBe(true);
-    expect(readFileSync(join(root, 'report.md'), 'utf-8')).toContain('Agent report');
-    expect(git('log -1 --format=%s', root)).toContain('testsquad/testagent');
+    expect(result.outcome).toBe('branch-preserved');
+    if (result.outcome === 'branch-preserved') expect(result.branch).toBe(branch);
+    // The operator's checkout is untouched — integration is an inbox decision.
+    expect(git('rev-parse HEAD', root).trim()).toBe(trunkBefore);
+    expect(existsSync(join(root, 'report.md'))).toBe(false);
+    // The work exists, committed on the agent branch.
+    expect(git(`log -1 --format=%s '${branch}'`, root)).toContain('testsquad/testagent');
   });
 
   it('preserves the branch when the project root has diverged', async () => {


### PR DESCRIPTION
P1 containment, reproduced live this morning (see #966 comment): task dropped, 13 agents ran against the host repo, junk commits fast-forwarded onto local main, false success footer.

**Cut 1 — refuse, don't reinterpret**: squad-level `--task` + non-tool-use provider exits 1 with both working remedies (single-agent `--task` via the TASK DIRECTIVE path; tool-use provider for conversations).

**Cut 2 — the trunk is sacred**: `harvestProviderWork` no longer fast-forwards the project root under any condition. Executor output lands on the agent branch; the inbox stranded-branch scanner surfaces it; integration is a human decision. (The #823 never-lose-work rationale predates the inbox — branch + gate now satisfies it without writing to anyone's checkout.)

Verified: the exact incident command refuses with exit 1; harvest test asserts trunk HEAD unchanged; 2220/2220 tests green.

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)