### PR TITLE
refactor(commands): 0.9 deprecation pass — 62 visible verbs become 25

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ import type { SessionSummaryData } from './commands/sessions.js';
 
 // Setup imports (must run on every invocation)
 import { registerExitHandler, installCommandTelemetry } from './lib/telemetry.js';
+import { applyCommandSurface, installDeprecationNotices } from './lib/command-surface.js';
 import { applyStackConfig } from './lib/stack-config.js';
 
 // Register-pattern commands (must define subcommand structure before parseAsync)
@@ -1335,6 +1336,14 @@ function handleError(error: unknown): void {
 // Register global error handlers
 process.on('uncaughtException', handleError);
 process.on('unhandledRejection', handleError);
+
+// #1020: shrink the visible surface to the canonical loop verbs — absorbed
+// names keep working (hidden + one stderr deprecation notice per use).
+applyCommandSurface(program);
+installDeprecationNotices(program);
+program.addHelpText('after', chalk.dim(
+  '\nDeprecated command names still work but are hidden — each prints its canonical replacement.\nFull surface: squads commands --json --all\n'
+));
 
 // Parse arguments (use parseAsync to properly await async actions)
 try {

--- a/src/lib/command-surface.ts
+++ b/src/lib/command-surface.ts
@@ -1,0 +1,105 @@
+/**
+ * command-surface.ts — the 0.9 deprecation pass (#1020).
+ *
+ * The audit (2026-07-07) found 61 top-level commands with real usage
+ * concentrated in ~17 verbs and 19 commands with zero doc mentions. This
+ * module shrinks the VISIBLE surface without breaking anyone: absorbed
+ * command names keep working exactly as before, but are hidden from
+ * --help and print a one-line deprecation notice (to stderr, so piped
+ * stdout and --json consumers never see it). Removal happens no earlier
+ * than one minor version after hiding.
+ *
+ * The canonical verb set is taught by the seed skill (templates/seed/
+ * skills/squads-cli/SKILL.md) — this map is its enforcement half.
+ */
+
+import type { Command } from 'commander';
+
+/** Absorbed command name → the canonical verb that owns the concern now. */
+export const DEPRECATED_COMMANDS: Record<string, string> = {
+  // execution — one verb runs work
+  exec: 'run',
+  orchestrate: 'run',
+  autonomous: 'run',
+  autopilot: 'run',
+  autonomy: 'run',
+  trigger: 'run',
+  // the human gate
+  approval: 'inbox',
+  review: 'inbox',
+  // observability — runs/status/usage/doctor cover it
+  log: 'runs',
+  obs: 'runs',
+  results: 'runs',
+  sessions: 'status',
+  list: 'status',
+  context: 'status',
+  health: 'doctor',
+  cost: 'usage',
+  budget: 'usage',
+  stats: 'usage',
+  history: 'usage',
+  // direction
+  goals: 'goal',
+  kpi: 'goal',
+  progress: 'goal',
+  // knowledge
+  learn: 'memory',
+  learnings: 'memory',
+  cognition: 'memory',
+  sync: 'memory',
+  // evaluation
+  eval: 'feedback',
+  // platform/provider tail
+  credentials: 'providers',
+  tier: 'providers',
+  services: 'providers',
+  catalog: 'providers',
+  deploy: 'providers',
+  release: 'providers',
+  // scaffolding
+  add: 'init',
+  'detect-squad': 'status',
+  brief: 'propose',
+};
+
+/** Plumbing kept registered for hooks/automation but hidden from humans —
+ *  no deprecation notice (SessionStart hooks call it on every session). */
+export const HIDDEN_PLUMBING = new Set(['session']);
+
+/**
+ * Hide absorbed + plumbing commands from --help. Behavior is unchanged —
+ * `hidden` only affects help listings; `squads commands --json --all`
+ * still enumerates everything.
+ */
+export function applyCommandSurface(program: Command): void {
+  for (const cmd of program.commands) {
+    const name = cmd.name();
+    if (name in DEPRECATED_COMMANDS || HIDDEN_PLUMBING.has(name)) {
+      // Commander's help renderer reads the internal `_hidden` field — the
+      // same one `.command(name, { hidden: true })` sets at creation (stable
+      // since v7). The public `hidden` typing is read-surface only; assigning
+      // it creates a dead property the renderer never consults.
+      (cmd as Command & { _hidden: boolean })._hidden = true;
+    }
+  }
+}
+
+/**
+ * One dim notice per invocation of a deprecated name, on stderr so stdout
+ * (including --json) stays clean for parsers.
+ */
+export function installDeprecationNotices(program: Command): void {
+  program.hook('preAction', (_root, actionCommand) => {
+    // Walk to the top-level command under the program.
+    let top: Command = actionCommand;
+    while (top.parent && top.parent.parent) top = top.parent;
+    const name = top.name();
+    const canonical = DEPRECATED_COMMANDS[name];
+    if (canonical) {
+      process.stderr.write(
+        `  squads ${name} is deprecated — the canonical verb is: squads ${canonical}\n`
+      );
+    }
+  });
+}

--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -9,45 +9,22 @@
 | Command | Description |
 |---------|-------------|
 | `squads init` | Plant the seed: create manager agent, CLI skill, and starter squads |
-| `squads add <name>` | Add a new squad with directory structure and starter files |
 | `squads run [target] [agent]` | Run a squad or agent (no target lists squads). Use --org to run all squads as one coordinated cycle. |
-| `squads list` | List squads (alias for: squads status) |
 | `squads pause <squad>` | Pause a squad — run/org/cron dispatch will refuse until resumed |
 | `squads resume <squad>` | Resume a paused squad |
-| `squads orchestrate <squad>` | Run squad with lead agent orchestration |
 | `squads env show <squad>` | Show execution environment for a squad |
 | `squads env prompt <squad>` | Output ready-to-use prompt for Claude Code execution |
-| `squads exec list` | List recent executions |
-| `squads exec show <id>` | Show execution details |
-| `squads exec stats` | Show execution statistics |
-| `squads log` | Show run history with timestamps, duration, and status |
 | `squads dashboard [name]` | Show dashboards. Use "squads dash" for overview, "squads dash <name>" for specific dashboard, "squads dash --list" to see all. |
 | `squads status [squad]` | Show squad status and state |
-| `squads context` | Get business context for alignment: goals, memory, costs, activity |
-| `squads cost` | Show cost summary (today, week, by squad) |
-| `squads budget <squad>` | Check budget status for a squad |
 | `squads usage` | Show local cost/token usage (today, rolling window, by squad) |
-| `squads health` | Quick health check for all infrastructure services |
 | `squads doctor` | Check local tools, auth, and project readiness |
-| `squads history` | Show recent agent execution history |
-| `squads results [squad]` | Show squad results: git activity + KPI goals vs actuals |
 | `squads goal set <squad> <description>` | Set a goal for a squad |
 | `squads goal list [squad]` | List goals for squad(s) |
 | `squads goal complete <squad> <index>` | Mark a goal as completed |
 | `squads goal progress <squad> <index> <progress>` | Update goal progress |
-| `squads kpi list` | List all KPIs across squads |
-| `squads kpi show <squad>` | Show KPI status for a squad |
-| `squads kpi record <squad> <kpi> <value>` | Record a KPI value |
-| `squads kpi trend <squad> <kpi>` | Show KPI trend over time |
-| `squads kpi insights [squad]` | Generate insights from KPI data |
-| `squads progress start <squad> <description>` | Register a new active task |
-| `squads progress complete <taskId>` | Mark a task as completed |
 | `squads feedback add <squad> <rating> <feedback>` | Add feedback for last execution (rating 1-5) |
 | `squads feedback show <squad>` | Show feedback history |
 | `squads feedback stats` | Show feedback summary across all squads |
-| `squads autonomy` | Show autonomy score and confidence metrics |
-| `squads autopilot` | [deprecated] Use "squads run" instead — autopilot mode when no target given |
-| `squads stats [squad]` | Show agent outcome scorecards: merge rate, waste, cost per outcome |
 | `squads memory query <query>` | Search across all squad memory |
 | `squads memory read <squad>` | Show memory for a squad |
 | `squads memory write <squad> <content>` | Add to squad memory |
@@ -55,61 +32,10 @@
 | `squads memory sync` | Sync memory from git: pull remote changes, process commits, optionally push to Postgres |
 | `squads memory search <query>` | Search stored conversations (requires authentication: squads login) |
 | `squads memory extract` | Extract memories from recent conversations into Engram |
-| `squads learn <insight>` | Capture a learning for future sessions |
-| `squads learnings show <squad>` | Show learnings for a squad |
-| `squads learnings search <query>` | Search learnings across all squads |
-| `squads sync` | Git memory synchronization (Postgres sync optional) |
-| `squads trigger list [squad]` | List triggers |
-| `squads trigger sync` | Sync SQUAD.md triggers to scheduler |
-| `squads trigger fire <name>` | Manually fire a trigger |
-| `squads trigger enable <name>` | Enable a trigger |
-| `squads trigger disable <name>` | Disable a trigger |
-| `squads trigger status` | Show scheduler status |
-| `squads approval send <type>` | Send approval request to Slack |
-| `squads approval list` | List approvals |
-| `squads approval check <id>` | Check approval status |
-| `squads approval cancel <id>` | Cancel pending approval |
-| `squads autonomous start` | Start the scheduling daemon |
-| `squads autonomous stop` | Stop the scheduling daemon |
-| `squads autonomous status` | Show daemon status, running agents, and next runs |
-| `squads autonomous pause [reason]` | Pause the daemon (e.g. quota exhausted) |
-| `squads autonomous resume` | Resume a paused daemon |
-| `squads sessions history` | Show session history and statistics |
-| `squads sessions summary` | Show pretty session summary (auto-detects current session or pass JSON) |
-| `squads session start` | Register a new session |
-| `squads session stop` | End current session |
-| `squads session heartbeat` | Update session heartbeat |
-| `squads detect-squad` | Detect current squad based on cwd (for use in hooks) |
 | `squads login` | Log in to Squads (Pro & Enterprise) |
 | `squads logout` | Log out from Squads |
 | `squads whoami` | Show current logged in user |
-| `squads eval <target>` | Evaluate agent readiness for deployment (e.g., squads eval company/coo) |
-| `squads deploy status` | Show current platform deployment status |
-| `squads deploy pull` | Pull execution data and learnings from platform |
-| `squads cognition brief` | Executive summary: hot beliefs + recent signals + pending decisions |
-| `squads cognition beliefs` | Display world model beliefs |
-| `squads cognition decisions` | Decision journal with outcome scores |
-| `squads cognition reflect` | Trigger meta-cognition reflection |
 | `squads contract validate` | Derive + validate every agent contract; non-zero exit on any violation |
-| `squads catalog list` | List all services in the catalog |
-| `squads catalog show <service>` | Show detailed info for a service |
-| `squads catalog check [service]` | Run scorecard checks for a service (or all) |
-| `squads release pre-check <service>` | Validate dependencies and health before deploying a service |
-| `squads obs history` | Show execution history with tokens and cost |
-| `squads obs cost` | Show token spend summary |
-| `squads obs sync` | Backfill JSONL execution data to Postgres (Tier 2) |
-| `squads tier` | Show active infrastructure tier and available services |
-| `squads services up` | Start local services (Docker required) |
-| `squads services down` | Stop local services |
-| `squads services status` | Show running Docker containers and health |
-| `squads goals` | Dashboard of all squad goals — status at a glance |
-| `squads credentials create <squad>` | Create a service account and key for a squad |
-| `squads credentials create-all` | Create credentials for all squads with GCP config in SQUAD.md |
-| `squads credentials rotate <squad>` | Rotate a squad credential (create new key, delete old) |
-| `squads credentials list` | List all squad credentials and their status |
-| `squads credentials revoke <squad>` | Delete a squad service account and all keys |
-| `squads review` | Post-cycle evaluation — goals, costs, blockers, founder actions |
-| `squads brief` | Read recent sessions, extract founder intentions, create GitHub issues |
 | `squads providers` | Show available LLM CLI providers (claude, gemini, codex, etc.) |
 | `squads update` | Check for and install updates |
 | `squads version` | Show version information |

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -304,3 +304,53 @@ describe('installCommandTelemetry (#1009)', () => {
     expect(typeof done?.properties?.durationMs).toBe('number');
   });
 });
