### PR TITLE
fix(guardrail): drop stale MultiEdit deny rules (4 warnings on every first run)

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -16,7 +16,7 @@ Governance files set the **target**; memory files capture the **trajectory**. If
 
 ## How it's enforced
 
-`squads run` (and the daemon) launch each agent with `--settings templates/guardrail.json`, which carries native Claude Code `permissions.deny` rules for `Edit`/`Write`/`MultiEdit` on `goals.md`, `directives.md`, `SQUAD.md`. An agent that tries to edit one is refused by Claude Code itself ("denied by your permission settings") — no custom hook, no parsing.
+`squads run` (and the daemon) launch each agent with `--settings templates/guardrail.json`, which carries native Claude Code `permissions.deny` rules for `Edit`/`Write` on `goals.md`, `directives.md`, `SQUAD.md`. An agent that tries to edit one is refused by Claude Code itself ("denied by your permission settings") — no custom hook, no parsing.
 
 **Interactive sessions are unaffected.** The founder's (and cofounder's) own Claude Code sessions don't get the injected `--settings`, so they edit governance files normally. The boundary is exactly *human-in-session can; autonomous agent can't* — including when the COO runs as a scheduled agent (it executes, it doesn't rewrite goals).
 

--- a/src/lib/agent-contract.ts
+++ b/src/lib/agent-contract.ts
@@ -71,7 +71,7 @@ export interface AgentContract {
 
 // ── Tool-grant vocabulary (what the Claude Code allowlist can enforce) ───────
 const TOOL_NAME =
-  /^(Read|Write|Edit|MultiEdit|Grep|Glob|Bash|Agent|Task|WebFetch|WebSearch|TodoWrite|NotebookEdit)$/;
+  /^(Read|Write|Edit|Grep|Glob|Bash|Agent|Task|WebFetch|WebSearch|TodoWrite|NotebookEdit)$/;
 const BASH_SCOPED = /^Bash\([A-Za-z0-9_./ -]+(:\*)?\)$/; // Bash(git:*) | Bash(git status:*) — literal space only (not \s, which allows \n/\r/\t)
 const MCP_TOOL = /^mcp__[a-z0-9_]+__([a-z0-9_]+|\*)$/;
 

--- a/templates/guardrail.json
+++ b/templates/guardrail.json
@@ -1,10 +1,10 @@
 {
   "permissions": {
     "deny": [
-      "Edit(**/goals.md)", "Write(**/goals.md)", "MultiEdit(**/goals.md)",
-      "Edit(**/directives.md)", "Write(**/directives.md)", "MultiEdit(**/directives.md)",
-      "Edit(**/strategy.md)", "Write(**/strategy.md)", "MultiEdit(**/strategy.md)",
-      "Edit(**/SQUAD.md)", "Write(**/SQUAD.md)", "MultiEdit(**/SQUAD.md)"
+      "Edit(**/goals.md)", "Write(**/goals.md)",
+      "Edit(**/directives.md)", "Write(**/directives.md)",
+      "Edit(**/strategy.md)", "Write(**/strategy.md)",
+      "Edit(**/SQUAD.md)", "Write(**/SQUAD.md)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Every fresh `squads init` + `squads run demo hello-world` printed 4 error-looking warnings (`Permission deny rule "MultiEdit(**/goals.md)" matches no known tool`) because Claude Code folded MultiEdit into Edit. Dropped the 4 stale entries from `templates/guardrail.json` — the paired Edit/Write rules keep full protection. Synced `docs/governance.md:19` and the agent-contract TOOL_NAME regex.

**Verified**: build ✓, 2228/2228 tests ✓, and behaviorally — fresh workspace + local build, demo run prints **0** warnings (was 4).

Fixes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)