### PR TITLE
chore(release): v0.9.0 prep — bump, changelog, skill reference regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to `squads-cli` are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 Releases are also published as [GitHub Releases](https://github.com/agents-squads/squads-cli/releases).
 
+## [0.9.0] — 2026-07-07
+
+The loop release: the CLI teaches the loop, presents it, and enforces its trust properties.
+
+### The loop, taught and presented
+- The seed skill teaches the operating rhythm — intent → execute → decide → learn — with the human-five split from agent working verbs (#1019)
+- 62 visible commands become 25 canonical verbs; absorbed names keep working, hidden from `--help`, each printing its canonical replacement on stderr so piped output and `--json` stay clean (#1020)
+- `docs/architecture.md` updated to the shipped loop: containment, bounded dispatch, the decision gate, measured feedback, initiative — with the canonical execution-loop diagram (light/dark)
+
+### Trust enforcement
+- **Inbox is truthful** (#1021): headless/autonomous decisions stamp `agent:<name>`, never a login identity the human didn't exercise; run-artifact rows reconcile against live PR state — landed work stops showing as "waiting"
+- **The trunk is sacred** (#966): squad-level `--task` on a non-tool-use provider lane refuses with remedies instead of silently reinterpreting; provider harvest never fast-forwards the operator's checkout — work lands on the agent branch and integrates only through the inbox gate
+- **Fresh bases** (#1014): run worktrees are cut from freshly-fetched `origin/develop`, never a stale local trunk (offline falls back with a visible warning)
+- **One autonomy story** (#970): the orphaned in-CLI autopilot loop is deleted — autonomous cadence belongs to the platform heartbeat and the opt-in ambient `squads heartbeat` (upcoming)
+
+### Behavior changes
+- Provider-executed agent work is no longer auto-merged into your checkout on run completion — review it via `squads inbox` (this closes the path that could write to a repo's main without a human decision)
+- `--help` lists the canonical surface only; `squads commands --json --all` still enumerates everything
+
 ## 0.8.3 — 2026-07-07
 
 The first-run journey release: squads now works on a stranger's machine, verified by clean-room persona tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squads-cli",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Your AI workforce. Every user gets an AI manager that runs their team \u2014 finance, marketing, engineering, operations \u2014 for the cost of API calls.",
   "type": "module",
   "bin": {

--- a/templates/seed/skills/squads-cli/references/commands.md
+++ b/templates/seed/skills/squads-cli/references/commands.md
@@ -1,6 +1,6 @@
 # Squads CLI — Full Command Reference
 
-> GENERATED from `squads commands --json` (squads-cli v0.8.3) — do not edit.
+> GENERATED from `squads commands --json` (squads-cli v0.9.0) — do not edit.
 > Regenerate: `npm run build && npm run gen:skill`. For the live tree on any
 > installed version, run `squads commands --json` directly.
 


### PR DESCRIPTION
Release prep for v0.9.0 — the loop release. Version 0.8.3 → 0.9.0, CHANGELOG section (taught/presented · trust enforcement · behavior changes), seed skill reference regenerated at v0.9.0 (25 top-level commands). Same pattern as the 0.8.3 prep (#1004).

Refs the v0.9 milestone (all six issues closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)