### PR TITLE
fix(copy): one voice — tagline + canonical run syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Agents Squads
 
-**Your AI ops teams.**
+**Your AI workforce.**
 
 Autonomous AI agents for engineering, marketing, finance, and operations.
 You make the decisions. They do the work.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,7 +296,7 @@ program.command('create <name>', { hidden: true }).description('[renamed]').acti
 // Run command - execute squads or individual agents
 program
   .command('run [target] [agent]')
-  .description('Run a squad or agent (no target lists squads). Use --org to run all squads as one coordinated cycle.')
+  .description('Run a squad or agent: squads run <squad>/<agent> (also: <squad> <agent>). No target lists squads; --org runs all squads as one coordinated cycle.')
   .allowExcessArguments(false)
   .option('-v, --verbose', 'Verbose output')
   .option('-d, --dry-run', 'Show what would be run without executing')

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1038,7 +1038,7 @@ export async function initCommand(options: InitOptions): Promise<void> {
   writeLine();
   // Dynamic first-run suggestion based on use case
   const firstRun = getFirstRunCommand(selectedUseCase);
-  const firstRunCmd = `squads run ${firstRun.squad} -a ${firstRun.agent}`;
+  const firstRunCmd = `squads run ${firstRun.squad}/${firstRun.agent}`;
   writeLine(`  ${chalk.green('→')} Run your first real agent:`);
   writeLine(`     ${chalk.yellow(firstRunCmd)}`);
   writeLine();


### PR DESCRIPTION
Cold-pass finding (verified): README tagline ('Your AI ops teams') diverged from the --help banner ('Your AI workforce'), and three surfaces taught three different run-example forms. Now: tagline **Your AI workforce** everywhere; canonical example form `squads run <squad>/<agent>` in README + init epilogue (list empty-state already used it); the two-positional alternative documented once in `run`'s help line.

Verified: build ✓, --help shows the new run description.

Fixes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)