+
+// ─── #1020: command-surface deprecation pass ────────────────────────────
+import { applyCommandSurface, installDeprecationNotices, DEPRECATED_COMMANDS } from '../src/lib/command-surface.js';
+
+describe('command surface (#1020)', () => {
+  it('hides every absorbed name and session plumbing from help, behavior intact', () => {
+    const program = new Command('squads');
+    const run = program.command('run');
+    const cost = program.command('cost');
+    const session = program.command('session');
+    applyCommandSurface(program);
+    // assert against what the help renderer actually consults
+    const helpText = program.helpInformation();
+    expect(helpText).toContain('run');
+    expect(helpText).not.toContain('cost');
+    expect(helpText).not.toContain('session');
+    void run; void cost; void session;
+  });
+
+  it('prints one stderr notice with the canonical verb for a deprecated top-level command', async () => {
+    const program = new Command('squads');
+    program.command('cost').action(async () => {});
+    installDeprecationNotices(program);
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((s) => { writes.push(String(s)); return true; });
+    await program.parseAsync(['cost'], { from: 'user' });
+    spy.mockRestore();
+    expect(writes.join('')).toContain('squads cost is deprecated');
+    expect(writes.join('')).toContain('squads usage');
+  });
+
+  it('never notices canonical verbs or session plumbing', async () => {
+    const program = new Command('squads');
+    program.command('run').action(async () => {});
+    const session = program.command('session');
+    session.command('start').action(async () => {});
+    installDeprecationNotices(program);
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((s) => { writes.push(String(s)); return true; });
+    await program.parseAsync(['run'], { from: 'user' });
+    await program.parseAsync(['session', 'start'], { from: 'user' });
+    spy.mockRestore();
+    expect(writes.join('')).not.toContain('deprecated');
+  });
+
+  it('every deprecated name maps to a live canonical verb', () => {
+    const canonicals = new Set(Object.values(DEPRECATED_COMMANDS));
+    for (const c of canonicals) expect(c in DEPRECATED_COMMANDS).toBe(false);
+  });
+});


### PR DESCRIPTION
0.9 loop release, part 2 of 3 (#1019 skill ✓, #1021 inbox ✓). Founder-approved absorb table from today's usage audit.

**Zero breakage**: absorbed names work exactly as before — hidden from `--help`, one dim **stderr** notice per use naming the canonical verb (stdout/`--json` stays parseable). `session` hides silently (SessionStart hooks call it every session). Removal no earlier than one minor after hiding.

**Visible surface (25)**: init · run · pause · resume · env · dashboard · status · usage · doctor · goal · feedback · memory · login/logout/whoami · contract · providers · update · version · runs · inbox · propose · scoreboard · kill · commands

Seed skill reference regenerated (25 top-level) — the docs CLI reference shrinks the same way on next release via the freshness binding.

Follow-up noted for the docs repo: the prose drift-guard checks against `--all` (includes hidden), so prose teaching deprecated names should be made to fail at deprecation time, not final removal.

Verified live: `--help` lists 25; `squads cost` prints the notice on stderr and runs; 2224/2224 tests.

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)