### PR TITLE
fix(run): route worktrees to the task-referenced repo via also_owns allowlist

### DIFF
--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -365,6 +365,7 @@ ${systemContext}${squadContext}${cognitionContext}${learningContext}`;
             squadName,
             agentName,
             model: options.model,
+            task: options.task,
             contextStats,
           });
         } else {
@@ -373,8 +374,9 @@ ${systemContext}${squadContext}${cognitionContext}${learningContext}`;
             foreground: !isBackground,
             // Route to the squad's bound repo (SQUAD.md repo: → sibling dir).
             // Without this the executor worktrees + harvests onto whatever
-            // repo the dispatch ran from (#844).
-            cwd: resolveTargetRepoRoot(getProjectRoot(), squad),
+            // repo the dispatch ran from (#844). Task refs may reroute to an
+            // also_owns repo (#1092).
+            cwd: resolveTargetRepoRoot(getProjectRoot(), squad, options.task),
             squadName,
             agentName,
             model: options.model || frontmatter.model,

--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -135,6 +135,8 @@ export interface ExecuteWithClaudeOptions {
   squadName: string;
   agentName: string;
   model?: string; // Model to use (Claude aliases or full model IDs like gemini-2.5-flash)
+  /** Task directive — `<repo>#<n>` refs route the run to an also_owns repo (#1092) */
+  task?: string;
   /** Assembly-time context stats from gatherSquadContext — emitted as the run's `context_assembled` event (#902). */
   contextStats?: ContextStats;
 }
