### PR TITLE
test(run): strip comments before matching digest-refresh call sites

### DIFF
--- a/test/digest-refresh-contract.test.ts
+++ b/test/digest-refresh-contract.test.ts
@@ -24,7 +24,10 @@ describe('founder-context refresh call sites (#1093)', () => {
   );
 
   it('never passes a force option into refreshFounderContext', () => {
-    const calls = source.match(/refresh(?:FounderContext|Ctx)\s*\([^)]*\)/g) ?? [];
+    // Strip comments first — the call sites carry comments explaining exactly
+    // this rule, which mention "force" without passing it.
+    const cleanSource = source.replace(/\/\*[\s\S]*?\*\/|\/\/.*/g, '');
+    const calls = cleanSource.match(/refresh(?:FounderContext|Ctx)\s*\([^)]*\)/g) ?? [];
     expect(calls.length).toBeGreaterThan(0);
     for (const call of calls) {
       expect(call).not.toMatch(/force/);


### PR DESCRIPTION
## Summary
Fix-forward for the Gemini review comment that landed after #1095 auto-merged: the source-contract test regex could false-positive on comments that mention `refreshFounderContext` together with the word "force" — which the call sites' own explanatory comments do. Comments are now stripped before matching (Gemini's suggested fix, applied verbatim).

## Testing
- [x] `test/digest-refresh-contract.test.ts` passes

Refs #1093 (review follow-up to PR #1095)