### PR TITLE
fix(readme): honest local-first claims — scoped no-login, documented telemetry opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ squads inbox                                    # everything waiting on YOUR dec
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (default
 provider — others optional). `squads doctor` checks your machine.
 
-Everything runs locally: your machine, your API keys, your data. No
-login, no cloud, no telemetry surprises.
+Runs locally by default: your machine, your API keys, your data stay
+on disk. No account needed for the open-source CLI — `squads login` is
+optional, only for Pro & Enterprise cloud features. Telemetry is
+anonymous and install-level only (command names, versions, error
+classes — never file contents, paths, or personal data); opt out any
+time with `DO_NOT_TRACK=1` or `SQUADS_TELEMETRY_DISABLED=1`.
 
 ## Development
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1047,6 +1047,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine();
   writeLine(`  ${chalk.dim('Telemetry: anonymous usage events (install id, command names, versions, error classes —')}`);
   writeLine(`  ${chalk.dim('never file contents, paths, or personal data) help us fix what breaks first.')}`);
+  writeLine(`  ${chalk.dim('Opt out any time: DO_NOT_TRACK=1 or SQUADS_TELEMETRY_DISABLED=1')}`);
   writeLine();
 
   // 7. Opt-in email capture for founder outreach


### PR DESCRIPTION
README.md:83-84 promised "No login, no cloud, no telemetry surprises" while --help ships `login (Pro & Enterprise)` and telemetry is on by default with the opt-out documented nowhere — the seam a Show-HN thread would tear open (cold-pass finding, verified). New copy scopes it honestly: local by default, keys/data on disk, login optional for Pro/Enterprise, telemetry anonymous + opt-out named (`DO_NOT_TRACK=1` / `SQUADS_TELEMETRY_DISABLED=1` — both verified real at telemetry.ts:150,153). The init telemetry notice now prints the opt-out vars too.

**Verified**: build ✓; fresh-workspace init prints the new opt-out line.

Fixes #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)