### PR TITLE
feat(providers): add Kimi (Moonshot) as a claude-harness lane provider

### DIFF
--- a/src/commands/board.ts
+++ b/src/commands/board.ts
@@ -162,19 +162,24 @@ function formatCost(usd: number): string {
 }
 
 /**
- * Reprice GLM runs at display time when env rates are now set.
- * GLM runs recorded with cost_usd=0 (because env rates weren't set at run time)
- * are re-priced using current SQUADS_GLM_COST_PER_MTOK_IN/OUT values.
- * This is display-only; the ledger is not modified.
+ * Reprice claude-harness lane runs at display time when env rates are now set.
+ * These lanes (glm/deepseek/kimi) discard the claude CLI's Claude-priced cost and
+ * fall back to SQUADS_<PROVIDER>_COST_PER_MTOK_IN/OUT (see makeClaudeHarnessStreamUsage);
+ * rows recorded with cost_usd=0 because those rates weren't set at run time are
+ * re-priced using the current values. Display-only; the ledger is not modified.
  */
+const REPRICEABLE_PROVIDERS = new Set(['glm', 'deepseek', 'kimi']);
+
 export function repriceIfNeeded(r: ObservabilityRecord): ObservabilityRecord {
-  // Only reprice GLM provider records with cost_usd=0 but tokens>0
-  if (r.provider !== 'glm' || r.cost_usd > 0) return r;
+  // Only reprice claude-harness-lane records with cost_usd=0 but tokens>0
+  const provider = (r.provider || '').toLowerCase();
+  if (!REPRICEABLE_PROVIDERS.has(provider) || r.cost_usd > 0) return r;
   const tokens = (r.input_tokens || 0) + (r.output_tokens || 0);
   if (tokens === 0) return r;
 
-  const inRate = parseFloat(process.env.SQUADS_GLM_COST_PER_MTOK_IN || '');
-  const outRate = parseFloat(process.env.SQUADS_GLM_COST_PER_MTOK_OUT || '');
+  const prefix = provider.toUpperCase();
+  const inRate = parseFloat(process.env[`SQUADS_${prefix}_COST_PER_MTOK_IN`] || '');
+  const outRate = parseFloat(process.env[`SQUADS_${prefix}_COST_PER_MTOK_OUT`] || '');
   if (!Number.isFinite(inRate) || !Number.isFinite(outRate)) return r;
 
   const recost = ((r.input_tokens || 0) * inRate + (r.output_tokens || 0) * outRate) / 1_000_000;

--- a/src/lib/llm-clis.ts
+++ b/src/lib/llm-clis.ts
@@ -114,6 +114,7 @@ function makeClaudeHarnessStreamUsage(envPrefix: string): (output: string) => Pr
 
 export const parseGlmStreamUsage = makeClaudeHarnessStreamUsage('GLM');
 export const parseDeepseekStreamUsage = makeClaudeHarnessStreamUsage('DEEPSEEK');
+export const parseKimiStreamUsage = makeClaudeHarnessStreamUsage('KIMI');
 
 /**
  * Usage from an opencode `--format json` log (#1177). Unlike the claude
@@ -301,6 +302,42 @@ export const LLM_CLIS: Record<string, CLIConfig> = {
     env: () => ({
       ANTHROPIC_BASE_URL: process.env.GLM_BASE_URL || 'https://api.z.ai/api/anthropic',
       ANTHROPIC_AUTH_TOKEN: process.env.GLM_API_KEY,
+      ANTHROPIC_API_KEY: undefined,
+      ANTHROPIC_MODEL: undefined,
+    }),
+  },
+
+  // Kimi (Moonshot) serves an Anthropic-compatible endpoint (verified live
+  // 2026-07-24: proper Anthropic message shape + usage on /anthropic/v1/messages
+  // for kimi-k3), so the claude CLI is the agentic harness, same pattern as
+  // glm/deepseek. K3 is a reasoning model that emits `thinking` blocks — the
+  // stream adapter already handles those (glm-4.7/5.2 do the same). Point it at
+  // Moonshot and auth with KIMI_API_KEY; ANTHROPIC_API_KEY is removed so an
+  // inherited key can't shadow the token.
+  kimi: {
+    provider: 'kimi',
+    displayName: 'Kimi (Moonshot via claude)',
+    command: 'claude',
+    install: 'npm i -g @anthropic-ai/claude-code, then set KIMI_API_KEY',
+    buildArgs: (prompt, opts) => [
+      '--print',
+      // Structured event stream so usage + outcomes are parseable (#1077);
+      // --verbose is required by the claude CLI for stream-json in print mode.
+      '--output-format', 'stream-json',
+      '--verbose',
+      '--model',
+      opts?.model || process.env.KIMI_MODEL || 'kimi-k3',
+      // In --print mode permission prompts can't be answered, so without an
+      // allowlist every Edit/Write is denied and the lane is read-only (#1073).
+      ...(opts?.allowedTools?.length ? ['--allowedTools', ...opts.allowedTools] : []),
+      '--disable-slash-commands',
+      prompt,
+    ],
+    streamJson: true,
+    parseUsage: parseKimiStreamUsage,
+    env: () => ({
+      ANTHROPIC_BASE_URL: process.env.KIMI_BASE_URL || 'https://api.moonshot.ai/anthropic',
+      ANTHROPIC_AUTH_TOKEN: process.env.KIMI_API_KEY,
       ANTHROPIC_API_KEY: undefined,
       ANTHROPIC_MODEL: undefined,
     }),

--- a/src/lib/scoreboard.ts
+++ b/src/lib/scoreboard.ts
@@ -85,6 +85,7 @@ export function modelFamily(model: string): string {
   if (m.includes('gpt')) return m.replace(/[^a-z0-9.-]/g, '').slice(0, 16);
   if (m.includes('qwen')) return 'qwen';
   if (m.includes('glm')) return 'glm';
+  if (m.includes('kimi')) return 'kimi';
   if (m.includes('gemini')) return 'gemini';
   return m === 'unknown' ? 'unknown' : m.slice(0, 16);
 }

--- a/test/llm-usage.test.ts
+++ b/test/llm-usage.test.ts
@@ -126,6 +126,48 @@ describe('glm lane (#926 — z.ai Anthropic-compatible endpoint via claude CLI)'
   });
 });
 
+describe('kimi lane (Moonshot Anthropic-compatible endpoint via claude CLI)', () => {
+  afterEach(() => {
+    delete process.env.KIMI_API_KEY;
+    delete process.env.KIMI_BASE_URL;
+    delete process.env.KIMI_MODEL;
+  });
+
+  it('delegates to the claude CLI in non-interactive print mode with a stream-json argv', () => {
+    expect(LLM_CLIS.kimi.command).toBe('claude');
+    expect(LLM_CLIS.kimi.streamJson).toBe(true);
+    const args = LLM_CLIS.kimi.buildArgs('do the thing', { allowedTools: ['Read', 'Edit'] });
+    expect(args[0]).toBe('--print');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--allowedTools');
+    expect(args).toContain('Read');
+    expect(args[args.length - 1]).toBe('do the thing');
+  });
+
+  it('defaults to kimi-k3 and honors override precedence (opts > KIMI_MODEL)', () => {
+    expect(LLM_CLIS.kimi.buildArgs('hi')).toContain('kimi-k3');
+    process.env.KIMI_MODEL = 'kimi-k2.7-code';
+    expect(LLM_CLIS.kimi.buildArgs('hi')).toContain('kimi-k2.7-code');
+    expect(LLM_CLIS.kimi.buildArgs('hi', { model: 'kimi-k3' })).toContain('kimi-k3');
+  });
+
+  it('maps KIMI_API_KEY to ANTHROPIC_AUTH_TOKEN and removes shadowing vars', () => {
+    process.env.KIMI_API_KEY = 'moonshot-test-key';
+    const env = LLM_CLIS.kimi.env!();
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://api.moonshot.ai/anthropic');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('moonshot-test-key');
+    // undefined = the runner must DELETE these, or an inherited ANTHROPIC_API_KEY
+    // silently routes the Kimi run to Anthropic instead.
+    expect(env).toHaveProperty('ANTHROPIC_API_KEY', undefined);
+    expect(env).toHaveProperty('ANTHROPIC_MODEL', undefined);
+  });
+
+  it('honors KIMI_BASE_URL override', () => {
+    process.env.KIMI_BASE_URL = 'https://proxy.example/anthropic';
+    expect(LLM_CLIS.kimi.env!().ANTHROPIC_BASE_URL).toBe('https://proxy.example/anthropic');
+  });
+});
+
 describe('opencode lane (#1177 — fallback harness, `opencode run --format json`)', () => {
   it('is registered in LLM_CLIS with the right identity', () => {
     expect(LLM_CLIS.opencode.provider).toBe('opencode');


### PR DESCRIPTION
## What
Adds `kimi` to the provider registry so squad lanes can run on Moonshot's Kimi models (default `kimi-k3`) through the same `claude`-harness path as GLM and DeepSeek.

## Why
Kimi serves an **Anthropic-compatible endpoint** (`https://api.moonshot.ai/anthropic`). Verified live 2026-07-24: `kimi-k3` returns a proper Anthropic message shape + usage block on that endpoint. So it drops into our existing multi-model ladder with **no new dependency** — reuses the claude CLI as the agentic harness. Extends the provider ladder with a cheap, strong coding/reasoning model.

## Changes
- **`src/lib/llm-clis.ts`** — `kimi` provider entry mirroring GLM: `command: claude`, `--output-format stream-json`, default model `kimi-k3` (override via `KIMI_MODEL`/opts), `ANTHROPIC_BASE_URL=…/anthropic`, `ANTHROPIC_AUTH_TOKEN=KIMI_API_KEY`, shadow vars removed. Plus `parseKimiStreamUsage`.
- **`src/lib/scoreboard.ts`** — `kimi-*` models map to the `kimi` family.
- **`src/commands/board.ts`** — generalize display-time repricing from GLM-only to all claude-harness lanes (glm/deepseek/kimi) via `SQUADS_<PROVIDER>_COST_PER_MTOK_IN/OUT`.
- **`test/llm-usage.test.ts`** — kimi lane: print-mode stream-json argv, model default/override precedence, `KIMI_API_KEY`→`ANTHROPIC_AUTH_TOKEN` mapping, shadow-var removal, base-url override.

## Verification
- `kimi-k3` confirmed working on the Anthropic endpoint (real API call).
- tsc + eslint clean; `npm run build` success; full unit suite green (the lone infra-integration test requires a running docker stack and skips in CI).

## Notes
- Kimi K3 is a reasoning model (emits `thinking` blocks) — the stream adapter already handles those (glm-4.7/5.2 do the same).
- Cost env rates (`SQUADS_KIMI_COST_PER_MTOK_IN/OUT`) unset → $0 shown as a visible gap, never fabricated.
- The `solver-lane-kimi` agent definition lands separately in hq.

Closes #1205