### PR TITLE
fix(observability): real outcomes on foreground runs — parse session JSONL, never fake zeros

### DIFF
--- a/src/lib/event-render.ts
+++ b/src/lib/event-render.ts
@@ -76,10 +76,10 @@ export function renderEvent(event: ExecEvent): string | null {
     case 'run_end': {
       const o = event.outcomes;
       const made: string[] = [];
-      if (o.commits) made.push(`${o.commits} commit${o.commits > 1 ? 's' : ''}`);
-      if (o.prs_created) made.push(`${o.prs_created} PR${o.prs_created > 1 ? 's' : ''}`);
-      if (o.issues_created) made.push(`${o.issues_created} issue${o.issues_created > 1 ? 's' : ''}`);
-      if (o.files_edited) made.push(`${o.files_edited} file${o.files_edited > 1 ? 's' : ''} edited`);
+      if (o?.commits) made.push(`${o.commits} commit${o.commits > 1 ? 's' : ''}`);
+      if (o?.prs_created) made.push(`${o.prs_created} PR${o.prs_created > 1 ? 's' : ''}`);
+      if (o?.issues_created) made.push(`${o.issues_created} issue${o.issues_created > 1 ? 's' : ''}`);
+      if (o?.files_edited) made.push(`${o.files_edited} file${o.files_edited > 1 ? 's' : ''} edited`);
       const status = event.ok ? `${colors.green}completed${RESET}` : `${colors.red}failed${RESET}`;
       return `${colors.cyan}■${RESET} ${status} ${colors.dim}in ${fmtDuration(event.durationMs)}${event.totalUsage.costEst ? ` · $${event.totalUsage.costEst.toFixed(4)}` : ''}${made.length ? ` · ${made.join(', ')}` : ''}${RESET}`;
     }

--- a/src/lib/exec-events.ts
+++ b/src/lib/exec-events.ts
@@ -48,7 +48,7 @@ export type ExecEvent =
   | { type: 'subagent_done'; childRunId: string; agent: string; ok: boolean }
   | { type: 'token_usage'; input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number; model: string }
   | { type: 'artifact'; kind: 'commit' | 'pr' | 'issue' | 'file'; ref: string }
-  | { type: 'run_end'; ok: boolean; durationMs: number; totalUsage: { input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number }; outcomes: { actions: number; files_edited: number; commits: number; prs_created: number; issues_created: number } }
+  | { type: 'run_end'; ok: boolean; durationMs: number; totalUsage: { input: number; output: number; cacheRead: number; cacheWrite: number; costEst: number }; outcomes?: { actions: number; files_edited: number; commits: number; prs_created: number; issues_created: number } }
   | { type: 'truncated'; droppedCount: number; reason: string };
 
 /** Envelope stamped on every persisted line. */

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -748,6 +748,15 @@ export function executeForeground(config: {
         goals_before: Object.keys(goalsBefore).length > 0 ? goalsBefore : undefined,
         goals_after: Object.keys(goalsAfter).length > 0 ? goalsAfter : undefined,
         goals_changed: goalsChanged.length > 0 ? goalsChanged : undefined,
+        // Real outcomes parsed from the session JSONL (#1060) — absent when
+        // unknown so the scoreboard never ingests fake zeros.
+        ...(sessionUsage?.outcomes ? {
+          actions: sessionUsage.outcomes.actions,
+          files_edited: sessionUsage.outcomes.files_edited,
+          commits: sessionUsage.outcomes.commits,
+          prs_created: sessionUsage.outcomes.prs_created,
+          issues_created: sessionUsage.outcomes.issues_created,
+        } : {}),
       };
       logObservability(obsRecord);
 
@@ -774,7 +783,7 @@ export function executeForeground(config: {
             cacheWrite: sessionUsage?.cache_write_tokens || 0,
             costEst: sessionUsage?.cost_usd || 0,
           },
-          outcomes: { actions: 0, files_edited: 0, commits: 0, prs_created: 0, issues_created: 0 },
+          outcomes: sessionUsage?.outcomes,
         });
         config.events.close();
       }
@@ -831,7 +840,6 @@ export function executeForeground(config: {
           ok: false,
           durationMs,
           totalUsage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costEst: 0 },
-          outcomes: { actions: 0, files_edited: 0, commits: 0, prs_created: 0, issues_created: 0 },
         });
         config.events.close();
       }

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -10,6 +10,7 @@
 import { existsSync, readFileSync, appendFileSync, mkdirSync, readdirSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import { findProjectRoot } from './squad-parser.js';
+import { parseOutcomes, emptyOutcomes, addOutcomes, type RunOutcomes, type AssistantContentBlock } from './stream-json.js';
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -150,6 +151,9 @@ interface SessionUsage {
   cache_write_tokens: number;
   cost_usd: number;
   messages: number;
+  // What the session's tool_use blocks show the agent DID (#1060). Absent when
+  // no tool calls were seen — consumers must treat that as unknown, not zero.
+  outcomes?: RunOutcomes;
 }
 
 /**
@@ -234,6 +238,8 @@ function parseSessionUsage(sessionPath: string): SessionUsage | null {
       messages: 0,
     };
 
+    let outcomes = emptyOutcomes();
+
     for (const line of lines) {
       try {
         const record = JSON.parse(line);
@@ -250,6 +256,10 @@ function parseSessionUsage(sessionPath: string): SessionUsage | null {
             usage.cache_write_tokens += u.cache_creation_input_tokens || 0;
           }
 
+          if (Array.isArray(msg.content)) {
+            outcomes = addOutcomes(outcomes, parseOutcomes(msg.content as AssistantContentBlock[]));
+          }
+
           if (!usage.model || usage.model === 'unknown') {
             usage.model = msg.model || 'unknown';
           }
@@ -263,6 +273,11 @@ function parseSessionUsage(sessionPath: string): SessionUsage | null {
     }
 
     if (usage.messages === 0) return null;
+
+    // Same convention as the detached path (spool.ts): zero actions is
+    // indistinguishable from a parse miss, so report outcomes only when the
+    // agent verifiably did something — absent means unknown, never fake zero.
+    if (outcomes.actions > 0) usage.outcomes = outcomes;
 
     // Calculate cost from tokens if not directly available
     if (usage.cost_usd === 0) {

--- a/src/lib/spool.ts
+++ b/src/lib/spool.ts
@@ -235,13 +235,7 @@ function toRecord(spool: SpoolRecord, obsRoot: string): ObservabilityRecord {
           ok: status === 'completed',
           durationMs,
           totalUsage: { input, output, cacheRead, cacheWrite, costEst: cost },
-          outcomes: {
-            actions: outcomes?.actions || 0,
-            files_edited: outcomes?.files_edited || 0,
-            commits: outcomes?.commits || 0,
-            prs_created: outcomes?.prs_created || 0,
-            issues_created: outcomes?.issues_created || 0,
-          },
+          outcomes,
         });
       } catch { /* events are best-effort; the obs record below is the source of truth */ }
     }