@@ -465,13 +467,44 @@ export function logVerboseExecution(config: {
 
 // ── Worktree management ──────────────────────────────────────────────
 
-/** Resolve the target repo root from the squad's repo field (e.g. "org/squads-cli" → sibling dir) */
-export function resolveTargetRepoRoot(projectRoot: string, squad: Squad | null): string {
+/**
+ * Resolve the target repo root from the squad's repo field (e.g. "org/squads-cli" → sibling dir).
+ * A `<repo>#<n>` ref in the task directive may reroute to an `also_owns` repo (#1092) —
+ * allowlisted to [repo, ...also_owns], never an arbitrary repo named in the task.
+ */
+export function resolveTargetRepoRoot(projectRoot: string, squad: Squad | null, task?: string): string {
   if (!squad?.repo) return projectRoot;
+  if (task) {
+    const owned = [squad.repo, ...(squad.also_owns ?? [])];
+    for (const ref of task.matchAll(/(?:([\w.-]+)\/)?([\w.-]+)#\d+/g)) {
+      const [, refOrg, refName] = ref;
+      const hit = owned.find((o) => {
+        const slash = o.lastIndexOf('/');
+        const [oOrg, oName] = slash === -1 ? [undefined, o] : [o.slice(0, slash), o.slice(slash + 1)];
+        return oName === refName && (!refOrg || !oOrg || refOrg === oOrg);
+      });
+      if (!hit) continue; // ref to a repo this squad doesn't own — ignore
+      const candidate = join(projectRoot, '..', hit.split('/').pop()!);
+      if (existsSync(candidate)) return candidate;
+      break; // owned but not checked out as a sibling — fall back to primary
+    }
+  }
   const repoName = squad.repo.split('/').pop();
   if (!repoName) return projectRoot;
   const candidatePath = join(projectRoot, '..', repoName);
   return existsSync(candidatePath) ? candidatePath : projectRoot;
+}
+
+/** All repo roots a squad may operate in: primary repo + existing also_owns sibling dirs (#1092) */
+export function resolveOwnedRepoRoots(projectRoot: string, squad: Squad | null): string[] {
+  const roots = [resolveTargetRepoRoot(projectRoot, squad)];
+  for (const owned of squad?.also_owns ?? []) {
+    const name = owned.split('/').pop();
+    if (!name) continue;
+    const candidate = join(projectRoot, '..', name);
+    if (existsSync(candidate)) roots.push(candidate);
+  }
+  return roots;
 }
 
 /** Create an isolated worktree for agent execution (Node.js-based, for foreground mode) */
@@ -995,8 +1028,9 @@ export async function executeWithClaude(
   const resolvedModel = resolveModel(effectiveModel, squad, taskType);
   const provider = resolvedModel ? detectProviderFromModel(resolvedModel) : 'anthropic';
 
-  // Resolve target repo for worktree creation (squad.repo → sibling dir)
-  const targetRepoRoot = resolveTargetRepoRoot(projectRoot, squad);
+  // Resolve target repo for worktree creation (squad.repo → sibling dir;
+  // task refs may reroute to an also_owns repo, #1092)
+  const targetRepoRoot = resolveTargetRepoRoot(projectRoot, squad, options.task);
 
   // Delegate to non-Anthropic providers
   if (provider !== 'anthropic' && provider !== 'unknown') {

--- a/src/lib/runs-inventory.ts
+++ b/src/lib/runs-inventory.ts
@@ -23,7 +23,7 @@ import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from 'fs'
 import { join, resolve } from 'path';
 import { execSync } from 'child_process';
 import { findSquadsDir, listSquads, loadSquad } from './squad-parser.js';
-import { resolveTargetRepoRoot, harvestProviderWork } from './execution-engine.js';
+import { resolveOwnedRepoRoots, harvestProviderWork } from './execution-engine.js';
 import { logObservability, type ObservabilityRecord } from './observability.js';
 
 export interface DetachedRun {
@@ -55,7 +55,9 @@ export function inventoryRoots(projectRoot: string): string[] {
     if (squadsDir) {
       for (const name of listSquads(squadsDir)) {
         try {
-          roots.add(resolve(resolveTargetRepoRoot(projectRoot, loadSquad(name))));
+          for (const root of resolveOwnedRepoRoots(projectRoot, loadSquad(name))) {
+            roots.add(resolve(root));
+          }
         } catch { /* unresolvable squad repo — skip */ }
       }
     }

--- a/src/lib/squad-parser.ts
+++ b/src/lib/squad-parser.ts
@@ -58,6 +58,8 @@ export interface SquadFrontmatter {
   name?: string;
   mission?: string;
   repo?: string;
+  /** Additional repos this squad owns and may be routed to via task refs (#1092) */
+  also_owns?: string[];
   stack?: string;
   context?: SquadContext;
   effort?: EffortLevel;
@@ -146,6 +148,8 @@ export interface Squad {
   effort?: EffortLevel;  // Squad-level default effort
   context?: SquadContext;  // Frontmatter context block
   repo?: string;
+  /** Additional repos this squad owns and may be routed to via task refs (#1092) */
+  also_owns?: string[];
   stack?: string;
   /** Agents that participate in squad conversations. Others run on schedules. */
   conversation_agents?: string[];
@@ -424,6 +428,7 @@ export function parseSquadFile(filePath: string): Squad {
     effort: fm.effort,
     context: fm.context,
     repo: fm.repo,
+    also_owns: Array.isArray(fm.also_owns) ? fm.also_owns : undefined,
     stack: fm.stack,
     conversation_agents: Array.isArray(fm.conversation_agents) ? fm.conversation_agents : undefined,
     providers: fm.providers,

--- a/test/repo-routing.test.ts
+++ b/test/repo-routing.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resolveTargetRepoRoot, resolveOwnedRepoRoots } from '../src/lib/execution-engine.js';
+import { parseSquadFile } from '../src/lib/squad-parser.js';
+import type { Squad } from '../src/lib/squad-parser.js';
+
+/**
+ * #1092: worktree provisioning must resolve the repo from `<repo>#<n>` refs
+ * in the --task directive when the squad owns that repo (repo: + also_owns:),
+ * instead of always defaulting to the squad's primary repo. Routing is
+ * allowlisted — a task naming a repo the squad does NOT own never reroutes.
+ */
+
+let base: string;
+let projectRoot: string;
+
+function squadWith(overrides: Partial<Squad>): Squad {
+  return { name: 'app', dir: 'app', mission: '', agents: [], pipelines: [], triggers: { scheduled: [], event: [], manual: [] }, routines: [], dependencies: [], outputPath: '', goals: [], ...overrides };
+}
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'squads-routing-'));
+  projectRoot = join(base, 'hq');
+  mkdirSync(projectRoot, { recursive: true });
+  mkdirSync(join(base, 'squads-app'), { recursive: true });
+  mkdirSync(join(base, 'squads-api'), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('resolveTargetRepoRoot task routing (#1092)', () => {
+  const squad = () => squadWith({
+    repo: 'agents-squads/squads-app',
+    also_owns: ['agents-squads/squads-api'],
+  });
+
+  it('routes to the primary repo when no task is given (existing behavior)', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad())).toBe(join(base, 'squads-app'));
+  });
+
+  it('routes to an also_owns repo referenced as <repo>#<n> in the task', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work squads-api#166 — wire the SSE endpoints'))
+      .toBe(join(base, 'squads-api'));
+  });
+
+  it('routes on fully-qualified org/repo#n refs', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work agents-squads/squads-api#162'))
+      .toBe(join(base, 'squads-api'));
+  });
+
+  it('keeps the primary repo when the task references the primary repo', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work squads-app#65 — home screen'))
+      .toBe(join(base, 'squads-app'));
+  });
+
+  it('first owned ref wins when the task references several repos', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work squads-api#166, mirrors squads-app#65'))
+      .toBe(join(base, 'squads-api'));
+  });
+
+  it('never routes to a repo the squad does not own', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work squads-cli#1092 — not ours'))
+      .toBe(join(base, 'squads-app'));
+  });
+
+  it('skips unowned refs but honors a later owned ref', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'After squads-cli#1092 lands, work squads-api#166'))
+      .toBe(join(base, 'squads-api'));
+  });
+
+  it('does not cross-route when the org differs on a qualified ref', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work other-org/squads-api#1'))
+      .toBe(join(base, 'squads-app'));
+  });
+
+  it('falls back to the primary repo when the owned repo is not checked out as a sibling', () => {
+    rmSync(join(base, 'squads-api'), { recursive: true, force: true });
+    expect(resolveTargetRepoRoot(projectRoot, squad(), 'Work squads-api#166'))
+      .toBe(join(base, 'squads-app'));
+  });
+
+  it('falls back to projectRoot when the squad has no repo binding', () => {
+    expect(resolveTargetRepoRoot(projectRoot, squadWith({}), 'Work squads-api#166'))
+      .toBe(projectRoot);
+  });
+
+  it('falls back to projectRoot when the primary repo dir does not exist', () => {
+    const s = squadWith({ repo: 'agents-squads/nonexistent' });
+    expect(resolveTargetRepoRoot(projectRoot, s, 'no refs here')).toBe(projectRoot);
+  });
+});
+
+describe('resolveOwnedRepoRoots (#1092)', () => {
+  it('returns primary + existing also_owns sibling dirs', () => {
+    const s = squadWith({
+      repo: 'agents-squads/squads-app',
+      also_owns: ['agents-squads/squads-api', 'agents-squads/not-checked-out'],
+    });
+    expect(resolveOwnedRepoRoots(projectRoot, s))
+      .toEqual([join(base, 'squads-app'), join(base, 'squads-api')]);
+  });
+
+  it('returns just the resolved primary root without also_owns', () => {
+    const s = squadWith({ repo: 'agents-squads/squads-app' });
+    expect(resolveOwnedRepoRoots(projectRoot, s)).toEqual([join(base, 'squads-app')]);
+  });
+});
+
+describe('parseSquadFile also_owns (#1092)', () => {
+  it('parses also_owns from SQUAD.md frontmatter', () => {
+    const squadDir = join(base, '.agents', 'squads', 'app');
+    mkdirSync(squadDir, { recursive: true });
+    const file = join(squadDir, 'SQUAD.md');
+    writeFileSync(file, [
+      '---',
+      'name: app',
+      'repo: agents-squads/squads-app',
+      'also_owns:',
+      '  - agents-squads/squads-api',
+      '---',
+      '',
+      '# Squad: app',
+    ].join('\n'));
+    const squad = parseSquadFile(file);
+    expect(squad.repo).toBe('agents-squads/squads-app');
+    expect(squad.also_owns).toEqual(['agents-squads/squads-api']);
+  });
+
+  it('leaves also_owns undefined when absent', () => {
+    const squadDir = join(base, '.agents', 'squads', 'plain');
+    mkdirSync(squadDir, { recursive: true });
+    const file = join(squadDir, 'SQUAD.md');
+    writeFileSync(file, ['---', 'name: plain', 'repo: agents-squads/squads-app', '---', '', '# Squad: plain'].join('\n'));
+    expect(parseSquadFile(file).also_owns).toBeUndefined();
+  });
+});

