### PR TITLE
fix(providers): background lanes spawn with the compiled --allowedTools

### DIFF
--- a/src/lib/execution-engine.ts
+++ b/src/lib/execution-engine.ts
@@ -1538,8 +1538,11 @@ export async function executeWithProvider(
     mkdirSync(logDir, { recursive: true });
   }
 
-  const escapedPrompt = effectivePrompt.replace(/'/g, "'\\''");
-  const providerArgs = cliConfig.buildArgs(escapedPrompt).map(a => `'${a}'`).join(' ');
+  // Single argv source with the foreground path (#1101): rebuilding here via a
+  // second buildArgs call silently dropped buildOpts — background claude-harness
+  // lanes spawned with NO --allowedTools, so every Write/Edit was denied in
+  // --print mode and the lane was read-only. Quote per-arg for the shell wrapper.
+  const providerArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
   // Detached harvest (shell equivalent of harvestProviderWork): commit whatever
   // the executor wrote, fast-forward the project root, and only delete the
   // agent branch when its work is integrated or empty — never lose output.

--- a/test/provider-background-args.test.ts
+++ b/test/provider-background-args.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Regression guard for #1101: the background/detached branch of
+ * executeWithProvider rebuilt the provider argv with a SECOND
+ * `cliConfig.buildArgs(escapedPrompt)` call that omitted buildOpts — so
+ * claude-harness lanes (glm) spawned with no --allowedTools and every
+ * Write/Edit was denied in --print mode (the lane went read-only and died
+ * dumping its implementation as text). Type-safe, test-green, broken at the
+ * call site — same class as #844, same source-contract guard: both spawn
+ * paths must share ONE argv construction.
+ */
+describe('executeWithProvider background argv (#1101)', () => {
+  const source = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'lib', 'execution-engine.ts'),
+    'utf8'
+  );
+  const fn = source.slice(
+    source.indexOf('export async function executeWithProvider('),
+  );
+
+  it('builds the provider argv exactly once (buildOpts included)', () => {
+    const calls = fn.match(/cliConfig\.buildArgs\(/g) ?? [];
+    expect(calls).toHaveLength(1);
+    expect(fn).toContain('cliConfig.buildArgs(effectivePrompt, buildOpts)');
+  });
+
+  it('derives the detached shell argv from the shared args array, shell-escaping each arg', () => {
+    expect(fn).toContain("const providerArgs = args.map(a => `'${a.replace(/'/g, \"'\\\\''\")}'`).join(' ');");
+  });
+});


### PR DESCRIPTION
## Summary
First real background dispatch of the GLM lane (working #1099) ran 81 turns and died unshipped: every Write/Edit denied despite `Write` being in the compiled allowlist. Root cause was NOT the sandbox-settings anchor — the detached branch of `executeWithProvider` rebuilt the provider argv with a **second `cliConfig.buildArgs(escapedPrompt)` call that omitted `buildOpts`**, so background claude-harness lanes spawned with no `--allowedTools` (and no model override). In `--print` mode permission prompts can't be answered, so the lane was structurally read-only. Foreground lanes were unaffected (they pass `buildOpts`), which is why Gate 0b validated GREEN.

## Changes
- `executeWithProvider` builds the argv exactly once; the detached shell string derives from that same array, shell-escaping per-arg (prompt escaping behavior unchanged).
- Background lanes now also honor the `model` override, restoring parity with foreground.
- Source-contract regression test (`test/provider-background-args.test.ts`, same idiom as #844): exactly one `buildArgs` call inside `executeWithProvider`, detached argv derived from the shared array.

## Impact
Unfreezes the lane strategy: background GLM/claude-harness dispatches can ship again. Same class as #1092/#1093/#1100 — harness bug found by real dogfood dispatch.

## Testing
- [x] Full suite: 140 files / 2274 tests pass
- [x] `npm run build` clean
- [x] Repro evidence: 9 "haven't granted it yet" denials in the #1101 log; denial path only constructible via the opts-less argv

Closes #1101