### PR TITLE
fix(run): address Gemini review on #1094 — routing scan + also_owns type filter

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -486,7 +486,7 @@ export function resolveTargetRepoRoot(projectRoot: string, squad: Squad | null, 
       if (!hit) continue; // ref to a repo this squad doesn't own — ignore
       const candidate = join(projectRoot, '..', hit.split('/').pop()!);
       if (existsSync(candidate)) return candidate;
-      break; // owned but not checked out as a sibling — fall back to primary
+      // owned but not checked out as a sibling — a later owned ref may still match
     }
   }
   const repoName = squad.repo.split('/').pop();

--- a/src/lib/squad-parser.ts
+++ b/src/lib/squad-parser.ts
@@ -428,7 +428,9 @@ export function parseSquadFile(filePath: string): Squad {
     effort: fm.effort,
     context: fm.context,
     repo: fm.repo,
-    also_owns: Array.isArray(fm.also_owns) ? fm.also_owns : undefined,
+    also_owns: Array.isArray(fm.also_owns)
+      ? fm.also_owns.filter((v): v is string => typeof v === 'string')
+      : undefined,
     stack: fm.stack,
     conversation_agents: Array.isArray(fm.conversation_agents) ? fm.conversation_agents : undefined,
     providers: fm.providers,

--- a/test/repo-routing.test.ts
+++ b/test/repo-routing.test.ts
@@ -84,6 +84,17 @@ describe('resolveTargetRepoRoot task routing (#1092)', () => {
       .toBe(join(base, 'squads-app'));
   });
 
+  it('routes to a later owned ref when the first owned ref is not checked out', () => {
+    mkdirSync(join(base, 'squads-console'), { recursive: true });
+    rmSync(join(base, 'squads-api'), { recursive: true, force: true });
+    const s = squadWith({
+      repo: 'agents-squads/squads-app',
+      also_owns: ['agents-squads/squads-api', 'agents-squads/squads-console'],
+    });
+    expect(resolveTargetRepoRoot(projectRoot, s, 'Work squads-api#166 then squads-console#3'))
+      .toBe(join(base, 'squads-console'));
+  });
+
   it('falls back to projectRoot when the squad has no repo binding', () => {
     expect(resolveTargetRepoRoot(projectRoot, squadWith({}), 'Work squads-api#166'))
       .toBe(projectRoot);
@@ -137,5 +148,25 @@ describe('parseSquadFile also_owns (#1092)', () => {
     const file = join(squadDir, 'SQUAD.md');
     writeFileSync(file, ['---', 'name: plain', 'repo: agents-squads/squads-app', '---', '', '# Squad: plain'].join('\n'));
     expect(parseSquadFile(file).also_owns).toBeUndefined();
+  });
+
+  it('drops non-string entries from also_owns', () => {
+    const squadDir = join(base, '.agents', 'squads', 'mixed');
+    mkdirSync(squadDir, { recursive: true });
+    const file = join(squadDir, 'SQUAD.md');
+    writeFileSync(file, [
+      '---',
+      'name: mixed',
+      'repo: agents-squads/squads-app',
+      'also_owns:',
+      '  - agents-squads/squads-api',
+      '  - 42',
+      '  - null',
+      '  - {repo: agents-squads/squads-console}',
+      '---',
+      '',
+      '# Squad: mixed',
+    ].join('\n'));
+    expect(parseSquadFile(file).also_owns).toEqual(['agents-squads/squads-api']);
   });
 });


### PR DESCRIPTION
## Summary
Fix-forward for the two Gemini review comments that landed after #1094 auto-merged (reviews lag label/auto merges).

## Changes
- `resolveTargetRepoRoot`: an owned task ref whose sibling checkout is missing no longer aborts the scan — later owned refs are still considered before falling back to the primary repo.
- `parseSquadFile`: `also_owns` filters non-string YAML entries, preventing a runtime `TypeError` in routing on malformed frontmatter.
- Tests: later-owned-ref routing when the first ref isn't checked out; non-string `also_owns` entries dropped.

## Testing
- [x] `npm run build` passes
- [x] Full vitest suite: 139 files / 2272 tests green

Refs #1092 (review follow-up to PR #1094)