### PR TITLE
test(providers): regex-based source-contract assertions (#1102 review)

### DIFF
--- a/test/provider-background-args.test.ts
+++ b/test/provider-background-args.test.ts
@@ -25,10 +25,10 @@ describe('executeWithProvider background argv (#1101)', () => {
   it('builds the provider argv exactly once (buildOpts included)', () => {
     const calls = fn.match(/cliConfig\.buildArgs\(/g) ?? [];
     expect(calls).toHaveLength(1);
-    expect(fn).toContain('cliConfig.buildArgs(effectivePrompt, buildOpts)');
+    expect(fn).toMatch(/cliConfig\.buildArgs\(\s*effectivePrompt\s*,\s*buildOpts\s*\)/);
   });
 
   it('derives the detached shell argv from the shared args array, shell-escaping each arg', () => {
-    expect(fn).toContain("const providerArgs = args.map(a => `'${a.replace(/'/g, \"'\\\\''\")}'`).join(' ');");
+    expect(fn).toMatch(/const providerArgs = args\s*\.map\(\s*a\s*=>.*\.replace\(.*\)\s*.*\.join\(' '\)/);
   });
 });


### PR DESCRIPTION
Fix-forward for Gemini review on #1102 (merged before replies): both source-contract assertions in test/provider-background-args.test.ts move from exact strings to regexes, so formatting-only refactors (quotes, whitespace, replaceAll) can't break them while the #1101 contract stays locked. Related to #1101.