### PR TITLE
fix(worktree): run worktrees base on fresh origin/develop, never stale local trunk

### DIFF
--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -53,20 +53,41 @@ export interface RunWorktree {
 let runCounter = 0;
 
 /**
- * Resolve the base branch for the worktree: prefer `develop` if it exists on
- * the repo, else the repo's current branch (HEAD). Falls back to 'HEAD' if the
- * current branch can't be determined.
+ * Resolve the base branch for the worktree: prefer the FRESH remote trunk
+ * (`origin/develop` after a fetch), else local `develop`, else the repo's
+ * current branch (HEAD).
+ *
+ * #1014: a run worktree cut from a stale local develop (16 commits behind)
+ * made a worker implement against an old tree — 40 minutes and real money
+ * for zero salvageable work. One bounded fetch per run buys a current base;
+ * offline machines fall back to local refs with a visible warning.
  */
 function resolveBaseRef(repoDir: string): string {
-  // Prefer develop when present (product repos branch off develop).
+  const rev = (ref: string): boolean => {
+    try {
+      execSync(`git rev-parse --verify --quiet ${ref}`, { cwd: repoDir, stdio: 'pipe' });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  // Freshen the trunk ref when a remote exists. Bounded: one ref, 15s cap.
+  let fetched = false;
   try {
-    execSync('git rev-parse --verify --quiet refs/heads/develop', {
-      cwd: repoDir,
-      stdio: 'pipe',
-    });
-    return 'develop';
+    execSync('git fetch --quiet origin develop', { cwd: repoDir, stdio: 'pipe', timeout: 15_000 });
+    fetched = true;
   } catch {
-    // develop doesn't exist locally — fall through to current branch.
+    // no remote / offline / no develop on origin — local refs are all we have
+  }
+
+  if (fetched && rev('refs/remotes/origin/develop')) return 'origin/develop';
+
+  if (rev('refs/heads/develop')) {
+    if (!fetched) {
+      writeLine(`  ${colors.yellow}worktree base = LOCAL develop (fetch failed — offline?); it may be stale${RESET}`);
+    }
+    return 'develop';
   }
 
   try {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -211,3 +211,39 @@ describe('createRunWorktree (#440)', () => {
     expect(tip).toBeTruthy();
   });
 });
+
+// ─── #1014: worktree base is the FRESH remote trunk ─────────────────────
+import { execSync as _ex } from 'child_process';
+
+describe('worktree base freshness (#1014)', () => {
+  it('cuts the worktree from origin/develop, not a stale local develop', () => {
+    const remote = mkdtempSync(join(tmpdir(), 'squads-wt-remote-'));
+    const clone = mkdtempSync(join(tmpdir(), 'squads-wt-clone-'));
+    const g = (cmd: string, cwd: string) =>
+      _ex(`git ${cmd}`, { cwd, encoding: 'utf8', env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t' } });
+    try {
+      // Remote with develop at commit A, then advanced to B.
+      g('init -q -b develop .', remote);
+      writeFileSync(join(remote, 'a.txt'), 'A');
+      g('add -A', remote); g('commit -qm A', remote);
+      g(`clone -q '${remote}' '${clone}/repo'`, remote);
+      const repo = join(clone, 'repo');
+      // Remote advances AFTER the clone — local develop is now stale.
+      writeFileSync(join(remote, 'b.txt'), 'B');
+      g('add -A', remote); g('commit -qm B', remote);
+
+      const wt = createRunWorktree(repo, 'freshtest');
+      try {
+        expect(wt.cwd).not.toBe(repo);
+        // The worktree must contain commit B (fresh origin/develop), which
+        // local develop does not have.
+        expect(existsSync(join(wt.cwd, 'b.txt'))).toBe(true);
+      } finally {
+        wt.cleanup();
+      }
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+      rmSync(clone, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Root cause of this morning's $33 zero-artifact timeout (#1014): the run worktree was cut from local develop, 16 commits behind origin, despite explicit branch-from-latest instructions in the task. One bounded fetch (single ref, 15s timeout) before base resolution; graceful offline fallback with a visible warning; regression test asserts a stale clone's worktree contains the remote-only commit.

2224+1 tests green.

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)