### PR TITLE
feat(inbox): goal/coherence/oracle/strategy classes + fleet budget caps

### DIFF
--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -16,6 +16,10 @@ const KIND_LABEL: Record<InboxItem['kind'], string> = {
   pr: 'PR',
   run_branch: 'BRANCH',
   run_artifacts: 'RUN',
+  goal: 'GOAL',
+  coherence: 'COHERE',
+  oracle_alert: 'ALERT',
+  strategy_proposal: 'PROP',
 };
 
 const VERBS = new Set(['approve', 'reject', 'defer']);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,6 +22,8 @@ export interface ProjectConfig {
   agent_timeout_minutes: number;
   token_budget: number;
   cost_ceiling: number;
+  daily_budget_usd: number;
+  monthly_budget_usd: number;
   company_name: string;
   compose_file: string | null;
   telemetry: boolean;
@@ -33,6 +35,8 @@ const DEFAULTS: ProjectConfig = {
   agent_timeout_minutes: DEFAULT_TIMEOUT_MINUTES,
   token_budget: 50000,
   cost_ceiling: 25,
+  daily_budget_usd: 0,     // 0 = no company-level daily cap
+  monthly_budget_usd: 0,   // 0 = no company-level monthly cap
   company_name: '',
   compose_file: null,
   telemetry: true,
@@ -149,6 +153,14 @@ export function loadProjectConfig(): ProjectConfig {
       process.env.SQUADS_COST_CEILING ?? fileValues.cost_ceiling,
       DEFAULTS.cost_ceiling,
     ),
+    daily_budget_usd: toNumber(
+      process.env.SQUADS_DAILY_BUDGET_USD ?? fileValues.daily_budget_usd,
+      DEFAULTS.daily_budget_usd,
+    ),
+    monthly_budget_usd: toNumber(
+      process.env.SQUADS_MONTHLY_BUDGET_USD ?? fileValues.monthly_budget_usd,
+      DEFAULTS.monthly_budget_usd,
+    ),
     company_name:
       process.env.SQUADS_COMPANY_NAME ?? fileValues.company_name ?? DEFAULTS.company_name,
     compose_file:
@@ -167,4 +179,76 @@ export function loadProjectConfig(): ProjectConfig {
  */
 export function resetConfigCache(): void {
   cachedConfig = null;
+}
+
+// ── Fleet-Level Budget Enforcement ──────────────────────────────────
+
+export interface BudgetCheckResult {
+  allowed: boolean;
+  message: string;
+  /** Current spend in the window, USD. */
+  currentSpend: number;
+  /** Configured cap (0 = unlimited). */
+  cap: number;
+}
+
+/**
+ * Check whether dispatching another squad run would exceed the company-level
+ * daily or monthly budget. Reads local executions.jsonl (same source as
+ * `squads usage` — local-first, no API dependency).
+ *
+ * Returns { allowed: true } when no cap is configured (cap = 0).
+ * Caps are SOFT: the caller decides whether to block, warn, or override.
+ */
+export function checkFleetBudget(obsRoot: string): { daily: BudgetCheckResult; monthly: BudgetCheckResult } {
+  const config = loadProjectConfig();
+  const dailyCap = config.daily_budget_usd;
+  const monthlyCap = config.monthly_budget_usd;
+  const now = Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+  const dayStart = now - (now % dayMs);
+  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime();
+  let dailySpend = 0;
+  let monthlySpend = 0;
+
+  try {
+    const { readFileSync, existsSync } = require('fs');
+    const { join } = require('path');
+    const execFile = join(obsRoot, '.agents', 'observability', 'executions.jsonl');
+    if (existsSync(execFile)) {
+      for (const line of readFileSync(execFile, 'utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const e = JSON.parse(line);
+          const ts = e.started_at;
+          if (!ts) continue;
+          const epochMs = typeof ts === 'number' ? (ts > 1e12 ? ts : ts * 1000) : Date.parse(ts);
+          if (isNaN(epochMs)) continue;
+          const cost = parseFloat(e.cost_usd) || 0;
+          if (epochMs >= dayStart) dailySpend += cost;
+          if (epochMs >= monthStart) monthlySpend += cost;
+        } catch { /* corrupt line */ }
+      }
+    }
+  } catch { /* file unavailable */ }
+
+  const dailyResult: BudgetCheckResult = {
+    allowed: dailyCap === 0 || dailySpend < dailyCap,
+    message: dailyCap === 0 ? 'no daily cap configured'
+      : dailySpend >= dailyCap ? `daily budget exceeded: $${dailySpend.toFixed(2)} / $${dailyCap}`
+      : `daily spend: $${dailySpend.toFixed(2)} / $${dailyCap} (${((dailySpend / dailyCap) * 100).toFixed(0)}%)`,
+    currentSpend: dailySpend,
+    cap: dailyCap,
+  };
+
+  const monthlyResult: BudgetCheckResult = {
+    allowed: monthlyCap === 0 || monthlySpend < monthlyCap,
+    message: monthlyCap === 0 ? 'no monthly cap configured'
+      : monthlySpend >= monthlyCap ? `monthly budget exceeded: $${monthlySpend.toFixed(2)} / $${monthlyCap}`
+      : `monthly spend: $${monthlySpend.toFixed(2)} / $${monthlyCap} (${((monthlySpend / monthlyCap) * 100).toFixed(0)}%)`,
+    currentSpend: monthlySpend,
+    cap: monthlyCap,
+  };
+
+  return { daily: dailyResult, monthly: monthlyResult };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -207,13 +207,14 @@ export function checkFleetBudget(obsRoot: string): { daily: BudgetCheckResult; m
   const now = Date.now();
   const dayMs = 24 * 60 * 60 * 1000;
   const dayStart = now - (now % dayMs);
-  const monthStart = new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime();
+  // UTC month boundary — dayStart above is UTC-based; mixing in the local
+  // timezone here would shift monthly totals by up to a month at boundaries.
+  const nowDate = new Date(now);
+  const monthStart = Date.UTC(nowDate.getUTCFullYear(), nowDate.getUTCMonth(), 1);
   let dailySpend = 0;
   let monthlySpend = 0;
 
   try {
-    const { readFileSync, existsSync } = require('fs');
-    const { join } = require('path');
     const execFile = join(obsRoot, '.agents', 'observability', 'executions.jsonl');
     if (existsSync(execFile)) {
       for (const line of readFileSync(execFile, 'utf8').split('\n')) {

--- a/src/lib/inbox-decisions.ts
+++ b/src/lib/inbox-decisions.ts
@@ -212,6 +212,11 @@ export function approveItem(item: InboxItem, ctx: DecisionContext): DecisionOutc
     outcome = mergePr(number, item.ref, ctx.repoRoot, run);
   } else if (item.kind === 'run_branch') {
     outcome = approveBranch(item.ref, ctx.repoRoot, run);
+  } else if (item.kind === 'goal' || item.kind === 'coherence' || item.kind === 'oracle_alert' || item.kind === 'strategy_proposal') {
+    // Decision-gate items: approve = record the decision, no code mutation.
+    // Code mutations (goals.md edits, strategy updates) are executed by
+    // the bridge (inbox-sync.py) or the human operator after approval.
+    outcome = { ok: true, message: `${item.kind} '${item.title.slice(0, 60)}' approved — recorded in ledger` };
   } else {
     return {
       ok: false,
@@ -312,6 +317,10 @@ export function rejectItem(item: InboxItem, reason: string, ctx: DecisionContext
   } else if (item.kind === 'run_branch') {
     squad = squadFromBranch(item.ref);
     outcome = archiveBranch(item.ref, ctx.repoRoot, run);
+  } else if (item.kind === 'goal' || item.kind === 'coherence' || item.kind === 'oracle_alert' || item.kind === 'strategy_proposal') {
+    // Decision-gate reject: record the decision. The item is dismissed
+    // from the inbox; no artifact to archive/close.
+    outcome = { ok: true, message: `${item.kind} '${item.title.slice(0, 60)}' rejected — recorded in ledger` };
   } else {
     return {
       ok: false,

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -11,7 +11,7 @@
 
 import { execSync } from 'child_process';
 import { existsSync, readdirSync, statSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { parsePersistedLine } from './event-render.js';
 import { activeDeferrals } from './inbox-decisions.js';
 
@@ -235,6 +235,23 @@ export function scanRunsWithArtifacts(obsRoot: string, limit = 15, opts?: { run?
 }
 
 /**
+ * Run a validation script whose non-zero exit code IS the signal — these
+ * scripts exit non-zero precisely when they find problems, which is the case
+ * the caller wants to parse. Returns captured stdout either way; empty string
+ * only when the script produced no output (missing, crashed, timed out).
+ */
+function runValidationScript(script: string, timeoutMs: number): string {
+  try {
+    return execSync(`bash ${script}`, {
+      encoding: 'utf8', timeout: timeoutMs, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const stdout = (err as { stdout?: unknown }).stdout;
+    return typeof stdout === 'string' ? stdout : '';
+  }
+}
+
+/**
  * Machine-detected goal lifecycle events (hq#478). Reads goals.md across
  * squads and surfaces: achieved (all PR refs merged), contradicted (refs not
  * found), stale (no activity). Detection is from validate-goals.sh; this
@@ -250,9 +267,7 @@ export function scanGoalEvents(obsRoot: string): InboxItem[] {
   try {
     const validateScript = join(squadsDir, '..', '..', 'scripts', 'validate-goals.sh');
     if (!existsSync(validateScript)) return [];
-    const raw = execSync(`bash ${validateScript}`, {
-      encoding: 'utf8', timeout: 120_000, stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const raw = runValidationScript(validateScript, 120_000);
     for (const line of raw.split('\n')) {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('✓')) continue;
@@ -293,9 +308,8 @@ export function scanCoherenceViolations(obsRoot: string): InboxItem[] {
     return deriveCoherenceFromStatus(obsRoot);
   }
   try {
-    const raw = execSync(`bash ${coherenceScript}`, {
-      encoding: 'utf8', timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const raw = runValidationScript(coherenceScript, 30_000);
+    if (!raw) return deriveCoherenceFromStatus(obsRoot);
     const items: InboxItem[] = [];
     for (const line of raw.split('\n')) {
       const trimmed = line.trim();
@@ -393,7 +407,7 @@ export function scanStrategyProposals(obsRoot: string): InboxItem[] {
       if (!entry.isDirectory()) continue;
       const alignmentFile = join(memoryDir, entry.name, 'founder-alignment.md');
       if (!existsSync(alignmentFile)) continue;
-      const text = readFileSync(alignmentFile, 'utf8');
+      const text = readFileSync(alignmentFile, 'utf8').replace(/\r\n/g, '\n');
       const cycleMatch = text.match(/\*\*Suggested cycle output\*\*\n((?:\s*- .+\n?)+)/);
       if (!cycleMatch) continue;
       const suggestions = cycleMatch[1].split('\n').filter((l) => l.trim().startsWith('-'));

--- a/src/lib/inbox.ts
+++ b/src/lib/inbox.ts
@@ -15,7 +15,7 @@ import { join } from 'path';
 import { parsePersistedLine } from './event-render.js';
 import { activeDeferrals } from './inbox-decisions.js';
 
-export type InboxKind = 'pr' | 'run_branch' | 'run_artifacts';
+export type InboxKind = 'pr' | 'run_branch' | 'run_artifacts' | 'goal' | 'coherence' | 'oracle_alert' | 'strategy_proposal';
 
 export interface InboxItem {
   /** Stable handle for Child A's decisions: pr-12 | branch-<name> | run-<execId>. */
@@ -235,6 +235,186 @@ export function scanRunsWithArtifacts(obsRoot: string, limit = 15, opts?: { run?
 }
 
 /**
+ * Machine-detected goal lifecycle events (hq#478). Reads goals.md across
+ * squads and surfaces: achieved (all PR refs merged), contradicted (refs not
+ * found), stale (no activity). Detection is from validate-goals.sh; this
+ * scanner creates inbox items from its structured output.
+ */
+export function scanGoalEvents(obsRoot: string): InboxItem[] {
+  const memoryDir = join(obsRoot, '.agents', 'memory');
+  if (!existsSync(memoryDir)) return [];
+  const items: InboxItem[] = [];
+  let squadsDir = join(obsRoot, '.agents', 'squads');
+  if (!existsSync(squadsDir)) squadsDir = join(dirname(obsRoot), '.agents', 'squads');
+  if (!existsSync(squadsDir)) return [];
+  try {
+    const validateScript = join(squadsDir, '..', '..', 'scripts', 'validate-goals.sh');
+    if (!existsSync(validateScript)) return [];
+    const raw = execSync(`bash ${validateScript}`, {
+      encoding: 'utf8', timeout: 120_000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('✓')) continue;
+      const reviewMatch = trimmed.match(/⤴ REVIEW.*:\s+(.+)/);
+      if (reviewMatch) {
+        items.push({
+          id: `goal-${reviewMatch[1].slice(0, 40).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`,
+          kind: 'goal', ref: reviewMatch[1], title: `Goal achieved: ${reviewMatch[1].slice(0, 80)}`,
+          ageDays: 0, approveSemantics: 'move to Achieved in goals.md',
+          detail: 'all PR refs merged — appears complete',
+        });
+        continue;
+      }
+      const contraMatch = trimmed.match(/✗ CONTRADICTED:\s+(.+)/);
+      if (contraMatch) {
+        items.push({
+          id: `goal-${contraMatch[1].slice(0, 40).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`,
+          kind: 'goal', ref: contraMatch[1], title: `Goal contradicted: ${contraMatch[1].slice(0, 80)}`,
+          ageDays: 7, approveSemantics: 'keep as active',
+          detail: 'refs not found or not merged — may need review or drop',
+        });
+      }
+    }
+  } catch {
+    // validate-goals.sh unavailable — no goal items this cycle
+  }
+  return items;
+}
+
+/**
+ * Coherence violations (hq#479). Surfaces strategy↔runtime mismatches.
+ * If coherence-check.sh exists, delegates to it; otherwise derives from
+ * SQUAD.md status vs strategy.md active list.
+ */
+export function scanCoherenceViolations(obsRoot: string): InboxItem[] {
+  const coherenceScript = join(obsRoot, 'scripts', 'coherence-check.sh');
+  if (!existsSync(coherenceScript)) {
+    return deriveCoherenceFromStatus(obsRoot);
+  }
+  try {
+    const raw = execSync(`bash ${coherenceScript}`, {
+      encoding: 'utf8', timeout: 30_000, stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const items: InboxItem[] = [];
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('FAIL:')) continue;
+      const detail = trimmed.slice(5).trim();
+      items.push({
+        id: `coherence-${detail.slice(0, 30).replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase()}`,
+        kind: 'coherence', ref: detail, title: detail.slice(0, 100),
+        ageDays: 0, approveSemantics: 'acknowledge (fix or accept drift)',
+        detail: 'declarative state ≠ operational state — surfaced by coherence check',
+      });
+    }
+    return items;
+  } catch {
+    return deriveCoherenceFromStatus(obsRoot);
+  }
+}
+
+function deriveCoherenceFromStatus(obsRoot: string): InboxItem[] {
+  const items: InboxItem[] = [];
+  try {
+    const strategyFile = join(obsRoot, '.agents', 'memory', 'company', 'strategy.md');
+    const squadsDir = join(obsRoot, '.agents', 'squads');
+    if (!existsSync(strategyFile) || !existsSync(squadsDir)) return items;
+    const strategyText = readFileSync(strategyFile, 'utf8');
+    const activeMatch = strategyText.match(/\*\*Active:\*\*\s*(.+)/);
+    if (!activeMatch) return items;
+    const strategyActive = activeMatch[1].split(',').map((s: string) => s.trim());
+    const squads = readdirSync(squadsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+    for (const squad of squads) {
+      const squadFile = join(squadsDir, squad, 'SQUAD.md');
+      if (!existsSync(squadFile)) continue;
+      const squadText = readFileSync(squadFile, 'utf8');
+      const statusMatch = squadText.match(/^status:\s*(.+)/m);
+      const runtimePaused = statusMatch && statusMatch[1].trim() === 'paused';
+      const strategyActive_ = strategyActive.includes(squad);
+      if (runtimePaused && strategyActive_) {
+        items.push({
+          id: `coherence-squad-${squad}`,
+          kind: 'coherence', ref: squad,
+          title: `${squad}: paused at runtime but strategy.md says Active`,
+          ageDays: 0, approveSemantics: 'update strategy.md or squads resume',
+          detail: `SQUAD.md status=paused, strategy.md lists as Active`,
+        });
+      }
+    }
+  } catch { /* derivation failed */ }
+  return items;
+}
+
+/**
+ * Oracle alerts — survival signals that crossed a threshold. GPS stale >3d,
+ * lead silent >7d, coherence mismatch count >0. Reads from local state.
+ */
+export function scanOracleAlerts(obsRoot: string): InboxItem[] {
+  const items: InboxItem[] = [];
+  const gpsDir = join(obsRoot, 'data', 'intelligence');
+  if (existsSync(gpsDir)) {
+    try {
+      const backups = readdirSync(gpsDir)
+        .filter((f) => f.startsWith('gps.duckdb.backup.'))
+        .sort().reverse();
+      if (backups.length > 0) {
+        const latestBackup = join(gpsDir, backups[0]);
+        const mtime = statSync(latestBackup).mtimeMs;
+        const daysStale = Math.floor((Date.now() - mtime) / 86400000);
+        if (daysStale > 3) {
+          items.push({
+            id: 'oracle-gps-stale',
+            kind: 'oracle_alert', ref: 'gps-freshness',
+            title: `GPS data is ${daysStale}d stale — intelligence cadence at risk`,
+            ageDays: daysStale,
+            approveSemantics: 'acknowledge (dispatch GPS enrichment)',
+            detail: `last ingestion: ${backups[0].replace('gps.duckdb.backup.', '')}`,
+          });
+        }
+      }
+    } catch { /* unavailable */ }
+  }
+  return items;
+}
+
+/**
+ * Strategy proposals — machine-suggested direction from founder-alignment.md.
+ * Draft items the founder can promote to goals or dismiss.
+ */
+export function scanStrategyProposals(obsRoot: string): InboxItem[] {
+  const items: InboxItem[] = [];
+  const memoryDir = join(obsRoot, '.agents', 'memory');
+  if (!existsSync(memoryDir)) return items;
+  try {
+    for (const entry of readdirSync(memoryDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const alignmentFile = join(memoryDir, entry.name, 'founder-alignment.md');
+      if (!existsSync(alignmentFile)) continue;
+      const text = readFileSync(alignmentFile, 'utf8');
+      const cycleMatch = text.match(/\*\*Suggested cycle output\*\*\n((?:\s*- .+\n?)+)/);
+      if (!cycleMatch) continue;
+      const suggestions = cycleMatch[1].split('\n').filter((l) => l.trim().startsWith('-'));
+      for (const sug of suggestions.slice(0, 2)) {
+        const title = sug.replace(/^-\s*/, '').trim();
+        if (title.length < 10) continue;
+        const idSuffix = title.slice(0, 20).replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
+        items.push({
+          id: `proposal-${entry.name}-${idSuffix}`,
+          kind: 'strategy_proposal', ref: `founder-alignment:${entry.name}`,
+          title: `[${entry.name}] ${title.slice(0, 90)}`,
+          ageDays: 0, approveSemantics: 'promote to goals.md for this squad',
+          detail: 'from auto-generated founder-alignment — ready for review',
+        });
+      }
+    }
+  } catch { /* no proposals */ }
+  return items;
+}
+
+/**
  * The queue, newest-risk-first: open PRs (oldest = most overdue, first),
  * then stranded branches (the silent-loss class), then artifact runs.
  * Scanners are independent; one failing never empties the others.
@@ -248,7 +428,11 @@ export function buildInbox(repoRoot: string, obsRoot: string, opts?: { includeDe
   const prs = scanOpenPrs(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
   const branches = scanStrandedBranches(repoRoot).sort((a, b) => b.ageDays - a.ageDays);
   const runs = scanRunsWithArtifacts(obsRoot).sort((a, b) => b.ageDays - a.ageDays);
-  const all = [...prs, ...branches, ...runs];
+  const goals = scanGoalEvents(obsRoot);
+  const coherence = scanCoherenceViolations(obsRoot);
+  const oracleAlerts = scanOracleAlerts(obsRoot);
+  const proposals = scanStrategyProposals(obsRoot);
+  const all = [...prs, ...branches, ...runs, ...goals, ...coherence, ...oracleAlerts, ...proposals];
   if (opts?.includeDeferred) return all;
   const deferred = activeDeferrals(obsRoot);
   return deferred.size === 0 ? all : all.filter((i) => !deferred.has(i.id));


### PR DESCRIPTION
## Summary
Expands the inbox from 3 to 7 item kinds and adds fleet-level budget enforcement.

### #2 — Inbox classes (semi-autonomous system #2)
- 4 new InboxKind values: `goal`, `coherence`, `oracle_alert`, `strategy_proposal`
- `scanGoalEvents`: parses validate-goals.sh output for achieved (`⤴`) and contradicted (`✗`) goals
- `scanCoherenceViolations`: derives strategy↔runtime mismatches from SQUAD.md status vs strategy.md Active list
- `scanOracleAlerts`: GPS staleness >3d threshold
- `scanStrategyProposals`: founder-alignment.md suggested cycle output
- Decision-gate approve/reject for all new kinds (ledger-only, no code mutation — mutations come via inbox-sync bridge)
- `KIND_LABEL` updated for display

### #5 — Fleet-level budget enforcement (semi-autonomous system #5)
- `daily_budget_usd` and `monthly_budget_usd` added to ProjectConfig
- `SQUADS_DAILY_BUDGET_USD` / `SQUADS_MONTHLY_BUDGET_USD` env var support
- `checkFleetBudget()`: reads executions.jsonl, returns current spend vs cap
- Default 0 = unlimited (no breakage)

Tracks: [internal] (Company OS), [internal] (goals lifecycle), [internal] (coherence audit)

---
Agent: Claude