--- a/src/lib/stream-json.ts
+++ b/src/lib/stream-json.ts
@@ -110,7 +110,7 @@ export interface ParsedLine {
   };
 }
 
-interface AssistantContentBlock {
+export interface AssistantContentBlock {
   type?: string;
   text?: string;
   name?: string;                     // tool name on `tool_use` blocks
@@ -118,7 +118,7 @@ interface AssistantContentBlock {
 }
 
 /** Count what the agent did from a message's `tool_use` blocks. */
-function parseOutcomes(blocks: AssistantContentBlock[]): RunOutcomes {
+export function parseOutcomes(blocks: AssistantContentBlock[]): RunOutcomes {
   const o = emptyOutcomes();
   for (const b of blocks) {
     if (!b || b.type !== 'tool_use') continue;

--- a/test/observability-outcomes.test.ts
+++ b/test/observability-outcomes.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #1060 — outcomes on foreground runs come from the session JSONL, never
+ * fabricated zeros. Locks the parseSessionUsage outcome extraction via the
+ * public captureSessionUsageById reader against a hermetic HOME fixture.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { captureSessionUsageById } from '../src/lib/observability.js';
+
+describe('session outcomes extraction (#1060)', () => {
+  let home: string;
+  let oldHome: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'squads-home-'));
+    oldHome = process.env.HOME;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    process.env.HOME = oldHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeSession(sessionId: string, lines: object[]): void {
+    const projDir = join(home, '.claude', 'projects', '-Users-x-repo');
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, `${sessionId}.jsonl`), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+  }
+
+  const usage = { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 };
+
+  it('counts tool_use blocks into outcomes', () => {
+    writeSession('sess-real', [
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          usage,
+          content: [
+            { type: 'text', text: 'editing' },
+            { type: 'tool_use', name: 'Edit', input: { file_path: '/x' } },
+            { type: 'tool_use', name: 'Bash', input: { command: 'git add -A && git commit -m "x"' } },
+          ],
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          model: 'claude-sonnet-5',
+          usage,
+          content: [{ type: 'tool_use', name: 'Bash', input: { command: 'gh pr create --title x' } }],
+        },
+      },
+    ]);
+
+    const out = captureSessionUsageById('sess-real');
+    expect(out).not.toBeNull();
+    expect(out!.outcomes).toEqual({
+      actions: 3,
+      files_edited: 1,
+      commits: 1,
+      prs_created: 1,
+      issues_created: 0,
+    });
+  });
+
+  it('omits outcomes (unknown, not zero) when no tool_use blocks are seen', () => {
+    writeSession('sess-idle', [
+      {
+        type: 'assistant',
+        message: { model: 'claude-sonnet-5', usage, content: [{ type: 'text', text: 'just talked' }] },
+      },
+    ]);
+
+    const out = captureSessionUsageById('sess-idle');
+    expect(out).not.toBeNull();
+    expect(out!.outcomes).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Fixes #1060 — foreground Claude runs hardcoded `outcomes: {actions:0, files_edited:0, ...}` in `run_end` events (`execution-engine.ts:777/:834`), ledgering fake zeros for every foreground run.

## How

- `parseSessionUsage` (observability.ts) now counts the session JSONL's `tool_use` blocks via `parseOutcomes` (reused from stream-json.ts, now exported) — same convention as the detached path: outcomes reported only when `actions > 0`, absent = unknown.
- Foreground path emits real outcomes in `run_end` AND spreads them into the ObservabilityRecord, so the scoreboard's activity-per-$ finally sees foreground work.
- `run_end.outcomes` is now optional (exec-events.ts); spool + error paths stop fabricating zeros; event-render guards absent outcomes.
- New test locks extraction + the omit-when-unknown semantics.

## Impact

Scoreboard quality-per-cost, outcome-driven routing, and future smart-context L6 stop ingesting poisoned zeros — prerequisite for Gate 0b token-ROI claims (real cost per landed outcome).

**Verified**: against a real session JSONL — parsed `{actions:44, files_edited:12}` where the old path ledgered all-zero. Full suite 2228 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)