### PR TITLE
fix(run): stop forcing a digest regen on every --force dispatch

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -154,7 +154,11 @@ export async function runCommand(
     // into per-squad alignment files so agents run aligned with the founder's
     // current pipeline, not generic squad goals.
     if (!options.dryRun) {
-      const ctxResult = refreshFounderContext({ force: options.force });
+      // --force means "re-run squads that already completed today" — it must NOT
+      // force a synchronous digest regen (staleness governs; SQUADS_DIGEST_SYNC=1
+      // for an explicit sync regen). Conflating the two made every forced dispatch
+      // rebuild founder-context.md, drifting it between back-to-back runs (#1093).
+      const ctxResult = refreshFounderContext();
       if (ctxResult === 'failed') {
         writeLine(`  ${colors.red}Aborting org cycle. Fix the digest script and retry.${RESET}\n`);
         return;
@@ -557,9 +561,12 @@ export async function runCommand(
 
   // Refresh founder context for single-squad runs (same as --org, so agents
   // always see aligned strategic context regardless of how they're invoked).
+  // Never forced by --force: that flag re-runs completed squads, it does not
+  // mean "rebuild the digest" — forcing it here regenerated founder-context.md
+  // on every dispatch and drifted it between back-to-back runs (#1093).
   if (squad && !options.dryRun) {
     const { refreshFounderContext: refreshCtx } = await import('../lib/org-cycle.js');
-    refreshCtx({ force: options.force });
+    refreshCtx();
   }
 
   if (squad) {

--- a/test/digest-refresh-contract.test.ts
+++ b/test/digest-refresh-contract.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Regression guard for #1093: `--force` means "re-run squads that already
+ * completed today" (run-types.ts) — it must never be forwarded into
+ * refreshFounderContext, where force triggers a synchronous full digest
+ * regeneration. Conflating the two rebuilt founder-context.md on EVERY forced
+ * dispatch, so two dispatches seconds apart each read a different digest
+ * (compounding haiku drift, including fabricated squad names read by agents
+ * as blocking policy). Explicit sync regen remains available via
+ * SQUADS_DIGEST_SYNC=1 or the digest script's --full flag.
+ *
+ * A behavioral runCommand() test needs a deep mock stack (telemetry, gates,
+ * squad loading); this source contract pins the narrow regression the same
+ * way agent-runner-provider-routing.test.ts does for #844.
+ */
+describe('founder-context refresh call sites (#1093)', () => {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'commands', 'run.ts'),
+    'utf8'
+  );
+
+  it('never passes a force option into refreshFounderContext', () => {
+    const calls = source.match(/refresh(?:FounderContext|Ctx)\s*\([^)]*\)/g) ?? [];
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call).not.toMatch(/force/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`squads run <squad>/<agent> --task … --force` regenerated `founder-context.md` + all per-squad `founder-alignment.md` files on **every** dispatch, because both `refreshFounderContext` call sites in `run.ts` forwarded the dispatch `--force` flag as the digest force flag. Two dispatches fired ~23s apart each read a *different* haiku generation — drift that included fabricated squad names in "Out-of-scope" sections, which agents correctly treat as blocking policy (repro in #1093).

## Changes
- `run.ts` (`--org` path + single-squad path): call `refreshFounderContext()` without `force`. `--force` is documented as "force re-run squads that already completed today" (run-types.ts) — digest freshness is governed by staleness (2h, background refresh, #447) plus the digest script's own 60-min watermark window. Explicit sync regen stays available via `SQUADS_DIGEST_SYNC=1` or the script's `--full`.
- `test/digest-refresh-contract.test.ts`: source-contract regression guard (same pattern as the #844 guard) — no `refreshFounderContext` call site in `run.ts` may pass a force option.

## Companion fix (hq, same issue)
The drift had two more legs fixed on the hq side (domain repo, direct push): the CLI-preferred `.claude/hooks/founder-context-digest.py` was a Jun 8 fork missing the 60-min freshness window — now a shim exec'ing the canonical `scripts/` version — and both generation passes are roster-grounded (`.agents/squads/*` roster injected into the prompts + post-generation validation that rejects fabricated squad names, keeping the prior digest on failure).

## Testing
- [x] `npm run build` passes
- [x] Full vitest suite: 139 files / 2270 tests green

## Impact
Back-to-back lane dispatches see one stable digest instead of a fresh hallucination-prone regen each time; unblocks back-to-back `--task` dispatches (the app squad's squads-api lane hit this together with #1092).

Closes #1093