--- a/test/runs-inventory.test.ts
+++ b/test/runs-inventory.test.ts
@@ -7,7 +7,7 @@ import { spawn, spawnSync } from 'node:child_process';
 // Inventory only needs two things from the engine; mocking them keeps these
 // tests free of git fixtures (harvest itself is covered by harvest.test.ts).
 vi.mock('../src/lib/execution-engine.js', () => ({
-  resolveTargetRepoRoot: vi.fn((projectRoot: string) => projectRoot),
+  resolveOwnedRepoRoots: vi.fn((projectRoot: string) => [projectRoot]),
   harvestProviderWork: vi.fn(async () => ({ outcome: 'merged' })),
 }));
 


### PR DESCRIPTION
## Summary
`squads run <squad>/<agent> --task "Work <repo>#<n> …"` provisioned the worktree from the squad's primary `repo:` field only, ignoring the repo the task actually names. Any `also_owns`-repo dispatch landed the agent in the wrong checkout, which blocked the app squad's whole squads-api lane (repro in #1092).

## Changes
- **squad-parser**: `also_owns` is now parsed from SQUAD.md frontmatter (previously documentation-only) — `SquadFrontmatter` + `Squad` types and the `parseSquadFile` mapping.
- **execution-engine**: `resolveTargetRepoRoot(projectRoot, squad, task?)` matches `<repo>#<n>` / `org/<repo>#<n>` refs in the task against an allowlist of `[repo, ...also_owns]`. First owned match wins; refs to unowned repos are ignored; if the owned sibling checkout is missing it falls back to today's behavior. New `resolveOwnedRepoRoots()` returns every root a squad may operate in.
- **agent-runner**: threads `options.task` into `executeWithClaude` (new `task` field on `ExecuteWithClaudeOptions`) and into the provider-path `resolveTargetRepoRoot` call, so both execution paths route identically.
- **runs-inventory**: scans `also_owns` roots too, so `squads runs` / `squads kill` see PID files of rerouted runs.

## Testing
- [x] `npm run build` passes
- [x] Full vitest suite: 138 files / 2269 tests green
- [x] New `test/repo-routing.test.ts`: routing matrix (bare + org-qualified refs, first-match-wins, unowned-ref skip, org mismatch, missing-sibling fallback, no-repo fallback) + frontmatter parse
- [x] Verified against the real roster: app squad's SQUAD.md (`also_owns: [agents-squads/squads-api]`) — `--task "Work squads-api#166 …"` resolves to the `squads-api` sibling checkout; unowned refs stay on `squads-app`

## Impact
Unblocks task-directed dispatches into `also_owns` repos — the app squad's squads-api wiring lane and any future multi-repo squad. Routing stays allowlisted: a task naming a repo the squad doesn't own can never pull the run into it.

Closes #1092